### PR TITLE
Add index-v1 build with incremental sync and last-writer wins

### DIFF
--- a/index-v1.html
+++ b/index-v1.html
@@ -1166,7 +1166,7 @@
             constructor() { this.db = null; }
             async init() {
                 return new Promise((resolve, reject) => {
-                    const request = indexedDB.open('Orbital8-Goji-V1', 1);
+                    const request = indexedDB.open('Orbital8-Goji-V1', 2);
                     request.onupgradeneeded = (event) => {
                         const db = event.target.result;
                         if (!db.objectStoreNames.contains('folderCache')) {


### PR DESCRIPTION
## Summary
- add a frozen `index-v1.html` snapshot that keeps the incremental folder sync and metadata comparison logic used for last-device-wins behaviour
- bump IndexedDB schema to version 2 inside the new file so the sync queue store is provisioned for existing users

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd10708df8832da48465090fa04b99