### PR TITLE
Cache folders per session and sync differences

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,17 +488,26 @@
             border: none;
             cursor: pointer;
             z-index: 20;
-            padding: 0;
+            padding: 28px;
+            align-items: center;
+            justify-content: center;
+            border-radius: 999px;
+            min-width: 84px;
+            min-height: 84px;
+            touch-action: manipulation;
             color: #9ca3af; /* Standalone grey outline */
         }
+        #focus-favorite-btn svg { pointer-events: none; }
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-        
+
+        #focus-filename-display,
+        #focus-image-count { display: none !important; }
+
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #normal-image-count,
         .app-container.focus-mode #center-trash-btn { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
@@ -526,31 +535,17 @@
             touch-action: none;
             overflow: hidden;
         }
-        .gesture-layer .modeBanner {
-            position: absolute;
-            top: 12px;
-            left: 50%;
-            transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.45);
-            border: 1px solid rgba(255, 255, 255, 0.12);
-            color: #fff;
-            padding: 4px 12px;
-            border-radius: 999px;
-            font-size: 12px;
-            letter-spacing: 0.02em;
-        }
         .gesture-layer .tri,
         .gesture-layer .half {
             position: absolute;
             inset: 0;
-            opacity: 0.16;
+            opacity: 0;
             pointer-events: none;
-            transition: opacity 0.18s ease-out;
         }
-        .gesture-layer .tri.up { clip-path: polygon(0% 0%, 100% 0%, 50% 50%); background: rgba(46, 139, 87, 0.8); }
-        .gesture-layer .tri.right { clip-path: polygon(100% 0%, 100% 100%, 50% 50%); background: rgba(178, 138, 32, 0.85); }
-        .gesture-layer .tri.down { clip-path: polygon(0% 100%, 100% 100%, 50% 50%); background: rgba(139, 46, 46, 0.8); }
-        .gesture-layer .tri.left { clip-path: polygon(0% 0%, 0% 100%, 50% 50%); background: rgba(32, 93, 178, 0.85); }
+        .gesture-layer .tri.up { clip-path: polygon(0% 0%, 100% 0%, 50% 50%); background: transparent; }
+        .gesture-layer .tri.right { clip-path: polygon(100% 0%, 100% 100%, 50% 50%); background: transparent; }
+        .gesture-layer .tri.down { clip-path: polygon(0% 100%, 100% 100%, 50% 50%); background: transparent; }
+        .gesture-layer .tri.left { clip-path: polygon(0% 0%, 0% 100%, 50% 50%); background: transparent; }
         .gesture-layer .half.left {
             position: absolute;
             top: 12px;
@@ -558,7 +553,7 @@
             left: 12px;
             right: calc(50% + 6px);
             border-radius: 16px;
-            background: rgba(32, 93, 178, 0.85);
+            background: transparent;
         }
         .gesture-layer .half.right {
             position: absolute;
@@ -567,7 +562,7 @@
             left: calc(50% + 6px);
             right: 12px;
             border-radius: 16px;
-            background: rgba(178, 138, 32, 0.85);
+            background: transparent;
         }
         .gesture-layer .hub {
             position: absolute;
@@ -577,24 +572,54 @@
             width: min(18vw, 18vh);
             height: min(18vw, 18vh);
             border-radius: 50%;
-            border: 1px dashed rgba(255, 255, 255, 0.28);
-            background: rgba(17, 20, 32, 0.55);
-            display: grid;
-            place-items: center;
-            color: rgba(226, 232, 240, 0.82);
-            font-size: 12px;
-            letter-spacing: 0.04em;
-            text-transform: uppercase;
+            border: 1px solid transparent;
+            background: transparent;
             pointer-events: none;
+            z-index: 40;
         }
-        .gesture-layer .hub div { text-align: center; line-height: 1.3; }
         .gesture-layer .glow {
-            opacity: 0.85 !important;
-            box-shadow: 0 0 18px 6px rgba(255, 255, 255, 0.18) inset,
-                        0 0 16px rgba(255, 255, 255, 0.22);
+            opacity: 0 !important;
+            box-shadow: none;
         }
-        .gesture-layer .deglow { opacity: 0.16; transition: opacity 0.28s ease-in; }
+        .gesture-layer .deglow { opacity: 0; }
         .gesture-layer[hidden] { display: none; }
+
+        .gesture-layer .comet-trail {
+            position: absolute;
+            width: 26px;
+            height: 26px;
+            margin: -13px 0 0 -13px;
+            border-radius: 999px;
+            pointer-events: none;
+            background: radial-gradient(circle, rgba(255, 255, 255, 0.92) 0%, rgba(255, 255, 255, 0.28) 45%, rgba(255, 255, 255, 0) 75%);
+            opacity: 0.95;
+            transform: scale(0.85);
+            animation: cometFade 1.05s ease-out forwards;
+            mix-blend-mode: screen;
+            filter: blur(0.4px);
+            z-index: 30;
+        }
+        @keyframes cometFade {
+            0% { opacity: 0.95; transform: scale(0.85); }
+            100% { opacity: 0; transform: scale(2.6); }
+        }
+        .gesture-layer .tap-ripple {
+            position: absolute;
+            width: 22px;
+            height: 22px;
+            margin: -11px 0 0 -11px;
+            border-radius: 50%;
+            border: 2px solid rgba(255, 255, 255, 0.35);
+            pointer-events: none;
+            opacity: 0.9;
+            animation: rippleExpand 0.55s ease-out forwards;
+            mix-blend-mode: screen;
+            z-index: 30;
+        }
+        @keyframes rippleExpand {
+            0% { transform: scale(0.6); opacity: 0.9; }
+            100% { transform: scale(2.4); opacity: 0; }
+        }
 
     </style>
 </head>
@@ -691,20 +716,18 @@
         <!-- Gesture overlay (triangular sort zones + focus halves) -->
         <div class="gesture-layer" id="gesture-layer">
             <div id="gesture-screen-a" class="stage" role="application"
-                 aria-label="Sort mode. Triangular flick zones. Long-press center hub to enter focus mode.">
-                <div class="modeBanner" id="gesture-banner-a">Sort Mode — Triangular Zones</div>
+                 aria-label="Sort mode. Triangular flick zones. Double-tap center hub to enter focus mode.">
                 <div id="gesture-tri-up" class="tri up"></div>
                 <div id="gesture-tri-right" class="tri right"></div>
                 <div id="gesture-tri-down" class="tri down"></div>
                 <div id="gesture-tri-left" class="tri left"></div>
-                <div class="hub" id="gesture-hub-a"><div>Long-press<br>to focus</div></div>
+                <div class="hub" id="gesture-hub-a"></div>
             </div>
             <div id="gesture-screen-b" class="stage" role="application"
-                 aria-label="Focus mode. Left/right review halves. Long-press center hub to return to sort mode." hidden>
-                <div class="modeBanner" id="gesture-banner-b">Focus Mode — Review Halves</div>
+                 aria-label="Focus mode. Left/right review halves. Double-tap center hub to return to sort mode." hidden>
                 <div id="gesture-half-left" class="half left"></div>
                 <div id="gesture-half-right" class="half right"></div>
-                <div class="hub" id="gesture-hub-b"><div>Long-press<br>to sort</div></div>
+                <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
         
@@ -926,7 +949,8 @@
                 lazyLoadState: { allFiles: [], renderedCount: 0, observer: null, batchSize: 20 } },
             tags: new Set(), loadingProgress: { current: 0, total: 0 },
             folderMoveMode: { active: false, files: [] },
-            activeRequests: new AbortController()
+            activeRequests: new AbortController(),
+            sessionVisitedFolders: new Set()
         };
         const Utils = {
             elements: {},
@@ -996,8 +1020,6 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    gestureBannerA: document.getElementById('gesture-banner-a'),
-                    gestureBannerB: document.getElementById('gesture-banner-b'),
                     
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
@@ -1197,6 +1219,16 @@
                     const transaction = this.db.transaction('metadata', 'readwrite');
                     const store = transaction.objectStore('metadata');
                     const request = store.put({ id: fileId, metadata });
+                    request.onsuccess = () => resolve();
+                    request.onerror = () => reject(request.error);
+                });
+            }
+            async deleteMetadata(fileId) {
+                if (!this.db) return;
+                return new Promise((resolve, reject) => {
+                    const transaction = this.db.transaction('metadata', 'readwrite');
+                    const store = transaction.objectStore('metadata');
+                    const request = store.delete(fileId);
                     request.onsuccess = () => resolve();
                     request.onerror = () => reject(request.error);
                 });
@@ -1772,38 +1804,111 @@
                 }
             },
             async loadImages() {
-                const cachedFiles = await state.dbManager.getFolderCache(state.currentFolder.id);
+                const folderId = state.currentFolder.id;
+                const sessionKey = `${state.providerType || 'unknown'}::${folderId}`;
+                const cachedFiles = await state.dbManager.getFolderCache(folderId) || [];
+                const isFirstSessionVisit = !state.sessionVisitedFolders.has(sessionKey);
 
-                if (cachedFiles) {
-                    Utils.showScreen('app-container');
-                    state.imageFiles = cachedFiles;
-                    await this.processAllMetadata(state.imageFiles);
-                    Core.initializeStacks();
-                    Core.initializeImageDisplay();
-                    this.refreshFolderInBackground();
+                if (isFirstSessionVisit || cachedFiles.length === 0) {
+                    await this.syncFolderFromCloud(cachedFiles, sessionKey);
                     return;
                 }
 
+                state.imageFiles = cachedFiles;
+                Utils.showScreen('app-container');
+                Core.initializeStacks();
+                Core.initializeImageDisplay();
+                const pendingPngs = state.imageFiles.filter(file => file.mimeType === 'image/png' && file.metadataStatus === 'pending');
+                if (pendingPngs.length > 0) {
+                    this.extractMetadataInBackground(pendingPngs);
+                }
+            },
+            mergeCloudWithCache(cloudFiles, cachedFiles) {
+                const cachedMap = new Map(cachedFiles.map(file => [file.id, file]));
+                const merged = [];
+                const newIds = [];
+                const updatedIds = [];
+                const removedIds = [];
+
+                for (const cloudFile of cloudFiles) {
+                    const cached = cachedMap.get(cloudFile.id);
+                    if (!cached) {
+                        merged.push({ ...cloudFile });
+                        newIds.push(cloudFile.id);
+                    } else {
+                        const cloudModified = Date.parse(cloudFile.modifiedTime || cloudFile.createdTime || 0);
+                        const cachedModified = Date.parse(cached.modifiedTime || cached.createdTime || 0);
+                        if (!isNaN(cloudModified) && cloudModified > cachedModified) {
+                            merged.push({ ...cached, ...cloudFile });
+                            updatedIds.push(cloudFile.id);
+                        } else {
+                            merged.push(cached);
+                        }
+                        cachedMap.delete(cloudFile.id);
+                    }
+                }
+
+                for (const removedId of cachedMap.keys()) {
+                    removedIds.push(removedId);
+                }
+
+                return {
+                    mergedFiles: merged,
+                    newIds,
+                    updatedIds,
+                    removedIds,
+                    hasChanges: newIds.length > 0 || updatedIds.length > 0 || removedIds.length > 0
+                };
+            },
+            async syncFolderFromCloud(cachedFiles, sessionKey) {
+                const folderId = state.currentFolder.id;
+                const hadCached = cachedFiles.length > 0;
                 Utils.showScreen('loading-screen');
-                Utils.updateLoadingProgress(0, 0, 'Fetching from cloud...');
-                
+                Utils.updateLoadingProgress(0, hadCached ? cachedFiles.length : 0, hadCached ? 'Syncing with cloud...' : 'Fetching from cloud...');
+
                 try {
-                    const result = await state.provider.getFilesAndMetadata(state.currentFolder.id);
-                    const files = result.files || [];
-                    
-                    if (files.length === 0) {
+                    const result = await state.provider.getFilesAndMetadata(folderId);
+                    const cloudFiles = result.files || [];
+                    const { mergedFiles, newIds, updatedIds, removedIds, hasChanges } = this.mergeCloudWithCache(cloudFiles, cachedFiles);
+
+                    if (mergedFiles.length === 0) {
+                        await state.dbManager.saveFolderCache(folderId, []);
+                        state.imageFiles = [];
                         Utils.showToast('No images found in this folder', 'info', true);
                         this.returnToFolderSelection();
                         return;
                     }
-                    
-                    state.imageFiles = files;
-                    await this.processAllMetadata(state.imageFiles, true);
-                    await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
-                    
+
+                    for (const updatedId of updatedIds) {
+                        const updatedFile = mergedFiles.find(file => file.id === updatedId);
+                        if (updatedFile) {
+                            await state.dbManager.saveMetadata(updatedId, updatedFile);
+                        }
+                    }
+                    if (removedIds.length > 0) {
+                        await Promise.all(removedIds.map(id => state.dbManager.deleteMetadata(id)));
+                    }
+
+                    state.imageFiles = mergedFiles;
+                    await this.processAllMetadata(state.imageFiles, !hadCached);
+                    if (hasChanges || !hadCached) {
+                        await state.dbManager.saveFolderCache(folderId, state.imageFiles);
+                    }
+
+                    const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
+                    state.sessionVisitedFolders.add(key);
+                    this.switchToCommonUI();
                     Core.initializeStacks();
                     Core.initializeImageDisplay();
-                    
+
+                    if (hadCached && hasChanges) {
+                        const diffSummary = [];
+                        if (newIds.length > 0) diffSummary.push(`${newIds.length} new`);
+                        if (updatedIds.length > 0) diffSummary.push(`${updatedIds.length} updated`);
+                        if (removedIds.length > 0) diffSummary.push(`${removedIds.length} removed`);
+                        const summaryText = diffSummary.length > 0 ? diffSummary.join(', ') : 'changes';
+                        Utils.showToast(`Folder updated with cloud changes (${summaryText})`, 'info');
+                    }
                 } catch (error) {
                     if (error.name !== 'AbortError') {
                         Utils.showToast(`Error loading images: ${error.message}`, 'error', true);
@@ -1813,39 +1918,34 @@
             },
             async refreshFolderInBackground() {
                 try {
-                    const result = await state.provider.getFilesAndMetadata(state.currentFolder.id);
+                    const folderId = state.currentFolder.id;
+                    const cachedFiles = await state.dbManager.getFolderCache(folderId) || [];
+                    const result = await state.provider.getFilesAndMetadata(folderId);
                     const cloudFiles = result.files || [];
-                    const localFiles = await state.dbManager.getFolderCache(state.currentFolder.id) || [];
-                    const cloudFileMap = new Map(cloudFiles.map(f => [f.id, f]));
-                    const localFileMap = new Map(localFiles.map(f => [f.id, f]));
-                    let hasChanges = false;
-            
-                    for (const cloudFile of cloudFiles) {
-                        const localFile = localFileMap.get(cloudFile.id);
-                        if (!localFile || new Date(cloudFile.modifiedTime) > new Date(localFile.modifiedTime)) {
-                            hasChanges = true;
-                            localFileMap.set(cloudFile.id, cloudFile);
+                    const { mergedFiles, updatedIds, removedIds, hasChanges } = this.mergeCloudWithCache(cloudFiles, cachedFiles);
+
+                    if (!hasChanges) {
+                        return;
+                    }
+
+                    for (const updatedId of updatedIds) {
+                        const updatedFile = mergedFiles.find(file => file.id === updatedId);
+                        if (updatedFile) {
+                            await state.dbManager.saveMetadata(updatedId, updatedFile);
                         }
                     }
-            
-                    for (const localId of localFileMap.keys()) {
-                        if (!cloudFileMap.has(localId)) {
-                            hasChanges = true;
-                            localFileMap.delete(localId);
-                        }
+                    if (removedIds.length > 0) {
+                        await Promise.all(removedIds.map(id => state.dbManager.deleteMetadata(id)));
                     }
-            
-                    if (hasChanges) {
-                        const newMergedFiles = Array.from(localFileMap.values());
-                        await this.processAllMetadata(newMergedFiles);
-                        await state.dbManager.saveFolderCache(state.currentFolder.id, newMergedFiles);
-                        state.imageFiles = newMergedFiles;
-                        Core.initializeStacks();
-                        Core.updateStackCounts();
-                        if(state.imageFiles.length > 0) Core.displayCurrentImage();
-                        else Core.showEmptyState();
-                        Utils.showToast('Folder updated in background', 'info');
-                    }
+
+                    await this.processAllMetadata(mergedFiles);
+                    await state.dbManager.saveFolderCache(folderId, mergedFiles);
+                    state.imageFiles = mergedFiles;
+                    Core.initializeStacks();
+                    Core.updateStackCounts();
+                    if (state.imageFiles.length > 0) Core.displayCurrentImage();
+                    else Core.showEmptyState();
+                    Utils.showToast('Folder updated in background', 'info');
                 } catch (error) {
                     console.warn("Background refresh failed:", error.message);
                 }
@@ -2100,11 +2200,38 @@
                 const stack = state.stacks[state.currentStack];
                 const total = stack ? stack.length : 0;
                 const current = total > 0 ? state.currentStackPosition + 1 : 0;
+                const counterText = total > 0 ? `Item ${current} / ${total}` : 'No items';
+                if (Utils.elements.normalImageCount) {
+                    Utils.elements.normalImageCount.textContent = counterText;
+                    Utils.elements.normalImageCount.setAttribute('aria-label', counterText);
+                }
+                if (Utils.elements.focusImageCount) {
+                    Utils.elements.focusImageCount.textContent = counterText;
+                    Utils.elements.focusImageCount.setAttribute('aria-label', counterText);
+                }
+                if (Utils.elements.focusStackName) {
+                    const stackLabel = STACK_NAMES[state.currentStack] || state.currentStack;
+                    Utils.elements.focusStackName.textContent = stackLabel;
+                    Utils.elements.focusStackName.setAttribute('aria-label', `Switch stack (current: ${stackLabel})`);
+                }
             },
 
             updateFavoriteButton() {
                 const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
-                if (!currentFile) return;
+                if (!currentFile) {
+                    if (Utils.elements.focusFavoriteBtn) {
+                        Utils.elements.focusFavoriteBtn.classList.remove('favorited');
+                        Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', 'false');
+                    }
+                    return;
+                }
+                const isFavorite = Boolean(currentFile.favorite);
+                if (Utils.elements.focusFavoriteBtn) {
+                    Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
+                    Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
+                    const label = isFavorite ? 'Remove from favorites' : 'Add to favorites';
+                    Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
+                }
             },
             
             applyTransform() {
@@ -2826,14 +2953,19 @@
         const Gestures = {
             startPos: { x: 0, y: 0 },
             currentPos: { x: 0, y: 0 },
+            startTimestamp: 0,
             gestureStarted: false,
             edgeElements: [],
-            longPressTimer: null,
-            longPressTriggered: false,
             hubPressActive: false,
             overlay: null,
-            LONG_PRESS_MS: 600,
-            LONG_PRESS_MOVE_CANCEL: 18,
+            lastHubTap: { time: 0, x: 0, y: 0 },
+            DOUBLE_TAP_MAX_INTERVAL: 320,
+            DOUBLE_TAP_MAX_DISTANCE: 28,
+            TAP_DISTANCE_THRESHOLD: 26,
+            TAP_DURATION_THRESHOLD: 260,
+            TRAIL_INTERVAL_MS: 12,
+            TRAIL_LIFETIME_MS: 1050,
+            trailThrottle: null,
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -2872,6 +3004,31 @@
                     }
                 };
                 this.updateGestureOverlayMode();
+            },
+            spawnTrail(clientX, clientY) {
+                if (!this.overlay?.layer) return;
+                const rect = this.overlay.layer.getBoundingClientRect();
+                const trail = document.createElement('div');
+                trail.className = 'comet-trail';
+                trail.style.left = `${clientX - rect.left}px`;
+                trail.style.top = `${clientY - rect.top}px`;
+                this.overlay.layer.appendChild(trail);
+                setTimeout(() => trail.remove(), this.TRAIL_LIFETIME_MS);
+            },
+            spawnRipple(clientX, clientY) {
+                if (!this.overlay?.layer) return;
+                const rect = this.overlay.layer.getBoundingClientRect();
+                const ripple = document.createElement('div');
+                ripple.className = 'tap-ripple';
+                ripple.style.left = `${clientX - rect.left}px`;
+                ripple.style.top = `${clientY - rect.top}px`;
+                this.overlay.layer.appendChild(ripple);
+                setTimeout(() => ripple.remove(), 560);
+            },
+            queueTrail(clientX, clientY) {
+                if (this.trailThrottle) return;
+                this.spawnTrail(clientX, clientY);
+                this.trailThrottle = setTimeout(() => { this.trailThrottle = null; }, this.TRAIL_INTERVAL_MS);
             },
             flashElement(el) {
                 if (!el) return;
@@ -3002,32 +3159,25 @@
                 }
             },
             handleStart(e) {
-                if (state.stacks[state.currentStack].length === 0) return;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
                 const point = e.touches ? e.touches[0] : e;
+                const hubInteraction = this.isInHub(point.clientX, point.clientY);
+                if (!hubInteraction && state.stacks[state.currentStack].length === 0) return;
                 this.startPos = { x: point.clientX, y: point.clientY };
                 this.currentPos = { x: point.clientX, y: point.clientY };
+                this.startTimestamp = performance.now();
                 this.gestureStarted = false;
                 state.isDragging = true;
-                this.longPressTriggered = false;
-                this.hubPressActive = this.isInHub(point.clientX, point.clientY);
-                if (this.longPressTimer) clearTimeout(this.longPressTimer);
-                if (this.hubPressActive) {
-                    this.longPressTimer = setTimeout(() => {
-                        this.longPressTimer = null;
-                        this.longPressTriggered = true;
-                        this.toggleFocusMode();
-                        if (state.haptic) { state.haptic.triggerFeedback('buttonPress'); }
-                    }, this.LONG_PRESS_MS);
-                } else {
-                    this.longPressTimer = null;
+                this.hubPressActive = hubInteraction;
+                if (!hubInteraction) {
+                    Utils.elements.centerImage.classList.add('dragging');
                 }
-                Utils.elements.centerImage.classList.add('dragging');
+                this.spawnRipple(point.clientX, point.clientY);
+                this.queueTrail(point.clientX, point.clientY);
             },
             handleMove(e) {
                 if (!state.isDragging) return;
-                if (state.imageFiles.length === 0) return;
                 if (e.touches && e.touches.length > 1) {
                     state.isDragging = false; Utils.elements.centerImage.classList.remove('dragging');
                     this.hideAllEdgeGlows(); return;
@@ -3035,16 +3185,12 @@
                 e.preventDefault();
                 const point = e.touches ? e.touches[0] : e;
                 this.currentPos = { x: point.clientX, y: point.clientY };
+                this.queueTrail(point.clientX, point.clientY);
+                if (this.hubPressActive) { return; }
+                if (state.imageFiles.length === 0) return;
                 const deltaX = this.currentPos.x - this.startPos.x;
                 const deltaY = this.currentPos.y - this.startPos.y;
                 const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
-                if (this.longPressTimer) {
-                    const dist = Math.hypot(deltaX, deltaY);
-                    if (dist > this.LONG_PRESS_MOVE_CANCEL || !this.isInHub(point.clientX, point.clientY)) {
-                        clearTimeout(this.longPressTimer);
-                        this.longPressTimer = null;
-                    }
-                }
                 if (distance > 30) {
                     this.gestureStarted = true;
                     if(!state.isFocusMode) {
@@ -3059,17 +3205,37 @@
                 if (!state.isDragging) return;
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');
-                if (this.longPressTimer) { clearTimeout(this.longPressTimer); this.longPressTimer = null; }
                 const point = e.changedTouches && e.changedTouches.length ? e.changedTouches[0] : e;
                 if (point) { this.currentPos = { x: point.clientX, y: point.clientY }; }
+                this.spawnTrail(this.currentPos.x, this.currentPos.y);
                 const deltaX = this.currentPos.x - this.startPos.x;
                 const deltaY = this.currentPos.y - this.startPos.y;
                 const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+                const now = performance.now();
+                const duration = now - this.startTimestamp;
+                const isTap = distance < this.TAP_DISTANCE_THRESHOLD && duration < this.TAP_DURATION_THRESHOLD;
 
-                if (this.longPressTriggered) {
-                    this.longPressTriggered = false;
-                    this.hubPressActive = false;
+                if (this.hubPressActive) {
+                    if (isTap) {
+                        if (this.lastHubTap.time && (now - this.lastHubTap.time) <= this.DOUBLE_TAP_MAX_INTERVAL) {
+                            const tapDistance = Math.hypot(this.lastHubTap.x - this.currentPos.x, this.lastHubTap.y - this.currentPos.y);
+                            if (tapDistance <= this.DOUBLE_TAP_MAX_DISTANCE) {
+                                this.spawnRipple(this.currentPos.x, this.currentPos.y);
+                                this.toggleFocusMode();
+                                if (state.haptic) { state.haptic.triggerFeedback('buttonPress'); }
+                                this.lastHubTap = { time: 0, x: 0, y: 0 };
+                            } else {
+                                this.lastHubTap = { time: now, x: this.currentPos.x, y: this.currentPos.y };
+                            }
+                        } else {
+                            this.lastHubTap = { time: now, x: this.currentPos.x, y: this.currentPos.y };
+                        }
+                    } else {
+                        this.lastHubTap = { time: 0, x: 0, y: 0 };
+                    }
                     this.hideAllEdgeGlows();
+                    this.hubPressActive = false;
+                    this.gestureStarted = false;
                     return;
                 }
 
@@ -3088,13 +3254,13 @@
                             this.executeFlick(targetStack);
                         }
                     }
-                } else if (!this.gestureStarted) {
+                } else if (!this.gestureStarted && isTap) {
+                    this.spawnRipple(this.currentPos.x, this.currentPos.y);
                     this.handleTap(this.currentPos.x, this.currentPos.y);
                 }
                 this.hideAllEdgeGlows();
                 this.hubPressActive = false;
                 this.gestureStarted = false;
-                this.longPressTriggered = false;
             },
             getDistance(touch1, touch2) { const dx = touch1.clientX - touch2.clientX; const dy = touch1.clientY - touch2.clientY; return Math.sqrt(dx * dx + dy * dy); },
             getCenter(touch1, touch2) { return { x: (touch1.clientX + touch2.clientX) / 2, y: (touch1.clientY + touch2.clientY) / 2 }; },
@@ -3140,6 +3306,7 @@
                 Utils.elements.appContainer.classList.toggle('focus-mode', state.isFocusMode);
                 this.updateGestureOverlayMode();
                 Core.updateImageCounters();
+                this.lastHubTap = { time: 0, x: 0, y: 0 };
             },
             async nextImage() {
                 const stack = state.stacks[state.currentStack];


### PR DESCRIPTION
## Summary
- track session-level folder visits so the first entry performs a cloud sync and later visits use the indexedDB cache
- merge cloud results against cached items to load only changed files, update metadata, and prune removed entries
- add metadata delete support and reuse the diffing helper for background refresh updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd10708df8832da48465090fa04b99