### PR TITLE
Fix OneDrive folder sync and refresh cache on open

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -1,0 +1,3948 @@
+<!-- Orbital8-N-2025-09-21 04:30 PM -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no, maximum-scale=1.0">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <title>Orbital8 Goji Version</title>
+    <script src="https://alcdn.msauth.net/browser/2.28.1/js/msal-browser.min.js"></script>
+    <style>
+        :root {
+            --accent: #f59e0b;
+            --glass: rgba(255, 255, 255, 0.1);
+            --border: rgba(255, 255, 255, 0.3);
+            --dark: linear-gradient(135deg, #0f0f0f 0%, #1a1a1a 100%);
+            --glow: 0.6;
+            --ripple: 1500ms;
+        }
+
+        * { box-sizing: border-box; }
+        
+        body, html {
+            margin: 0; padding: 0; height: 100%;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
+        }
+        
+        .screen {
+            position: fixed; inset: 0; background: var(--dark);
+            display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
+        }
+        .screen.hidden { display: none; }
+        
+        .card {
+            background: var(--glass); backdrop-filter: blur(20px);
+            border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
+            padding: 40px; text-align: center; max-width: 500px; width: 90%;
+        }
+        
+        .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
+        .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
+        
+        .input, .notes-textarea, .tag-input {
+            width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
+            background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
+        }
+        .input::placeholder, .tag-input::placeholder { color: rgba(255, 255, 255, 0.5); }
+        .input:focus, .notes-textarea:focus, .tag-input:focus {
+            outline: none; border-color: var(--accent); box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.2);
+        }
+        .notes-textarea { min-height: 120px; font-family: inherit; resize: vertical; color: black; }
+
+        #action-modal .tag-input, #grid-modal .input {
+            color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
+        }
+        
+        .button, .folder-button, .btn {
+            background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
+            color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
+            transition: all 0.3s ease; box-shadow: 0 4px 20px rgba(245, 158, 11, 0.4); width: 100%; margin-bottom: 16px;
+        }
+        .button:hover:not(:disabled), .folder-button:hover, .btn:hover:not(:disabled) {
+            transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
+        }
+        .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
+        
+        .folder-button {
+            flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
+            font-size: 14px; backdrop-filter: blur(10px); width: auto;
+        }
+        .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
+        .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
+        
+        .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
+        .btn-primary { background-color: #3b82f6; }
+        .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
+        .btn-danger { background-color: #ef4444; }
+        .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
+        .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
+        .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
+        
+        .provider-button {
+            display: flex; align-items: center; justify-content: center; gap: 12px;
+            background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
+            border-radius: 15px; padding: 20px; margin-bottom: 16px; color: white;
+            font-size: 16px; font-weight: 500; cursor: pointer; transition: all 0.3s ease;
+            backdrop-filter: blur(10px);
+        }
+        .provider-button:hover {
+            background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
+            transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
+        }
+        
+        .settings-section {
+            margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
+        }
+        
+        .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
+        
+        .intensity-btn {
+            padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
+            background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
+            transition: all 0.2s ease;
+        }
+        .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
+        .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
+        
+        .checkbox-label {
+            color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
+            align-items: center; gap: 8px; cursor: pointer; justify-content: center;
+        }
+        
+        .status {
+            padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
+        }
+        .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
+        .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
+        .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
+        
+        .toast {
+            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
+            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
+            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
+        }
+        .toast.show { opacity: 1; }
+        .toast.success { background: rgba(16, 185, 129, 0.9); }
+        .toast.info { background: rgba(59, 130, 246, 0.9); }
+        .toast.error { background: rgba(239, 68, 68, 0.9); }
+        
+        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+        .folder-item {
+            display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
+            background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 12px; cursor: pointer; transition: all 0.2s ease; color: white; justify-content: space-between;
+        }
+        .folder-item:hover {
+            background: rgba(255, 255, 255, 0.1); border-color: rgba(245, 158, 11, 0.3); transform: translateY(-1px);
+        }
+        .folder-icon { width: 20px; height: 20px; margin-right: 12px; color: var(--accent); }
+        .folder-info { flex: 1; }
+        .folder-name { font-weight: 500; margin-bottom: 2px; }
+        .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
+        
+        .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
+        .folder-action-btn {
+            padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
+            background: rgba(255, 255, 255, 0.1); color: white; font-size: 12px; cursor: pointer;
+            transition: all 0.2s ease; backdrop-filter: blur(10px);
+        }
+        .folder-action-btn:hover { background: rgba(255, 255, 255, 0.2); transform: translateY(-1px); }
+        .folder-action-btn.drill-btn { border-color: rgba(245, 158, 11, 0.4); color: var(--accent); }
+        .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
+        .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
+        .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
+        
+        .spinner {
+            width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
+            border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
+        }
+        @keyframes spin { to { transform: rotate(360deg); } }
+        
+        .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
+        .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
+        .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
+        .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
+        
+        .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
+        
+        .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
+        .center-image {
+            max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
+            transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94), opacity 0.2s ease; transform-origin: center center; cursor: grab;
+        }
+        .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
+        .center-image.zoomable { pointer-events: auto; }
+        
+        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+        .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
+        .edge-glow.bottom { 
+            bottom: 0; left: 0; right: 0; height: 8px; 
+            background: linear-gradient(0deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%);
+            bottom: env(safe-area-inset-bottom, 0px);
+        }
+        .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
+        .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
+        .edge-glow.active { opacity: 1; }
+        
+        .pill-counter {
+            position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
+            color: black; opacity: 0; transition: all 0.3s ease;
+            cursor: pointer; z-index: 10; min-width: 50px; text-align: center;
+        }
+        .pill-counter.visible { opacity: 0.9; }
+        .pill-counter.active { font-weight: 700; background: white; opacity: 1; border: 3px solid black; }
+        .pill-counter:not(.active) { background: rgba(128, 128, 128, 0.4); border: none; }
+        .pill-counter:hover { opacity: 1; transform: scale(1.05); }
+        .pill-counter.top { top: 10px; left: 50%; transform: translateX(-50%); }
+        .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
+        .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
+        .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
+        
+        .pill-counter::before, .pill-counter::after {
+            content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
+        }
+        .pill-counter.triple-ripple::before { animation: tripleRipple1 var(--ripple) ease-out; }
+        .pill-counter.triple-ripple::after { animation: tripleRipple2 var(--ripple) ease-out 0.2s; }
+        .pill-counter.triple-ripple { animation: tripleRipple3 var(--ripple) ease-out 0.4s; }
+        .pill-counter.glow-effect { 
+            box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
+            animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
+        }
+        
+        .high-intensity-mode .pill-counter.glow-effect {
+            box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
+        }
+        
+        @keyframes tripleRipple1 {
+            0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
+            100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
+        }
+        @keyframes tripleRipple2 {
+            0% { opacity: 0.7; transform: scale(1); top: -6px; left: -6px; right: -6px; bottom: -6px; }
+            100% { opacity: 0; transform: scale(2.5); top: -30px; left: -30px; right: -30px; bottom: -30px; }
+        }
+        @keyframes tripleRipple3 {
+            0% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.5); }
+            50% { box-shadow: 0 0 20px rgba(245, 158, 11, 0.8); }
+            100% { box-shadow: 0 0 15px rgba(245, 158, 11, 0.6); }
+        }
+        @keyframes sustainedGlow {
+            0% { box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6)); }
+            50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
+            100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
+        }
+        
+        .empty-state {
+            position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
+            color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
+            text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); z-index: 5;
+        }
+        .empty-message { margin-bottom: 20px; font-size: 24px; font-weight: 400; }
+        .new-images-button {
+            background: rgba(245, 158, 11, 0.2); border: 1px solid rgba(245, 158, 11, 0.4); border-radius: 20px;
+            padding: 12px 24px; color: white; font-size: 16px; cursor: pointer;
+            transition: all 0.2s ease;
+        }
+        .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
+        
+        .modal { 
+            position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
+            display: flex; align-items: center; justify-content: center; z-index: 50; 
+        }
+        .modal.hidden { display: none !important; }
+        .modal-content {
+            background: white; border-radius: 8px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            width: 100%; height: 100%; max-width: 1152px; max-height: 90vh; margin: 16px;
+            display: flex; flex-direction: column;
+            position: absolute; /* For dragging */
+        }
+        .action-modal { max-width: 448px; padding: 24px; }
+        
+        .modal-header { 
+            position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
+            border-top-left-radius: 8px; border-top-right-radius: 8px;
+        }
+        .modal-header-main { 
+            padding: 12px 16px; border-bottom: 1px solid #f3f4f6; display: flex; 
+            align-items: center; justify-content: space-between; cursor: move; 
+        }
+        .modal-header-left { display: flex; align-items: center; gap: 12px; }
+        .modal-title { font-size: 20px; font-weight: 500; color: #1f2937; line-height: 1.5; }
+        .select-all-btn {
+            background-color: #e5e7eb; color: #4b5563; padding: 2px 8px; border-radius: 9999px; font-size: 14px; font-weight: 500;
+            display: inline-block; min-width: 36px; text-align: center; cursor: pointer;
+            transition: background-color 0.2s;
+        }
+        .select-all-btn:hover { background-color: #d1d5db; }
+        .close-btn {
+            color: #6b7280; transition: all 0.2s; cursor: pointer; background: transparent; border: none; border-radius: 6px;
+            padding: 4px; display: flex; align-items: center; justify-content: center;
+        }
+        .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
+        .close-btn svg { width: 24px; height: 24px; }
+        
+        .grid-row-2 {
+            padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
+            align-items: center; justify-content: space-between;
+        }
+        .selection-count {
+            background-color: #dbeafe; color: #1e40af; padding: 4px 12px; border-radius: 9999px; font-size: 14px;
+            display: flex; align-items: center; gap: 8px;
+        }
+        .deselect-all-btn {
+            margin-left: 4px; transition: all 0.2s; cursor: pointer; background: transparent; border: none; border-radius: 4px;
+            padding: 2px; display: flex; align-items: center; justify-content: center;
+        }
+        .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
+        .deselect-all-btn svg { width: 16px; height: 16px; }
+        
+        .zoom-control { display: flex; align-items: center; gap: 8px; }
+        #grid-size { width: 80px; }
+        #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
+        
+        .grid-row-3 {
+            padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
+        }
+        #omni-search {
+            flex-grow: 1; padding: 6px 30px 6px 10px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 14px;
+        }
+        #clear-search-btn {
+            position: absolute; right: 24px; top: 50%; transform: translateY(-50%);
+            color: #9ca3af; cursor: pointer; display: none;
+        }
+        #clear-search-btn:hover { color: #6b7280; }
+        
+        /* NEW: Search Helper */
+        .search-helper { position: relative; }
+        .search-helper-icon { color: #9ca3af; cursor: pointer; display: flex; align-items: center; }
+        .search-helper-icon:hover { color: #6b7280; }
+        .search-helper-popup {
+            display: none; position: absolute; right: 0; top: 100%; margin-top: 8px;
+            background: white; border: 1px solid #e5e7eb; border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+            padding: 8px; width: 220px; z-index: 20;
+        }
+        .search-helper:hover .search-helper-popup { display: block; }
+        .search-helper-popup h4 { font-size: 13px; font-weight: 600; color: #374151; margin: 4px 0 8px; padding-bottom: 4px; border-bottom: 1px solid #f3f4f6; }
+        .search-helper-popup a {
+            display: block; font-size: 12px; color: #3b82f6; text-decoration: none; padding: 4px 8px;
+            border-radius: 4px; cursor: pointer;
+        }
+        .search-helper-popup a:hover { background: #f3f4f6; }
+
+
+        .grid-row-4 {
+            padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
+        }
+        .bulk-actions { display: flex; align-items: center; gap: 8px; }
+        .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
+        
+        .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
+        .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
+        
+        .grid-item {
+            position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
+            display: flex; align-items: center; justify-content: center; overflow: hidden;
+        }
+        .grid-item::before { content: ""; display: block; padding-top: 100%; }
+        .grid-image {
+            position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: contain;
+            opacity: 0; transition: opacity 0.3s ease;
+        }
+        .grid-image[data-src] { opacity: 0; }
+        .grid-image.loaded { opacity: 1; }
+        .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px;
+            font-size: 14px;
+            text-align: center;
+            opacity: 0;
+            transition: opacity 0.3s;
+            pointer-events: none;
+        }
+
+        .grid-item:hover .filename-overlay {
+            opacity: 1;
+        }
+        
+        .details-modal-content { 
+            max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
+            resize: both; overflow: auto; min-width: 400px; min-height: 400px;
+        }
+        .details-header { 
+            display: flex; align-items: center; justify-content: space-between; padding: 16px; 
+            border-bottom: 1px solid #e5e7eb; flex-shrink: 0; cursor: move;
+        }
+        .details-title { font-size: 18px; font-weight: 500; color: #1f2937; }
+        .tab-nav { display: flex; border-bottom: 1px solid #e5e7eb; background: #f8fafc; flex-shrink: 0; }
+        .tab-button {
+            flex: 1; padding: 16px; border: none; background: transparent; color: #6b7280; font-size: 14px; font-weight: 500;
+            cursor: pointer; transition: all 0.2s; border-bottom: 2px solid transparent;
+        }
+        .tab-button:hover { color: #374151; background: rgba(0, 0, 0, 0.02); }
+        .tab-button.active { color: #3b82f6; border-bottom-color: #3b82f6; background: white; }
+        .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
+        .tab-content { display: none; padding: 20px; height: 100%; }
+        .tab-content.active { display: block; }
+        
+        .tags-container { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; min-height: 40px; }
+        .tag-item { display: inline-flex; align-items: center; background: #dbeafe; color: #1e40af; padding: 4px 8px; border-radius: 12px; font-size: 12px; gap: 6px; }
+        .tag-remove {
+            background: transparent; border: none; color: #1e40af; cursor: pointer; font-size: 14px; line-height: 1; padding: 0;
+            width: 16px; height: 16px; display: flex; align-items: center; justify-content: center; border-radius: 50%; transition: background-color 0.2s;
+        }
+        .tag-remove:hover { background: rgba(59, 130, 246, 0.1); }
+        .add-tag-btn {
+            background: #f3f4f6; border: 1px dashed #d1d5db; border-radius: 12px; padding: 4px 12px;
+            font-size: 12px; color: #6b7280; cursor: pointer; transition: all 0.2s;
+        }
+        .add-tag-btn:hover { background: #e5e7eb; color: #374151; }
+        
+        /* NEW: Action Modal Tag Chips */
+        #tag-chip-container { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
+        .tag-chip {
+            display: inline-flex; align-items: center; background: #e0e7ff; color: #3730a3; padding: 4px 8px;
+            border-radius: 12px; font-size: 13px; font-weight: 500; gap: 6px;
+        }
+        .tag-chip-remove {
+            background: transparent; border: none; color: #4338ca; cursor: pointer; font-size: 14px; line-height: 1; padding: 0;
+            width: 16px; height: 16px; display: flex; align-items: center; justify-content: center; border-radius: 50%;
+            transition: background-color 0.2s;
+        }
+        .tag-chip-remove:hover { background: rgba(99, 102, 241, 0.1); }
+
+
+        .star-rating { display: flex; gap: 4px; }
+        .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
+        .star:hover, .star.active { color: #fbbf24; }
+        
+        .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
+        .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
+        .metadata-table .key-cell {
+            font-weight: 500; color: #374151; width: 25%; border-right: 1px solid #e5e7eb; background: #f9fafb; min-width: 120px;
+        }
+        .metadata-table .value-cell { color: #6b7280; white-space: pre-wrap; position: relative; max-width: 0; word-break: break-all; }
+        .copy-button {
+            background: #f59e0b; border: none; border-radius: 4px; padding: 4px 8px; font-size: 11px; color: white;
+            cursor: pointer; transition: all 0.2s; margin-left: 8px; vertical-align: top;
+            font-weight: 500;
+        }
+        .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
+        .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
+        .copy-button.copied { background: #10b981; transform: scale(1.1); }
+        
+        .app-footer {
+            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6); text-align: center;
+            padding: 4px 8px;
+            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+        }
+
+        /* NEW: Standardized UI Button */
+        .ui-button {
+            background: rgba(0, 0, 0, 0.4);
+            color: #e5e7eb; /* light grey */
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            border-radius: 20px;
+            z-index: 20;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            backdrop-filter: blur(10px);
+            transition: none; /* No hover effect */
+            font-size: 14px;
+            padding: 10px 16px;
+            cursor: pointer;
+            position: absolute;
+        }
+
+        /* Applying standardized UI styles */
+        #back-button { top: 20px; left: 20px; }
+        #details-button { top: 20px; right: 20px; }
+        #normal-image-count { bottom: 20px; left: 20px; }
+        #center-trash-btn { bottom: 20px; right: 20px; }
+
+        /* Focus Mode UI elements */
+        .focus-mode-ui { display: none; }
+        #focus-stack-name { top: 20px; left: 20px; }
+        #focus-filename-display {
+            top: 20px; left: 50%; transform: translateX(-50%);
+            color: #e5e7eb; font-size: 14px;
+        }
+        #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
+        #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
+        #focus-favorite-btn {
+            position: absolute;
+            bottom: 20px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: transparent;
+            border: none;
+            cursor: pointer;
+            z-index: 20;
+            padding: 28px;
+            align-items: center;
+            justify-content: center;
+            border-radius: 999px;
+            min-width: 84px;
+            min-height: 84px;
+            touch-action: manipulation;
+            color: #9ca3af; /* Standalone grey outline */
+        }
+        #focus-favorite-btn svg { pointer-events: none; }
+        #focus-favorite-btn.favorited {
+            color: #ef4444; /* Solid red */
+        }
+
+        #focus-filename-display,
+        #focus-image-count { display: none !important; }
+
+        /* Focus Mode state toggling */
+        .app-container.focus-mode .pill-counter,
+        .app-container.focus-mode #back-button,
+        .app-container.focus-mode #center-trash-btn { display: none; }
+
+        .app-container.focus-mode .focus-mode-ui { display: flex; }
+        
+        .hidden { display: none !important; }
+        
+        @supports (height: 100dvh) {
+            .app-container, .image-viewport { height: 100dvh; }
+        }
+
+        /* Gesture overlay inspired by ui.html */
+        .gesture-layer {
+            position: absolute;
+            inset: 0;
+            z-index: 3;
+            pointer-events: none;
+        }
+        .gesture-layer .stage {
+            position: absolute;
+            inset: 0;
+            pointer-events: none;
+            user-select: none;
+            -webkit-user-select: none;
+            -webkit-tap-highlight-color: transparent;
+            touch-action: none;
+            overflow: hidden;
+        }
+        .gesture-layer .tri,
+        .gesture-layer .half {
+            position: absolute;
+            inset: 0;
+            opacity: 0;
+            pointer-events: none;
+        }
+        .gesture-layer .tri.up { clip-path: polygon(0% 0%, 100% 0%, 50% 50%); background: transparent; }
+        .gesture-layer .tri.right { clip-path: polygon(100% 0%, 100% 100%, 50% 50%); background: transparent; }
+        .gesture-layer .tri.down { clip-path: polygon(0% 100%, 100% 100%, 50% 50%); background: transparent; }
+        .gesture-layer .tri.left { clip-path: polygon(0% 0%, 0% 100%, 50% 50%); background: transparent; }
+        .gesture-layer .half.left {
+            position: absolute;
+            top: 12px;
+            bottom: 12px;
+            left: 12px;
+            right: calc(50% + 6px);
+            border-radius: 16px;
+            background: transparent;
+        }
+        .gesture-layer .half.right {
+            position: absolute;
+            top: 12px;
+            bottom: 12px;
+            left: calc(50% + 6px);
+            right: 12px;
+            border-radius: 16px;
+            background: transparent;
+        }
+        .gesture-layer .hub {
+            position: absolute;
+            left: 50%;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: min(18vw, 18vh);
+            height: min(18vw, 18vh);
+            border-radius: 50%;
+            border: 1px solid transparent;
+            background: transparent;
+            pointer-events: none;
+            z-index: 40;
+        }
+        .gesture-layer .glow {
+            opacity: 0 !important;
+            box-shadow: none;
+        }
+        .gesture-layer .deglow { opacity: 0; }
+        .gesture-layer[hidden] { display: none; }
+
+        .gesture-layer .comet-trail {
+            position: absolute;
+            width: 26px;
+            height: 26px;
+            margin: -13px 0 0 -13px;
+            border-radius: 999px;
+            pointer-events: none;
+            background: radial-gradient(circle, rgba(255, 255, 255, 0.92) 0%, rgba(255, 255, 255, 0.28) 45%, rgba(255, 255, 255, 0) 75%);
+            opacity: 0.95;
+            transform: scale(0.85);
+            animation: cometFade 1.05s ease-out forwards;
+            mix-blend-mode: screen;
+            filter: blur(0.4px);
+            z-index: 30;
+        }
+        @keyframes cometFade {
+            0% { opacity: 0.95; transform: scale(0.85); }
+            100% { opacity: 0; transform: scale(2.6); }
+        }
+        .gesture-layer .tap-ripple {
+            position: absolute;
+            width: 22px;
+            height: 22px;
+            margin: -11px 0 0 -11px;
+            border-radius: 50%;
+            border: 2px solid rgba(255, 255, 255, 0.35);
+            pointer-events: none;
+            opacity: 0.9;
+            animation: rippleExpand 0.55s ease-out forwards;
+            mix-blend-mode: screen;
+            z-index: 30;
+        }
+        @keyframes rippleExpand {
+            0% { transform: scale(0.6); opacity: 0.9; }
+            100% { transform: scale(2.4); opacity: 0; }
+        }
+
+    </style>
+</head>
+<body>
+    <!-- Provider Selection Screen -->
+    <div class="screen" id="provider-screen">
+        <div class="card">
+            <h1 class="title" style="font-size: 32px;">Orbital8</h1>
+            <p class="subtitle">Select your cloud storage provider</p>
+            <button class="provider-button" id="google-drive-btn">
+                <svg style="width: 20px; height: 20px;" viewBox="0 0 24 24"><path fill="currentColor" d="M6.28 7L9.69 1h4.62l3.41 6zM16.05 7H7.95l4.05 7zM11.76 15h8.58L24 21H7.05z"/></svg>
+                Google Drive
+            </button>
+            <button class="provider-button" id="onedrive-btn">
+                <svg style="width: 20px; height: 20px;" viewBox="0 0 24 24"><path fill="currentColor" d="M17.75 8C16.82 8 16 8.82 16 9.75S16.82 11.5 17.75 11.5s1.75-.82 1.75-1.75S18.68 8 17.75 8z"/></svg>
+                OneDrive
+            </button>
+            <div class="settings-section">
+                <div style="margin-bottom: 16px;">
+                    <label style="color: rgba(255,255,255,0.9); font-size: 14px; font-weight: 500; display: block; margin-bottom: 8px;">Visual Cue Intensity:</label>
+                    <div class="intensity-options">
+                        <button class="intensity-btn" data-level="low">Low</button>
+                        <button class="intensity-btn active" data-level="medium">Medium</button>
+                        <button class="intensity-btn" data-level="high">High</button>
+                    </div>
+                </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="haptic-enabled" checked style="margin: 0;">
+                        Enable Haptic Feedback (Mobile)
+                    </label>
+                </div>
+            </div>
+            <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
+        </div>
+        <div class="app-footer">Orbital8-M-2025-09-21 04:30 PM</div>
+    </div>
+    
+    <!-- Unified Auth Screen -->
+    <div class="screen hidden" id="auth-screen">
+        <div class="card">
+            <h1 class="title" id="auth-title">Provider</h1>
+            <p class="subtitle" id="auth-subtitle">Connect to your account</p>
+            <div id="gdrive-secret-container" class="hidden" style="margin-bottom: 16px;">
+                <input type="password" id="gdrive-client-secret" class="input" placeholder="Enter Google Client Secret" style="margin-bottom: 0;">
+            </div>
+            <button class="button" id="auth-button">Connect</button>
+            <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
+            <div id="auth-status" class="status info"></div>
+        </div>
+        <div class="app-footer">Orbital8-M-2025-09-21 04:30 PM</div>
+    </div>
+    
+    <!-- Unified Folder Screen -->
+    <div class="screen hidden" id="folder-screen">
+        <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
+            <h2 class="title" id="folder-title">Select Folder</h2>
+            <div class="subtitle" id="folder-subtitle">Choose a folder containing images</div>
+            <div class="folder-list" id="folder-list"></div>
+            <div class="folder-actions">
+                <button class="folder-button" id="folder-refresh-button">Refresh</button>
+                <button class="folder-button" id="folder-back-button">← Provider</button>
+                <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
+            </div>
+        </div>
+        <div class="app-footer">Orbital8-M-2025-09-21 04:30 PM</div>
+    </div>
+    
+    <!-- Loading Screen -->
+    <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
+        <div class="card">
+            <h2 class="title">Loading Images</h2>
+            <div class="loading-counter" id="loading-counter">0</div>
+            <div class="loading-message" id="loading-message">Processing files...</div>
+            <div class="loading-progress">
+                <div class="loading-progress-bar" id="loading-progress-bar"></div>
+            </div>
+            <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
+        </div>
+        <div class="app-footer">Orbital8-M-2025-09-21 04:30 PM</div>
+    </div>
+    
+    <!-- Main App Container -->
+    <div class="app-container hidden" id="app-container">
+        <button class="ui-button" id="back-button">
+            <span id="back-button-spinner" class="spinner" style="display: none; width: 14px; height: 14px; margin-right: 6px;"></span>
+            Folders
+        </button>
+        <button class="ui-button" id="details-button">Details</button>
+        
+        <div class="image-viewport" id="image-viewport">
+            <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
+        </div>
+        <!-- Gesture overlay (triangular sort zones + focus halves) -->
+        <div class="gesture-layer" id="gesture-layer">
+            <div id="gesture-screen-a" class="stage" role="application"
+                 aria-label="Sort mode. Triangular flick zones. Double-tap center hub to enter focus mode.">
+                <div id="gesture-tri-up" class="tri up"></div>
+                <div id="gesture-tri-right" class="tri right"></div>
+                <div id="gesture-tri-down" class="tri down"></div>
+                <div id="gesture-tri-left" class="tri left"></div>
+                <div class="hub" id="gesture-hub-a"></div>
+            </div>
+            <div id="gesture-screen-b" class="stage" role="application"
+                 aria-label="Focus mode. Left/right review halves. Double-tap center hub to return to sort mode." hidden>
+                <div id="gesture-half-left" class="half left"></div>
+                <div id="gesture-half-right" class="half right"></div>
+                <div class="hub" id="gesture-hub-b"></div>
+            </div>
+        </div>
+        
+        <div class="edge-glow top" id="edge-top"></div>
+        <div class="edge-glow bottom" id="edge-bottom"></div>
+        <div class="edge-glow left" id="edge-left"></div>
+        <div class="edge-glow right" id="edge-right"></div>
+        
+        <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
+        <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
+        <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
+        <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
+        
+        <div class="empty-state hidden" id="empty-state">
+            <div class="empty-message">No more images in this stack</div>
+            <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
+            <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
+        </div>
+        
+        <!-- Center Stage UI -->
+        <div id="normal-image-count" class="ui-button"></div>
+        <button id="center-trash-btn" class="ui-button">
+            <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+            </svg>
+        </button>
+
+        <!-- Focus Mode UI -->
+        <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
+        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
+        <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
+        <button id="focus-favorite-btn" class="focus-mode-ui">
+            <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
+        </button>
+        <button id="focus-delete-btn" class="ui-button focus-mode-ui">
+            <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+            </svg>
+        </button>
+        
+        <div id="toast" class="toast"></div>
+        <div class="app-footer">Orbital8-M-2025-09-21 04:30 PM</div>
+    </div>
+    
+    <!-- Enhanced Grid Modal -->
+    <div id="grid-modal" class="modal hidden">
+        <div class="modal-content">
+            <div class="modal-header">
+                <div id="grid-modal-header-main" class="modal-header-main">
+                    <div class="modal-header-left">
+                        <h2 id="grid-title" class="modal-title">Grid View</h2>
+                        <button id="select-all-btn" class="select-all-btn">0</button>
+                    </div>
+                    <button id="close-grid" class="close-btn">
+                        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                </div>
+                
+                <div class="grid-row-2">
+                    <span class="selection-count">
+                        <span id="selection-text">0 selected</span>
+                        <button id="deselect-all-btn" class="deselect-all-btn">
+                            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                    </span>
+                    <div class="zoom-control">
+                        <input type="range" id="grid-size" min="1" max="10" value="4">
+                        <span id="grid-size-value">4</span>
+                    </div>
+                </div>
+                
+                <div class="grid-row-3">
+                    <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
+                    <div class="search-helper">
+                        <div class="search-helper-icon">
+                            <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                        </div>
+                        <div class="search-helper-popup">
+                            <h4>Special Modifiers</h4>
+                            <a class="modifier-link" data-modifier="#favorite">#favorite</a>
+                            <a class="modifier-link" data-modifier="#quality:5">#quality:1-5</a>
+                            <a class="modifier-link" data-modifier="#content:5">#content:1-5</a>
+                        </div>
+                    </div>
+                    <button id="clear-search-btn">
+                         <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                    </button>
+                </div>
+                
+                <div class="grid-row-4">
+                    <div class="bulk-actions">
+                        <button id="tag-selected" class="btn btn-primary">Tag</button>
+                        <button id="move-selected" class="btn btn-primary">Move</button>
+                        <button id="delete-selected" class="btn btn-danger">Delete</button>
+                        <button id="export-selected" class="btn btn-primary">Export</button>
+                        <button id="folder-selected" class="btn btn-primary">Folder</button>
+                    </div>
+                </div>
+            </div>
+            <div id="grid-content" class="grid-content">
+                <div id="grid-container" class="grid-container"></div>
+                 <div id="grid-empty-state" class="empty-state hidden" style="color: #6b7280; position: relative; top: 20%; transform: none; left: 0;">
+                    <p>No results found for your search.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <!-- Unified Action Modal -->
+    <div id="action-modal" class="modal hidden">
+        <div class="modal-content action-modal">
+            <h3 id="action-title" class="title" style="font-size: 18px; color: #1f2937; margin-bottom: 16px;">Action</h3>
+            <div id="action-content"></div>
+            <div style="display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px;">
+                <button id="action-cancel" class="btn btn-secondary">Cancel</button>
+                <button id="action-confirm" class="btn btn-primary">Confirm</button>
+            </div>
+        </div>
+    </div>
+    
+    <!-- Details Modal -->
+    <div id="details-modal" class="modal hidden">
+        <div class="modal-content details-modal-content">
+            <div id="details-modal-header" class="details-header">
+                <h3 class="details-title">Image Details</h3>
+                <button id="details-close" class="close-btn">
+                    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+            
+            <div class="tab-nav">
+                <button class="tab-button active" data-tab="info">Info</button>
+                <button class="tab-button" data-tab="tags">Tags</button>
+                <button class="tab-button" data-tab="notes">Notes</button>
+                <button class="tab-button" data-tab="metadata">Metadata</button>
+            </div>
+            
+            <div class="details-content">
+                <div id="tab-info" class="tab-content active">
+                    <div style="margin-bottom: 20px;">
+                        <div style="display: flex; align-items: center; margin-bottom: 12px; gap: 12px;">
+                            <span style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Filename:</span>
+                            <a id="detail-filename-link" style="font-size: 14px; color: #3b82f6; flex: 1; word-break: break-word; text-decoration: none;" href="#" target="_blank">
+                                <span id="detail-filename"></span>
+                            </a>
+                        </div>
+                        <div style="display: flex; align-items: center; margin-bottom: 12px; gap: 12px;">
+                            <span style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Date:</span>
+                            <span id="detail-date" style="font-size: 14px; color: #374151; flex: 1; word-break: break-word;"></span>
+                        </div>
+                        <div style="display: flex; align-items: center; margin-bottom: 12px; gap: 12px;">
+                            <span style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Size:</span>
+                            <span id="detail-size" style="font-size: 14px; color: #374151; flex: 1; word-break: break-word;"></span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div id="tab-tags" class="tab-content">
+                    <div style="margin-bottom: 20px;">
+                        <div class="tags-container" id="detail-tags"></div>
+                    </div>
+                </div>
+                
+                <div id="tab-notes" class="tab-content">
+                    <div style="margin-bottom: 24px;">
+                        <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
+                        <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
+                    </div>
+                    
+                    <div style="margin-bottom: 20px;">
+                        <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
+                        <div class="star-rating" id="quality-rating">
+                            <svg class="star" data-rating="1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                            <svg class="star" data-rating="2" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                            <svg class="star" data-rating="3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                            <svg class="star" data-rating="4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                            <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        </div>
+                    </div>
+                    
+                    <div style="margin-bottom: 20px;">
+                        <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
+                        <div class="star-rating" id="content-rating">
+                            <svg class="star" data-rating="1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                            <svg class="star" data-rating="2" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                            <svg class="star" data-rating="3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                            <svg class="star" data-rating="4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                            <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        </div>
+                    </div>
+                </div>
+                
+                <div id="tab-metadata" class="tab-content">
+                    <table class="metadata-table" id="metadata-table"></table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // ===== ORBITAL8 Goji Version - App Root =====
+        
+        const STACKS = ['in', 'out', 'priority', 'trash'];
+        const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
+        const state = {
+            provider: null, providerType: null, dbManager: null, metadataExtractor: null,
+            syncManager: null, visualCues: null, haptic: null, export: null, currentFolder: { id: null, name: '' },
+            imageFiles: [], currentImageLoadId: null, currentStack: 'in', currentStackPosition: 0,
+            isFocusMode: false, stacks: { in: [], out: [], priority: [], trash: [] },
+            isDragging: false, isPinching: false, initialDistance: 0, currentScale: 1,
+            maxScale: 4, minScale: 0.3, panOffset: { x: 0, y: 0 },
+            grid: { stack: null, selected: [], filtered: [], isDirty: false,
+                lazyLoadState: { allFiles: [], renderedCount: 0, observer: null, batchSize: 20 } },
+            tags: new Set(), loadingProgress: { current: 0, total: 0 },
+            folderMoveMode: { active: false, files: [] },
+            activeRequests: new AbortController(),
+            sessionVisitedFolders: new Set()
+        };
+        const Utils = {
+            elements: {},
+            
+            init() {
+                this.elements = {
+                    providerScreen: document.getElementById('provider-screen'),
+                    authScreen: document.getElementById('auth-screen'),
+                    folderScreen: document.getElementById('folder-screen'),
+                    loadingScreen: document.getElementById('loading-screen'),
+                    appContainer: document.getElementById('app-container'),
+                    
+                    googleDriveBtn: document.getElementById('google-drive-btn'),
+                    onedriveBtn: document.getElementById('onedrive-btn'),
+                    providerStatus: document.getElementById('provider-status'),
+                    
+                    authTitle: document.getElementById('auth-title'),
+                    authSubtitle: document.getElementById('auth-subtitle'),
+                    gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
+                    gdriveClientSecret: document.getElementById('gdrive-client-secret'),
+                    authButton: document.getElementById('auth-button'),
+                    authBackButton: document.getElementById('auth-back-button'),
+                    authStatus: document.getElementById('auth-status'),
+
+                    folderTitle: document.getElementById('folder-title'),
+                    folderSubtitle: document.getElementById('folder-subtitle'),
+                    folderList: document.getElementById('folder-list'),
+                    folderRefreshButton: document.getElementById('folder-refresh-button'),
+                    folderBackButton: document.getElementById('folder-back-button'),
+                    folderLogoutButton: document.getElementById('folder-logout-button'),
+                    
+                    backButton: document.getElementById('back-button'),
+                    backButtonSpinner: document.getElementById('back-button-spinner'),
+                    detailsButton: document.getElementById('details-button'),
+                    imageViewport: document.getElementById('image-viewport'),
+                    centerImage: document.getElementById('center-image'),
+                    emptyState: document.getElementById('empty-state'),
+                    selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
+                    selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
+                    toast: document.getElementById('toast'),
+                    
+                    centerTrashBtn: document.getElementById('center-trash-btn'),
+                    focusStackName: document.getElementById('focus-stack-name'),
+                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    focusImageCount: document.getElementById('focus-image-count'),
+                    normalImageCount: document.getElementById('normal-image-count'),
+                    focusDeleteBtn: document.getElementById('focus-delete-btn'),
+                    focusFavoriteBtn: document.getElementById('focus-favorite-btn'),
+                    focusFavoriteIcon: document.getElementById('focus-favorite-icon'),
+
+                    loadingCounter: document.getElementById('loading-counter'),
+                    loadingMessage: document.getElementById('loading-message'),
+                    loadingProgressBar: document.getElementById('loading-progress-bar'),
+                    cancelLoading: document.getElementById('cancel-loading'),
+                    
+                    edgeTop: document.getElementById('edge-top'),
+                    edgeBottom: document.getElementById('edge-bottom'),
+                    edgeLeft: document.getElementById('edge-left'),
+                    edgeRight: document.getElementById('edge-right'),
+
+                    gestureLayer: document.getElementById('gesture-layer'),
+                    gestureScreenA: document.getElementById('gesture-screen-a'),
+                    gestureScreenB: document.getElementById('gesture-screen-b'),
+                    gestureTriUp: document.getElementById('gesture-tri-up'),
+                    gestureTriRight: document.getElementById('gesture-tri-right'),
+                    gestureTriDown: document.getElementById('gesture-tri-down'),
+                    gestureTriLeft: document.getElementById('gesture-tri-left'),
+                    gestureHalfLeft: document.getElementById('gesture-half-left'),
+                    gestureHalfRight: document.getElementById('gesture-half-right'),
+                    
+                    pillPriority: document.getElementById('pill-priority'),
+                    pillTrash: document.getElementById('pill-trash'),
+                    pillIn: document.getElementById('pill-in'),
+                    pillOut: document.getElementById('pill-out'),
+                    
+                    gridModal: document.getElementById('grid-modal'),
+                    gridContent: document.getElementById('grid-content'),
+                    gridTitle: document.getElementById('grid-title'),
+                    gridContainer: document.getElementById('grid-container'),
+                    gridEmptyState: document.getElementById('grid-empty-state'),
+                    selectAllBtn: document.getElementById('select-all-btn'),
+                    deselectAllBtn: document.getElementById('deselect-all-btn'),
+                    selectionText: document.getElementById('selection-text'),
+                    closeGrid: document.getElementById('close-grid'),
+                    gridSize: document.getElementById('grid-size'),
+                    gridSizeValue: document.getElementById('grid-size-value'),
+                    
+                    omniSearch: document.getElementById('omni-search'),
+                    clearSearchBtn: document.getElementById('clear-search-btn'),
+                    
+                    tagSelected: document.getElementById('tag-selected'),
+                    moveSelected: document.getElementById('move-selected'),
+                    deleteSelected: document.getElementById('delete-selected'),
+                    exportSelected: document.getElementById('export-selected'),
+                    folderSelected: document.getElementById('folder-selected'),
+                    
+                    actionModal: document.getElementById('action-modal'),
+                    actionTitle: document.getElementById('action-title'),
+                    actionContent: document.getElementById('action-content'),
+                    actionCancel: document.getElementById('action-cancel'),
+                    actionConfirm: document.getElementById('action-confirm'),
+                    
+                    detailsModal: document.getElementById('details-modal'),
+                    detailsModalHeader: document.getElementById('details-modal-header'),
+                    gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
+                    detailsClose: document.getElementById('details-close'),
+                    detailFilename: document.getElementById('detail-filename'),
+                    detailFilenameLink: document.getElementById('detail-filename-link'),
+                    detailDate: document.getElementById('detail-date'),
+                    detailSize: document.getElementById('detail-size'),
+                    detailTags: document.getElementById('detail-tags'),
+                    detailNotes: document.getElementById('detail-notes'),
+                    qualityRating: document.getElementById('quality-rating'),
+                    contentRating: document.getElementById('content-rating'),
+                    metadataTable: document.getElementById('metadata-table')
+                };
+            },
+            
+            showScreen(screenId) {
+                const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
+                screens.forEach(id => {
+                    const screen = document.getElementById(id);
+                    if (screen) {
+                        screen.classList.toggle('hidden', id !== screenId);
+                    }
+                });
+            },
+            
+            showModal(id) { document.getElementById(id).classList.remove('hidden'); },
+            hideModal(id) { document.getElementById(id).classList.add('hidden'); },
+            
+            showToast(message, type = 'success', important = false) {
+                if (!important && Math.random() < 0.7) return;
+                const toast = this.elements.toast;
+                toast.textContent = message;
+                toast.className = `toast ${type} show`;
+                setTimeout(() => toast.classList.remove('show'), 3000);
+                if (important && state.haptic) {
+                    const hapticType = type === 'error' ? 'error' : 'buttonPress';
+                    state.haptic.triggerFeedback(hapticType);
+                }
+            },
+            
+            async setImageSrc(img, file) {
+                return this.setImageSrcAuthenticated(img, file);
+            },
+
+            async setImageSrcAuthenticated(img, file) {
+                const loadId = `${file.id}_${Date.now()}`;
+                const placeholder = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='150' height='150' viewBox='0 0 150 150' fill='none'%3E%3Crect width='150' height='150' fill='%23E5E7EB'/%3E%3Cpath d='M65 60H85V90H65V60Z' fill='%239CA3AF'/%3E%3Ccircle cx='75' cy='45' r='10' fill='%239CA3AF'/%3E%3C/svg%3E";
+                state.currentImageLoadId = loadId;
+                try {
+                    const blobUrl = await this.getAuthenticatedImageBlob(file);
+                    return new Promise((resolve) => {
+                        img.onload = () => {
+                            if (state.currentImageLoadId !== loadId) return;
+                            resolve();
+                        };
+                        img.onerror = () => {
+                            if (state.currentImageLoadId !== loadId) return;
+                            img.src = placeholder;
+                            resolve();
+                        };
+                        img.alt = file.name || 'Image';
+                        img.src = blobUrl;
+                    });
+                } catch (error) {
+                    if (state.currentImageLoadId !== loadId) { return Promise.resolve(); }
+                    img.alt = file.name || 'Image';
+                    img.src = placeholder;
+                    return Promise.resolve();
+                }
+            },
+
+            async getAuthenticatedImageBlob(file) {
+                if (!file || !file.id) { throw new Error('Invalid file reference'); }
+                let response;
+
+                if (state.providerType === 'googledrive') {
+                    response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, {}, false);
+                } else if (state.providerType === 'onedrive') {
+                    const accessToken = await state.provider.getAccessToken();
+                    response = await fetch(`https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`, {
+                        headers: { 'Authorization': `Bearer ${accessToken}` }
+                    });
+                } else {
+                    throw new Error('Unsupported provider type');
+                }
+
+                if (!response || !response.ok) {
+                    const status = response ? response.status : 'unknown';
+                    throw new Error(`Failed to load image: ${status}`);
+                }
+
+                const blob = await response.blob();
+                return URL.createObjectURL(blob);
+            },
+            
+            getPreferredImageUrl(file) {
+                if (state.providerType === 'googledrive') {
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s1000');
+                    }
+                    return this.getPersistentDownloadUrl(file);
+                } else { // OneDrive
+                    if (file.thumbnails && file.thumbnails.large) {
+                        return file.thumbnails.large.url;
+                    }
+                    return this.getPersistentDownloadUrl(file);
+                }
+            },
+
+            getFallbackImageUrl(file) {
+                return this.getPersistentDownloadUrl(file);
+            },
+
+            getPersistentDownloadUrl(file) {
+                if (!file || !file.id) { return file?.downloadUrl || ''; }
+                const existingUrl = file.downloadUrl || '';
+                if (state.provider && typeof state.provider.buildDownloadUrl === 'function') {
+                    const built = state.provider.buildDownloadUrl(file);
+                    if (built) { return built; }
+                }
+                if (existingUrl) { return existingUrl; }
+                if (state.providerType === 'googledrive') {
+                    return `https://drive.google.com/uc?export=view&id=${file.id}`;
+                } else if (state.providerType === 'onedrive') {
+                    return `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
+                }
+                return '';
+            },
+            
+            formatFileSize(bytes) {
+                if (bytes === 0) return '0 Bytes';
+                const k = 1024;
+                const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+                const i = Math.floor(Math.log(bytes) / Math.log(k));
+                return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+            },
+            
+            updateLoadingProgress(current, total, message = '') {
+                state.loadingProgress = { current, total };
+                this.elements.loadingCounter.textContent = current;
+                this.elements.loadingMessage.textContent = message || (total ? 
+                    `Processing ${current} of ${total} items...` : 
+                    `Found ${current} items`);
+                if (total > 0) {
+                    const percentage = (current / total) * 100;
+                    this.elements.loadingProgressBar.style.width = `${percentage}%`;
+                }
+            }
+        };
+
+        class DBManager {
+            constructor() { this.db = null; }
+            async init() {
+                return new Promise((resolve, reject) => {
+                    const request = indexedDB.open('Orbital8-Goji-V1', 1);
+                    request.onupgradeneeded = (event) => {
+                        const db = event.target.result;
+                        if (!db.objectStoreNames.contains('folderCache')) {
+                            db.createObjectStore('folderCache', { keyPath: 'folderId' });
+                        }
+                        if (!db.objectStoreNames.contains('metadata')) {
+                            db.createObjectStore('metadata', { keyPath: 'id' });
+                        }
+                        if (!db.objectStoreNames.contains('syncQueue')) {
+                            db.createObjectStore('syncQueue', { keyPath: 'id', autoIncrement: true });
+                        }
+                    };
+                    request.onsuccess = (event) => { this.db = event.target.result; resolve(); };
+                    request.onerror = (event) => reject(event.target.error);
+                });
+            }
+            async getFolderCache(folderId) {
+                if (!this.db) return null;
+                return new Promise((resolve, reject) => {
+                    const transaction = this.db.transaction('folderCache', 'readonly');
+                    const store = transaction.objectStore('folderCache');
+                    const request = store.get(folderId);
+                    request.onsuccess = () => resolve(request.result ? request.result.files : null);
+                    request.onerror = () => reject(request.error);
+                });
+            }
+            async saveFolderCache(folderId, files) {
+                if (!this.db) return;
+                return new Promise((resolve, reject) => {
+                    const transaction = this.db.transaction('folderCache', 'readwrite');
+                    const store = transaction.objectStore('folderCache');
+                    const request = store.put({ folderId, files, timestamp: Date.now() });
+                    request.onsuccess = () => resolve();
+                    request.onerror = () => reject(request.error);
+                });
+            }
+            async getMetadata(fileId) {
+                if (!this.db) return null;
+                return new Promise((resolve, reject) => {
+                    const transaction = this.db.transaction('metadata', 'readonly');
+                    const store = transaction.objectStore('metadata');
+                    const request = store.get(fileId);
+                    request.onsuccess = () => resolve(request.result ? request.result.metadata : null);
+                    request.onerror = () => reject(request.error);
+                });
+            }
+            async saveMetadata(fileId, metadata) {
+                if (!this.db) return;
+                return new Promise((resolve, reject) => {
+                    const transaction = this.db.transaction('metadata', 'readwrite');
+                    const store = transaction.objectStore('metadata');
+                    const request = store.put({ id: fileId, metadata });
+                    request.onsuccess = () => resolve();
+                    request.onerror = () => reject(request.error);
+                });
+            }
+            async deleteMetadata(fileId) {
+                if (!this.db) return;
+                return new Promise((resolve, reject) => {
+                    const transaction = this.db.transaction('metadata', 'readwrite');
+                    const store = transaction.objectStore('metadata');
+                    const request = store.delete(fileId);
+                    request.onsuccess = () => resolve();
+                    request.onerror = () => reject(request.error);
+                });
+            }
+            async addToSyncQueue(operation) { return Promise.resolve(); }
+            async readSyncQueue() { return Promise.resolve([]); }
+            async deleteFromSyncQueue(id) { return Promise.resolve(); }
+        }
+        class SyncManager {
+            constructor() { this.worker = null; this.syncInterval = null; }
+            start() { /* Placeholder */ }
+            stop() { /* Placeholder */ }
+            requestSync() { /* Placeholder */ }
+        }
+        class VisualCueManager {
+            constructor() {
+                this.currentIntensity = localStorage.getItem('orbital8_visual_intensity') || 'medium';
+                this.applyIntensity(this.currentIntensity);
+            }
+            setIntensity(level) {
+                this.currentIntensity = level;
+                this.applyIntensity(level);
+                localStorage.setItem('orbital8_visual_intensity', level);
+                document.querySelectorAll('.intensity-btn').forEach(btn => {
+                    btn.classList.toggle('active', btn.dataset.level === level);
+                });
+            }
+            applyIntensity(level) {
+                const settings = {
+                    low: { glow: 0.3, ripple: 1000, extraEffects: false },
+                    medium: { glow: 0.6, ripple: 1500, extraEffects: false },
+                    high: { glow: 1.0, ripple: 2000, extraEffects: true }
+                };
+                const config = settings[level];
+                document.documentElement.style.setProperty('--glow', config.glow);
+                document.documentElement.style.setProperty('--ripple', `${config.ripple}ms`);
+                if (config.extraEffects) { document.body.classList.add('high-intensity-mode');
+                } else { document.body.classList.remove('high-intensity-mode'); }
+            }
+        }
+        class HapticFeedbackManager {
+            constructor() {
+                this.isEnabled = localStorage.getItem('orbital8_haptic_enabled') !== 'false';
+                this.isSupported = 'vibrate' in navigator;
+                const checkbox = document.getElementById('haptic-enabled');
+                if (checkbox) checkbox.checked = this.isEnabled;
+            }
+            setEnabled(enabled) {
+                this.isEnabled = enabled;
+                localStorage.setItem('orbital8_haptic_enabled', enabled);
+            }
+            triggerFeedback(type) {
+                if (!this.isEnabled || !this.isSupported) return;
+                const patterns = { swipe: [20, 40], pillTap: [35], buttonPress: [25], error: [100, 50, 100] };
+                const pattern = patterns[type];
+                if (pattern && navigator.vibrate) { navigator.vibrate(pattern); }
+            }
+        }
+        class MetadataExtractor {
+            constructor() { this.abortController = null; }
+            abort() {
+                if (this.abortController) {
+                    this.abortController.abort();
+                    this.abortController = null;
+                }
+            }
+            async extract(buffer) {
+                if (!buffer) return {};
+                const metadata = {};
+                const view = new DataView(buffer);
+                if (buffer.byteLength < 8) return {};
+                let pos = 8;
+                try {
+                    while (pos < buffer.byteLength - 12) {
+                        const chunkLength = view.getUint32(pos, false);
+                        pos += 4;
+                        let chunkType = '';
+                        for (let i = 0; i < 4; i++) { chunkType += String.fromCharCode(view.getUint8(pos + i)); }
+                        pos += 4;
+                        if (chunkType === 'tEXt') {
+                            let keyword = '';
+                            let value = '';
+                            let nullFound = false;
+                            for (let i = 0; i < chunkLength; i++) {
+                                const byte = view.getUint8(pos + i);
+                                if (!nullFound) {
+                                    if (byte === 0) { nullFound = true; } else { keyword += String.fromCharCode(byte); }
+                                } else { value += String.fromCharCode(byte); }
+                            }
+                            metadata[keyword] = value;
+                        } else if (chunkType === 'IHDR') {
+                            const width = view.getUint32(pos, false);
+                            const height = view.getUint32(pos + 4, false);
+                            metadata._dimensions = { width, height };
+                        } else if (chunkType === 'IEND') { break; }
+                        pos += chunkLength + 4;
+                        if (chunkLength > buffer.byteLength || pos > buffer.byteLength) { break; }
+                    }
+                } catch (error) { /* Return what we have so far */ }
+                return metadata;
+            }
+            async fetchMetadata(file, isForExport = false) {
+                if (file.mimeType !== 'image/png') {
+                    if (!isForExport) file.metadataStatus = 'loaded';
+                    return { error: 'Not a PNG file' };
+                }
+                try {
+                    this.abortController = new AbortController();
+                    let response;
+                    const requestOptions = {};
+                    if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
+                    
+                    if (state.providerType === 'googledrive') {
+                        response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
+                    } else {
+                        const accessToken = await state.provider.getAccessToken();
+                        response = await fetch(`https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`, { headers: { 'Authorization': `Bearer ${accessToken}`, 'Range': 'bytes=0-65535' }, ...requestOptions });
+                    }
+                    if (!response.ok) { throw new Error(`HTTP ${response.status} ${response.statusText}`); }
+                    const buffer = await response.arrayBuffer();
+                    return await this.extract(buffer);
+                } catch (error) {
+                    if (error.name === 'AbortError') { return { error: 'Operation cancelled' }; }
+                    return { error: error.message };
+                }
+            }
+        }
+        class BaseProvider {
+            constructor() {
+                if (this.constructor === BaseProvider) {
+                    throw new Error("Abstract classes can't be instantiated.");
+                }
+            }
+            // Authentication
+            async authenticate() { throw new Error("Method 'authenticate()' must be implemented."); }
+            async disconnect() { throw new Error("Method 'disconnect()' must be implemented."); }
+
+            // Folder & File Reading
+            async getFolders() { throw new Error("Method 'getFolders()' must be implemented."); }
+            async getFilesAndMetadata(folderId) { throw new Error("Method 'getFilesAndMetadata(folderId)' must be implemented."); }
+            async drillIntoFolder(folder) { throw new Error("Method 'drillIntoFolder(folder)' must be implemented."); }
+            async navigateToParent() { throw new Error("Method 'navigateToParent()' must be implemented."); }
+
+            // File Writing/Manipulation
+            async updateFileMetadata(fileId, metadata) { throw new Error("Method 'updateFileMetadata(fileId, metadata)' must be implemented."); }
+            async moveFileToFolder(fileId, targetFolderId) { throw new Error("Method 'moveFileToFolder(fileId, targetFolderId)' must be implemented."); }
+            async deleteFile(fileId) { throw new Error("Method 'deleteFile(fileId)' must be implemented."); }
+            buildDownloadUrl() { return ''; }
+        }
+        class GoogleDriveProvider extends BaseProvider {
+            constructor() {
+                super();
+                this.name = 'googledrive';
+                this.clientId = '567988062464-fa6c1ovesqeudqs5398vv4mbo6q068p9.apps.googleusercontent.com';
+                this.redirectUri = window.location.origin + window.location.pathname;
+                this.scope = 'https://www.googleapis.com/auth/drive';
+                this.apiBase = 'https://www.googleapis.com/drive/v3';
+                this.accessToken = null; this.refreshToken = null; this.clientSecret = null;
+                this.isAuthenticated = false; this.onProgressCallback = null;
+                this.loadStoredCredentials();
+            }
+            loadStoredCredentials() {
+                this.accessToken = localStorage.getItem('google_access_token');
+                this.refreshToken = localStorage.getItem('google_refresh_token');
+                this.clientSecret = localStorage.getItem('google_client_secret');
+                this.isAuthenticated = !!(this.accessToken && this.refreshToken && this.clientSecret);
+            }
+            storeCredentials() {
+                if (this.accessToken) localStorage.setItem('google_access_token', this.accessToken);
+                if (this.refreshToken) localStorage.setItem('google_refresh_token', this.refreshToken);
+                if (this.clientSecret) localStorage.setItem('google_client_secret', this.clientSecret);
+            }
+            clearStoredCredentials() {
+                localStorage.removeItem('google_access_token');
+                localStorage.removeItem('google_refresh_token');
+                localStorage.removeItem('google_client_secret');
+            }
+            async authenticate(clientSecret) {
+                if (clientSecret) { this.clientSecret = clientSecret; this.storeCredentials(); }
+                if (!this.clientSecret) { throw new Error('Client secret is required for Google Drive authentication'); }
+                if (this.accessToken && this.refreshToken) {
+                    try { await this.makeApiCall('/files?pageSize=1'); this.isAuthenticated = true; return true; } catch (error) { /* continue */ }
+                }
+                return new Promise((resolve, reject) => {
+                    const authUrl = this.buildAuthUrl();
+                    const popup = window.open(authUrl, 'google-auth', 'width=500,height=600,scrollbars=yes,resizable=yes');
+                    if (!popup) { reject(new Error('Popup blocked by browser')); return; }
+                    const checkClosed = setInterval(() => { if (popup.closed) { clearInterval(checkClosed); reject(new Error('Authentication cancelled')); } }, 1000);
+                    const messageHandler = async (event) => {
+                        if (event.origin !== window.location.origin) return;
+                        if (event.data.type === 'GOOGLE_AUTH_SUCCESS') {
+                            clearInterval(checkClosed); window.removeEventListener('message', messageHandler); popup.close();
+                            try { await this.exchangeCodeForTokens(event.data.code); this.isAuthenticated = true; resolve(true); } catch (error) { reject(error); }
+                        } else if (event.data.type === 'GOOGLE_AUTH_ERROR') {
+                            clearInterval(checkClosed); window.removeEventListener('message', messageHandler); popup.close(); reject(new Error(event.data.error));
+                        }
+                    };
+                    window.addEventListener('message', messageHandler);
+                });
+            }
+            buildAuthUrl() {
+                const params = new URLSearchParams({ client_id: this.clientId, redirect_uri: this.redirectUri, response_type: 'code', scope: this.scope, access_type: 'offline', prompt: 'consent' });
+                return `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+            }
+            async exchangeCodeForTokens(code) {
+                const response = await fetch('https://oauth2.googleapis.com/token', {
+                    method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: new URLSearchParams({ client_id: this.clientId, client_secret: this.clientSecret, code: code, grant_type: 'authorization_code', redirect_uri: this.redirectUri })
+                });
+                if (!response.ok) { throw new Error('Token exchange failed'); }
+                const tokens = await response.json();
+                this.accessToken = tokens.access_token; this.refreshToken = tokens.refresh_token;
+                this.storeCredentials();
+            }
+            async refreshAccessToken() {
+                if (!this.refreshToken || !this.clientSecret) { throw new Error('No refresh token or client secret available'); }
+                const response = await fetch('https://oauth2.googleapis.com/token', {
+                    method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: new URLSearchParams({ client_id: this.clientId, client_secret: this.clientSecret, refresh_token: this.refreshToken, grant_type: 'refresh_token' })
+                });
+                if (!response.ok) { throw new Error('Failed to refresh access token'); }
+                const tokens = await response.json(); this.accessToken = tokens.access_token; this.storeCredentials(); return this.accessToken;
+            }
+            async makeApiCall(endpoint, options = {}, isJson = true) {
+                if (!this.accessToken) { throw new Error('Not authenticated'); }
+                const url = endpoint.startsWith('https://') ? endpoint : `${this.apiBase}${endpoint}`;
+                const headers = { 'Authorization': `Bearer ${this.accessToken}`, ...options.headers };
+                if(isJson) { headers['Content-Type'] = 'application/json'; }
+                let response = await fetch(url, { ...options, headers });
+                if (response.status === 401 && this.refreshToken && this.clientSecret) {
+                    try {
+                        await this.refreshAccessToken();
+                        headers['Authorization'] = `Bearer ${this.accessToken}`;
+                        response = await fetch(url, { ...options, headers });
+                    } catch (refreshError) { this.isAuthenticated = false; this.clearStoredCredentials(); throw new Error('Authentication expired. Please reconnect.'); }
+                }
+                if (!response.ok) { const errorText = await response.text(); throw new Error(`API call failed: ${response.status} ${response.statusText} - ${errorText}`); }
+                if (isJson) { return await response.json(); }
+                return response;
+            }
+            async getFolders() {
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
+                return response.files.map(folder => ({
+                    id: folder.id,
+                    name: folder.name,
+                    type: 'folder',
+                    createdTime: folder.createdTime,
+                    modifiedTime: folder.modifiedTime,
+                    itemCount: 0, // Google Drive API doesn't provide this in the list call
+                    hasChildren: false // Assume false to not show a non-functional 'Browse' button
+                }));
+            }
+            async getFilesAndMetadata(folderId = 'root') {
+                const allFiles = []; let nextPageToken = null;
+                do {
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
+                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
+                    const files = response.files.filter(file => file.mimeType && file.mimeType.startsWith('image/')).map(file => ({ id: file.id, name: file.name, type: 'file', mimeType: file.mimeType, size: file.size ? parseInt(file.size) : 0, createdTime: file.createdTime, modifiedTime: file.modifiedTime, thumbnailLink: file.thumbnailLink, downloadUrl: this.buildDownloadUrl(file), appProperties: file.appProperties || {}, parents: file.parents }));
+                    allFiles.push(...files);
+                    nextPageToken = response.nextPageToken;
+                    if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
+                } while (nextPageToken);
+                return { folders: [], files: allFiles };
+            }
+            async drillIntoFolder(folder) {
+                // Not applicable for Google Drive's flat folder structure, but fulfills the interface.
+                return Promise.resolve([]);
+            }
+            async navigateToParent() {
+                // Not applicable for Google Drive's flat folder structure, returns the root list.
+                return this.getFolders();
+            }
+            async moveFileToFolder(fileId, targetFolderId) {
+                const file = await this.makeApiCall(`/files/${fileId}?fields=parents`);
+                const previousParents = file.parents.join(',');
+                await this.makeApiCall(`/files/${fileId}?addParents=${targetFolderId}&removeParents=${previousParents}&fields=id,parents`, { method: 'PATCH' });
+                return true;
+            }
+            async updateFileMetadata(fileId, metadata) {
+                await this.makeApiCall(`/files/${fileId}`, { method: 'PATCH', body: JSON.stringify({ appProperties: metadata }) });
+                return true;
+            }
+            async updateUserMetadata(fileId, updates) {
+                const file = state.imageFiles.find(f => f.id === fileId);
+                if (!file) return;
+                Object.assign(file, updates);
+                await state.dbManager.saveMetadata(file.id, file);
+                await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
+            }
+
+            async deleteFile(fileId) {
+                await this.makeApiCall(`/files/${fileId}`, { method: 'PATCH', body: JSON.stringify({ trashed: true }) });
+                return true;
+            }
+            async disconnect() {
+                this.isAuthenticated = false; this.accessToken = null; this.refreshToken = null; this.clientSecret = null;
+                this.clearStoredCredentials();
+            }
+            buildDownloadUrl(file) {
+                const fileId = typeof file === 'string' ? file : (file && file.id ? file.id : '');
+                if (!fileId) { return ''; }
+                return `https://drive.google.com/uc?export=view&id=${fileId}`;
+            }
+        }
+        class OneDriveProvider extends BaseProvider {
+            constructor() {
+                super();
+                this.name = 'onedrive';
+                this.apiBase = 'https://graph.microsoft.com/v1.0';
+                this.isAuthenticated = false;
+                this.activeAccount = null;
+                this.msalInstance = null;
+                this.currentParentId = null;
+                this.currentParentPath = '';
+                this.breadcrumb = [];
+                this.onProgressCallback = null;
+                this.initMSAL();
+
+                const accounts = this.msalInstance.getAllAccounts();
+                if (accounts.length > 0) {
+                    this.msalInstance.setActiveAccount(accounts[0]);
+                    this.activeAccount = accounts[0];
+                    this.isAuthenticated = true;
+                }
+            }
+            initMSAL() {
+                const msalConfig = {
+                    auth: { clientId: 'b407fd45-c551-4dbb-9da5-cab3a2c5a949', authority: 'https://login.microsoftonline.com/common', redirectUri: window.location.origin + window.location.pathname },
+                    cache: { cacheLocation: 'localStorage' }
+                };
+                this.msalInstance = new msal.PublicClientApplication(msalConfig);
+            }
+            async authenticate() {
+                try {
+                    const accounts = this.msalInstance.getAllAccounts();
+                    if (accounts.length > 0) { this.msalInstance.setActiveAccount(accounts[0]); this.activeAccount = accounts[0]; }
+                    else { const loginResponse = await this.msalInstance.loginPopup({ scopes: ['Files.ReadWrite.AppFolder', 'User.Read'] });
+                        this.activeAccount = loginResponse.account; this.msalInstance.setActiveAccount(this.activeAccount);
+                    }
+                    this.isAuthenticated = true; return true;
+                } catch (error) { this.isAuthenticated = false; throw new Error(`Authentication failed: ${error.message}`); }
+            }
+            async getAccessToken() {
+                if (!this.activeAccount) { throw new Error('No active account'); }
+                try {
+                    const response = await this.msalInstance.acquireTokenSilent({ scopes: ['Files.ReadWrite.AppFolder'], account: this.activeAccount });
+                    return response.accessToken;
+                } catch (silentError) {
+                    if (silentError instanceof msal.InteractionRequiredAuthError) {
+                        const response = await this.msalInstance.acquireTokenPopup({ scopes: ['Files.ReadWrite.AppFolder'], account: this.activeAccount });
+                        return response.accessToken;
+                    } throw silentError;
+                }
+            }
+            async makeApiCall(endpoint, options = {}) {
+                const accessToken = await this.getAccessToken();
+                const url = endpoint.startsWith('https://') ? endpoint : `${this.apiBase}${endpoint}`;
+                const headers = { 'Authorization': `Bearer ${accessToken}`, 'Content-Type': 'application/json', ...options.headers };
+                const response = await fetch(url, { ...options, headers });
+                if (response.status === 401) { throw new Error('TOKEN_EXPIRED'); }
+                if (!response.ok) { const errorText = await response.text(); throw new Error(`API call failed: ${response.status} ${response.statusText} - ${errorText}`); }
+                return response;
+            }
+            async getFilesAndMetadata(folderId = 'root') {
+                const allFiles = [];
+                let endpoint = folderId === 'root' ? '/me/drive/root/children' : `/me/drive/items/${folderId}/children`;
+                let nextLink = `${this.apiBase}${endpoint}`;
+                while(nextLink) {
+                    const response = await this.makeApiCall(nextLink.replace(this.apiBase, ''), { signal: state.activeRequests.signal });
+                    const data = await response.json();
+                    const files = data.value.filter(item => item.file && item.file.mimeType && item.file.mimeType.startsWith('image/'))
+                        .map(item => ({
+                            id: item.id, name: item.name, type: 'file', mimeType: item.file.mimeType, size: item.size || 0,
+                            createdTime: item.createdDateTime, modifiedTime: item.lastModifiedDateTime,
+                            thumbnails: item.thumbnails && item.thumbnails.length > 0 ? { large: item.thumbnails[0].large } : null,
+                            downloadUrl: this.buildDownloadUrl(item)
+                        }));
+                    allFiles.push(...files);
+                    nextLink = data['@odata.nextLink'];
+                    if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
+                }
+                return { folders: [], files: allFiles };
+            }
+            async getDownloadsFolder() {
+                const response = await this.makeApiCall('/me/drive/root/children');
+                const data = await response.json();
+                const downloadsFolder = data.value.find(item => item.folder && (item.name.toLowerCase() === 'downloads' || item.name.toLowerCase() === 'download'));
+                if (downloadsFolder) { return downloadsFolder; }
+                return { id: 'root', name: 'Root', folder: true };
+            }
+            async getFolders() {
+                const downloadsFolder = await this.getDownloadsFolder();
+                this.currentParentId = downloadsFolder.id; this.currentParentPath = downloadsFolder.name;
+                this.breadcrumb = [{ id: downloadsFolder.id, name: downloadsFolder.name }];
+                return await this.loadFoldersInParent(downloadsFolder.id);
+            }
+            async loadFoldersInParent(parentId) {
+                const folders = [];
+                let endpoint = parentId === 'root' ? '/me/drive/root/children' : `/me/drive/items/${parentId}/children`;
+                let nextLink = `${this.apiBase}${endpoint}`;
+                do {
+                    const response = await this.makeApiCall(nextLink.replace(this.apiBase, ''));
+                    const data = await response.json();
+                    const folderItems = data.value.filter(item => item.folder).map(folder => ({ id: folder.id, name: folder.name, type: 'folder', createdTime: folder.createdDateTime, modifiedTime: folder.lastModifiedDateTime, itemCount: folder.folder.childCount || 0, hasChildren: (folder.folder.childCount || 0) > 0 }));
+                    folders.push(...folderItems);
+                    nextLink = data['@odata.nextLink'];
+                } while (nextLink);
+                return folders.sort((a, b) => a.name.localeCompare(b.name));
+            }
+            async drillIntoFolder(folder) {
+                this.breadcrumb.push({ id: folder.id, name: folder.name });
+                this.currentParentId = folder.id;
+                this.currentParentPath = this.breadcrumb.map(b => b.name).join(' / ');
+                return await this.loadFoldersInParent(folder.id);
+            }
+            async navigateToParent() {
+                if (this.breadcrumb.length <= 1) { return await this.getFolders(); }
+                this.breadcrumb.pop();
+                const parentFolder = this.breadcrumb[this.breadcrumb.length - 1];
+                this.currentParentId = parentFolder.id;
+                this.currentParentPath = this.breadcrumb.map(b => b.name).join(' / ');
+                return await this.loadFoldersInParent(parentFolder.id);
+            }
+            getCurrentPath() { return this.currentParentPath; }
+            canGoUp() { return this.breadcrumb.length > 1; }
+            async moveFileToFolder(fileId, targetFolderId) {
+                await this.makeApiCall(`/me/drive/items/${fileId}`, { method: 'PATCH', body: JSON.stringify({ parentReference: { id: targetFolderId } }) });
+                return true;
+            }
+            async updateFileMetadata(fileId, metadata) {
+                // Placeholder for Phase 2: Sync metadata to OneDrive
+                return Promise.resolve(true);
+            }
+            async deleteFile(fileId) {
+                await this.makeApiCall(`/me/drive/items/${fileId}`, { method: 'DELETE' });
+                return true;
+            }
+            async disconnect() {
+                this.isAuthenticated = false; this.activeAccount = null;
+                if (this.msalInstance) {
+                    const accounts = this.msalInstance.getAllAccounts();
+                    if (accounts.length > 0) { await this.msalInstance.logoutPopup({ account: accounts[0] }); }
+                }
+            }
+            buildDownloadUrl(file) {
+                if (file && typeof file === 'object') {
+                    if (file['@microsoft.graph.downloadUrl']) { return file['@microsoft.graph.downloadUrl']; }
+                    if (file.downloadUrl) { return file.downloadUrl; }
+                }
+                const fileId = typeof file === 'string' ? file : (file && file.id ? file.id : '');
+                if (!fileId) { return ''; }
+                return `https://graph.microsoft.com/v1.0/me/drive/items/${fileId}/content`;
+            }
+        }
+        class ExportSystem {
+            async exportData(imagesWithMetadata) {
+                if (imagesWithMetadata.length === 0) {
+                    Utils.showToast('No images to export', 'info', true);
+                    return;
+                }
+                const csvData = this.formatForCSV(imagesWithMetadata);
+                this.downloadCSV(csvData);
+            }
+            formatForCSV(images) {
+                const headers = [ 'Filename', 'Direct Image URL', 'Prompt', 'Negative Prompt', 'Model', 'Width', 'Height', 'Steps', 'Seed', 'CFG Scale', 'Size', 'Created Date', 'Modified Date', 'Tags', 'Notes', 'Quality Rating', 'Content Rating', 'Provider', 'Metadata (JSON)' ];
+                const rows = images.map(image => {
+                    const meta = image.extractedMetadata || {}; const dims = meta._dimensions || {};
+                    return [ image.name || '', this.getDirectImageURL(image), this.extractMetadataValue(meta, ['prompt', 'Prompt', 'parameters']), this.extractMetadataValue(meta, ['negative_prompt', 'Negative Prompt']), this.extractMetadataValue(meta, ['model', 'Model']), dims.width || '', dims.height || '', this.extractMetadataValue(meta, ['steps', 'Steps']), this.extractMetadataValue(meta, ['seed', 'Seed']), this.extractMetadataValue(meta, ['cfg_scale', 'CFG Scale']), Utils.formatFileSize(image.size), image.createdTime ? new Date(image.createdTime).toISOString() : '', image.modifiedTime ? new Date(image.modifiedTime).toISOString() : '', (image.tags || []).join('; '), image.notes || '', image.qualityRating || 0, image.contentRating || 0, state.providerType || 'unknown', JSON.stringify(meta) ];
+                });
+                return [headers, ...rows];
+            }
+            extractMetadataValue(metadata, keys) {
+                for (const key of keys) {
+                    if (metadata[key]) {
+                        if (key === 'parameters') {
+                            const promptMatch = metadata[key].match(/^(.*?)(Negative prompt:|$)/);
+                            if (promptMatch && promptMatch[1]) return promptMatch[1].trim();
+                        } return metadata[key];
+                    }
+                } return '';
+            }
+            getDirectImageURL(image) {
+                if (state.providerType === 'googledrive') { return `https://drive.google.com/uc?id=${image.id}&export=view`; }
+                else if (state.providerType === 'onedrive') { return Utils.getPersistentDownloadUrl(image); }
+                return '';
+            }
+            downloadCSV(data) {
+                const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+                const stackName = state.grid.stack;
+                const date = new Date().toISOString().split('T')[0];
+                const filename = `orbital8_${folderName}_${stackName}_${date}.csv`;
+                const csvContent = data.map(row => row.map(field => `"${String(field).replace(/"/g, '""')}"`).join(',') ).join('\n');
+                const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url; a.download = filename; a.style.display = 'none';
+                document.body.appendChild(a); a.click(); document.body.removeChild(a);
+                URL.revokeObjectURL(url);
+            }
+        }
+        if (window.location.search.includes('code=') || window.location.search.includes('error=')) {
+            const urlParams = new URLSearchParams(window.location.search);
+            const code = urlParams.get('code'); const error = urlParams.get('error');
+            if (window.opener) {
+                if (error) { window.opener.postMessage({ type: 'GOOGLE_AUTH_ERROR', error: error }, window.location.origin);
+                } else if (code) { window.opener.postMessage({ type: 'GOOGLE_AUTH_SUCCESS', code: code }, window.location.origin); }
+                window.close();
+            }
+        }
+
+        const App = {
+            selectProvider(type) {
+                state.providerType = type;
+                const isGoogle = type === 'googledrive';
+                state.provider = isGoogle ? new GoogleDriveProvider() : new OneDriveProvider();
+
+                if (state.provider.isAuthenticated) {
+                    Utils.showScreen('folder-screen');
+                    Folders.load();
+                } else {
+                    Utils.elements.authTitle.textContent = isGoogle ? 'Google Drive' : 'OneDrive';
+                    Utils.elements.authSubtitle.textContent = `Connect to ${isGoogle ? 'Google Drive' : 'OneDrive'}`;
+                    Utils.elements.gdriveSecretContainer.classList.toggle('hidden', !isGoogle);
+                    Utils.elements.authButton.textContent = `Connect ${isGoogle ? 'Drive' : 'OneDrive'}`;
+                    Utils.elements.authStatus.textContent = isGoogle ? 'Enter your client secret to continue' : 'Click to sign in with your Microsoft account';
+                    Utils.elements.authStatus.className = 'status info';
+                    Utils.showScreen('auth-screen');
+                }
+            },
+            async authenticateCurrentUser() {
+                const isGoogle = state.providerType === 'googledrive';
+                const provider = state.provider;
+                const { authButton, authStatus, gdriveClientSecret } = Utils.elements;
+                authButton.disabled = true;
+                authButton.textContent = 'Connecting...';
+                authStatus.textContent = `Connecting to ${isGoogle ? 'Google Drive' : 'OneDrive'}...`;
+                authStatus.className = 'status info';
+
+                try {
+                    let success;
+                    if (isGoogle) {
+                        const clientSecret = gdriveClientSecret.value.trim();
+                        if (!clientSecret) throw new Error('Please enter client secret');
+                        success = await provider.authenticate(clientSecret);
+                    } else {
+                        success = await provider.authenticate();
+                    }
+                    if (success) {
+                        state.provider = provider;
+                        authStatus.textContent = `✅ Connected to ${isGoogle ? 'Google Drive' : 'OneDrive'}!`;
+                        authStatus.className = 'status success';
+                        if (isGoogle) gdriveClientSecret.value = '';
+                        setTimeout(() => {
+                            Utils.showScreen('folder-screen');
+                            Folders.load();
+                        }, 1000);
+                    }
+                } catch (error) {
+                    authStatus.textContent = `Authentication failed: ${error.message}`;
+                    authStatus.className = 'status error';
+                } finally {
+                    authButton.disabled = false;
+                    authButton.textContent = `Connect ${isGoogle ? 'Drive' : 'OneDrive'}`;
+                }
+            },
+            backToProviderSelection() {
+                if(state.syncManager) state.syncManager.stop();
+                state.provider = null;
+                state.providerType = null;
+                Utils.showScreen('provider-screen');
+            },
+            async initializeWithProvider(providerType, folderId, folderName, providerInstance) {
+                try {
+                    state.providerType = providerType;
+                    state.provider = providerInstance;
+                    state.currentFolder.id = folderId;
+                    state.currentFolder.name = folderName;
+                    state.activeRequests = new AbortController();
+                    
+                    await this.loadImages();
+                    this.switchToCommonUI();
+                    if(state.syncManager) state.syncManager.start();
+                } catch (error) {
+                    Utils.showToast(`Initialization failed: ${error.message}`, 'error', true);
+                    this.returnToFolderSelection();
+                }
+            },
+            async loadImages() {
+                const folderId = state.currentFolder.id;
+                const sessionKey = `${state.providerType || 'unknown'}::${folderId}`;
+                const cachedFiles = await state.dbManager.getFolderCache(folderId) || [];
+                const hasCached = cachedFiles.length > 0;
+
+                if (hasCached) {
+                    state.imageFiles = cachedFiles;
+                    Utils.showScreen('app-container');
+                    Core.initializeStacks();
+                    Core.initializeImageDisplay();
+                    const pendingPngs = cachedFiles.filter(file => file.mimeType === 'image/png' && file.metadataStatus === 'pending');
+                    if (pendingPngs.length > 0) {
+                        this.extractMetadataInBackground(pendingPngs);
+                    }
+                }
+
+                await this.syncFolderFromCloud(cachedFiles, sessionKey, {
+                    background: hasCached,
+                    preserveSelection: hasCached
+                });
+            },
+            mergeCloudWithCache(cloudFiles, cachedFiles) {
+                const cachedMap = new Map(cachedFiles.map(file => [file.id, file]));
+                const merged = [];
+                const newIds = [];
+                const updatedIds = [];
+                const removedIds = [];
+
+                for (const cloudFile of cloudFiles) {
+                    const cached = cachedMap.get(cloudFile.id);
+                    if (!cached) {
+                        merged.push({ ...cloudFile });
+                        newIds.push(cloudFile.id);
+                    } else {
+                        const cloudModified = Date.parse(cloudFile.modifiedTime || cloudFile.createdTime || 0);
+                        const cachedModified = Date.parse(cached.modifiedTime || cached.createdTime || 0);
+                        if (!isNaN(cloudModified) && cloudModified > cachedModified) {
+                            merged.push({ ...cached, ...cloudFile });
+                            updatedIds.push(cloudFile.id);
+                        } else {
+                            merged.push(cached);
+                        }
+                        cachedMap.delete(cloudFile.id);
+                    }
+                }
+
+                for (const removedId of cachedMap.keys()) {
+                    removedIds.push(removedId);
+                }
+
+                return {
+                    mergedFiles: merged,
+                    newIds,
+                    updatedIds,
+                    removedIds,
+                    hasChanges: newIds.length > 0 || updatedIds.length > 0 || removedIds.length > 0
+                };
+            },
+            async syncFolderFromCloud(cachedFiles, sessionKey, options = {}) {
+                const { background = false, preserveSelection = false, silent = false, allowRetry = true } = options;
+                const folderId = state.currentFolder.id;
+                const hadCached = cachedFiles.length > 0;
+                const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
+
+                if (!state.activeRequests || state.activeRequests.signal.aborted) {
+                    state.activeRequests = new AbortController();
+                }
+
+                const previousSelection = preserveSelection ? {
+                    stack: state.currentStack,
+                    index: state.currentStackPosition,
+                    fileId: (state.stacks[state.currentStack] || [])[state.currentStackPosition]?.id || null
+                } : null;
+
+                if (!background) {
+                    Utils.showScreen('loading-screen');
+                    Utils.updateLoadingProgress(0, hadCached ? cachedFiles.length : 0, hadCached ? 'Syncing with cloud...' : 'Fetching from cloud...');
+                }
+
+                try {
+                    const result = await state.provider.getFilesAndMetadata(folderId);
+                    const cloudFiles = result.files || [];
+                    const { mergedFiles, newIds, updatedIds, removedIds, hasChanges } = this.mergeCloudWithCache(cloudFiles, cachedFiles);
+
+                    if (mergedFiles.length === 0) {
+                        await state.dbManager.saveFolderCache(folderId, []);
+                        state.imageFiles = [];
+                        if (!background) {
+                            Utils.showToast('No images found in this folder', 'info', true);
+                            this.returnToFolderSelection();
+                        } else {
+                            Core.showEmptyState();
+                            if (!silent) {
+                                Utils.showToast('No images remain in this folder', 'info');
+                            }
+                        }
+                        return;
+                    }
+
+                    for (const updatedId of updatedIds) {
+                        const updatedFile = mergedFiles.find(file => file.id === updatedId);
+                        if (updatedFile) {
+                            await state.dbManager.saveMetadata(updatedId, updatedFile);
+                        }
+                    }
+                    if (removedIds.length > 0) {
+                        await Promise.all(removedIds.map(id => state.dbManager.deleteMetadata(id)));
+                    }
+
+                    state.imageFiles = mergedFiles;
+                    await this.processAllMetadata(state.imageFiles, !background && !hadCached);
+                    if (hasChanges || !hadCached) {
+                        await state.dbManager.saveFolderCache(folderId, state.imageFiles);
+                    }
+
+                    state.sessionVisitedFolders.add(key);
+
+                    if (!background) {
+                        this.switchToCommonUI();
+                        Core.initializeStacks();
+                        Core.initializeImageDisplay();
+                    } else {
+                        Core.initializeStacks();
+                        Core.updateStackCounts();
+
+                        if (previousSelection) {
+                            let targetStack = previousSelection.stack;
+                            if (!state.stacks[targetStack] || state.stacks[targetStack].length === 0) {
+                                const fallback = STACKS.find(stack => state.stacks[stack]?.length > 0);
+                                if (fallback) {
+                                    targetStack = fallback;
+                                }
+                            }
+                            state.currentStack = targetStack;
+                            const currentStackArray = state.stacks[targetStack] || [];
+                            if (previousSelection.fileId) {
+                                const foundIndex = currentStackArray.findIndex(f => f.id === previousSelection.fileId);
+                                state.currentStackPosition = foundIndex !== -1 ? foundIndex : 0;
+                            } else {
+                                state.currentStackPosition = Math.min(previousSelection.index || 0, Math.max(currentStackArray.length - 1, 0));
+                            }
+                        }
+
+                        if (!state.stacks[state.currentStack] || state.stacks[state.currentStack].length === 0) {
+                            const fallback = STACKS.find(stack => state.stacks[stack]?.length > 0);
+                            if (fallback) {
+                                state.currentStack = fallback;
+                                state.currentStackPosition = 0;
+                            }
+                        }
+
+                        if (state.stacks[state.currentStack] && state.stacks[state.currentStack].length > 0) {
+                            await Core.displayCurrentImage();
+                        } else {
+                            Core.showEmptyState();
+                        }
+                    }
+
+                    if ((background || hadCached) && hasChanges && !silent) {
+                        const diffSummary = [];
+                        if (newIds.length > 0) diffSummary.push(`${newIds.length} new`);
+                        if (updatedIds.length > 0) diffSummary.push(`${updatedIds.length} updated`);
+                        if (removedIds.length > 0) diffSummary.push(`${removedIds.length} removed`);
+                        const summaryText = diffSummary.length > 0 ? diffSummary.join(', ') : 'changes';
+                        Utils.showToast(`Folder updated with cloud changes (${summaryText})`, 'info');
+                    }
+                } catch (error) {
+                    if (error.name === 'AbortError') {
+                        return;
+                    }
+
+                    if (allowRetry && error.message && error.message.includes('TOKEN_EXPIRED')) {
+                        try {
+                            await state.provider.authenticate();
+                            await this.syncFolderFromCloud(cachedFiles, sessionKey, { ...options, allowRetry: false });
+                            return;
+                        } catch (authError) {
+                            if (!silent) {
+                                const message = authError && authError.message ? authError.message : 'Reauthentication required';
+                                Utils.showToast(`Authentication failed: ${message}`, 'error', true);
+                            }
+                        }
+                    } else if (!silent) {
+                        Utils.showToast(`Error loading images: ${error.message}`, 'error', true);
+                    }
+
+                    if (!background) {
+                        this.returnToFolderSelection();
+                    }
+                }
+            },
+            async refreshFolderInBackground() {
+                try {
+                    const folderId = state.currentFolder.id;
+                    if (!folderId) { return; }
+                    const cachedFiles = await state.dbManager.getFolderCache(folderId) || [];
+                    const sessionKey = `${state.providerType || 'unknown'}::${folderId}`;
+                    await this.syncFolderFromCloud(cachedFiles, sessionKey, {
+                        background: true,
+                        preserveSelection: true,
+                        silent: true
+                    });
+                } catch (error) {
+                    console.warn('Background refresh failed:', error.message);
+                }
+            },
+            async processAllMetadata(files, isFirstLoad = false) {
+                 if (isFirstLoad) Utils.updateLoadingProgress(0, files.length, 'Processing files...');
+                for (let i = 0; i < files.length; i++) {
+                    const file = files[i];
+                    try {
+                        const metadata = await state.dbManager.getMetadata(file.id);
+                        if (metadata) {
+                            Object.assign(file, metadata);
+                        } else {
+                            const defaultMetadata = this.generateDefaultMetadata(file);
+                            Object.assign(file, defaultMetadata);
+                            await state.dbManager.saveMetadata(file.id, defaultMetadata);
+                        }
+                        const persistentUrl = Utils.getPersistentDownloadUrl(file);
+                        if (persistentUrl && state.providerType === 'googledrive') { file.downloadUrl = persistentUrl; }
+                    } catch (error) {
+                        console.error(`Failed to process metadata for ${file.name}:`, error);
+                    }
+                    if(isFirstLoad) Utils.updateLoadingProgress(i + 1, files.length);
+                }
+                this.extractMetadataInBackground(files.filter(f => f.mimeType === 'image/png'));
+            },
+            generateDefaultMetadata(file) {
+                 const baseMetadata = {
+                    stack: 'in',
+                    tags: [],
+                    qualityRating: 0,
+                    contentRating: 0,
+                    notes: '',
+                    stackSequence: 0,
+                    favorite: false,
+                    extractedMetadata: {},
+                    metadataStatus: 'pending',
+                    downloadUrl: state.providerType === 'googledrive' ? Utils.getPersistentDownloadUrl(file) : (file.downloadUrl || '')
+                };
+                 if (state.providerType === 'googledrive' && file.appProperties) {
+                    baseMetadata.stack = file.appProperties.slideboxStack || 'in';
+                    baseMetadata.tags = file.appProperties.slideboxTags ? file.appProperties.slideboxTags.split(',').map(t => t.trim()) : [];
+                    baseMetadata.qualityRating = parseInt(file.appProperties.qualityRating) || 0;
+                    baseMetadata.contentRating = parseInt(file.appProperties.contentRating) || 0;
+                    baseMetadata.notes = file.appProperties.notes || '';
+                    baseMetadata.stackSequence = parseInt(file.appProperties.stackSequence) || 0;
+                    baseMetadata.favorite = file.appProperties.favorite === 'true';
+                 }
+                 return baseMetadata;
+            },
+            switchToCommonUI() {
+                Utils.showScreen('app-container');
+            },
+            async returnToFolderSelection() {
+                try {
+                    if (state.syncManager) {
+                        state.syncManager.requestSync();
+                    }
+                    state.activeRequests.abort(); 
+                    this.resetViewState();
+                    Utils.showScreen('folder-screen');
+                    await Folders.load();
+                } catch(error) {
+                    Utils.showToast(`Error returning to folders: ${error.message}`, 'error', true);
+                    Utils.showScreen('folder-screen');
+                }
+            },
+            resetViewState() {
+                state.imageFiles = [];
+                state.stacks = { in: [], out: [], priority: [], trash: [] };
+                Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
+                Core.updateStackCounts();
+                Core.showEmptyState();
+                Utils.elements.emptyState.classList.add('hidden');
+            },
+            async updateUserMetadata(fileId, updates) {
+                try {
+                    const file = state.imageFiles.find(f => f.id === fileId);
+                    if (!file) return;
+                    Object.assign(file, updates);
+                    await state.dbManager.saveMetadata(file.id, file);
+                    await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
+                } catch (error) {
+                    Utils.showToast(`Failed to update metadata: ${error.message}`, 'error', true);
+                }
+            },
+            async deleteFile(fileId) {
+                const fileIndex = state.imageFiles.findIndex(f => f.id === fileId);
+                if (fileIndex > -1) {
+                    const [file] = state.imageFiles.splice(fileIndex, 1);
+                    const stackIndex = state.stacks[file.stack].findIndex(f => f.id === fileId);
+                    if (stackIndex > -1) { state.stacks[file.stack].splice(stackIndex, 1); }
+                }
+                await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
+                try {
+                    await state.provider.deleteFile(fileId);
+                } catch (e) {
+                    Utils.showToast(`Failed to delete from cloud: ${e.message}`, 'error', true);
+                }
+            },
+            async extractMetadataInBackground(pngFiles) {
+                const BATCH_SIZE = 5;
+                for (let i = 0; i < pngFiles.length; i += BATCH_SIZE) {
+                    if (state.activeRequests.signal.aborted) return;
+                    const batch = pngFiles.slice(i, i + BATCH_SIZE);
+                    const promises = batch.map(file => {
+                        if (file.metadataStatus === 'pending') {
+                            return this.processFileMetadata(file);
+                        }
+                        return Promise.resolve();
+                    });
+                    await Promise.allSettled(promises);
+                }
+            },
+            async processFileMetadata(file) {
+                if (file.metadataStatus === 'loaded' || file.metadataStatus === 'loading' || file.metadataStatus === 'error') return;
+                file.metadataStatus = 'loading';
+                try {
+                    const metadata = await state.metadataExtractor.fetchMetadata(file);
+                    let finalMetadata = { ...file };
+                    if (metadata.error) {
+                        finalMetadata.metadataStatus = 'error';
+                        finalMetadata.extractedMetadata = { 'Error': metadata.error };
+                        finalMetadata.prompt = `Metadata Error: ${metadata.error}`;
+                    } else {
+                        finalMetadata.metadataStatus = 'loaded';
+                        finalMetadata.extractedMetadata = metadata;
+                    }
+                    await state.dbManager.saveMetadata(file.id, finalMetadata);
+                    Object.assign(file, finalMetadata);
+                } catch (error) {
+                    if (error.name === 'AbortError') return;
+                    console.warn(`Background metadata extraction failed for ${file.name}: ${error.message}`);
+                    file.metadataStatus = 'error';
+                    file.extractedMetadata = { 'Error': error.message };
+                    file.prompt = `Metadata Error: ${error.message}`;
+                    await state.dbManager.saveMetadata(file.id, file);
+                }
+            }
+        };
+        const Core = {
+            initializeStacks() {
+                STACKS.forEach(stack => { state.stacks[stack] = []; });
+                state.imageFiles.forEach(file => {
+                    const stack = file.stack || 'in';
+                    if (STACKS.includes(stack)) {
+                        state.stacks[stack].push(file);
+                    } else {
+                        state.stacks.in.push(file);
+                    }
+                });
+                STACKS.forEach(stack => {
+                    state.stacks[stack] = this.sortFiles(state.stacks[stack]);
+                });
+                this.updateStackCounts();
+            },
+            
+            sortFiles(files) {
+                return [...files].sort((a, b) => {
+                    const seqA = a.stackSequence || 0;
+                    const seqB = b.stackSequence || 0;
+                    if (seqB !== seqA) {
+                        return seqB - seqA;
+                    }
+                    return (a.name || '').localeCompare(b.name || '');
+                });
+            },
+            
+            updateStackCounts() {
+                STACKS.forEach(stack => {
+                    const count = state.stacks[stack] ? state.stacks[stack].length : 0;
+                    const pill = document.getElementById(`pill-${stack}`);
+                    if (pill) {
+                        pill.textContent = count > 999 ? ':)' : count;
+                        pill.classList.toggle('visible', count > 0);
+                    }
+                });
+            },
+            
+            initializeImageDisplay() {
+                if (state.imageFiles.length === 0) {
+                    this.showEmptyState();
+                    return;
+                }
+                state.currentStackPosition = 0;
+                state.currentStack = 'in';
+                
+                this.displayTopImageFromStack('in');
+                this.updateActiveProxTab();
+                this.updateStackCounts();
+            },
+            
+            async displayTopImageFromStack(stackName) {
+                try {
+                    const stack = state.stacks[stackName];
+                    if (!stack || stack.length === 0) {
+                        this.showEmptyState();
+                        return;
+                    }
+                    
+                    Utils.elements.emptyState.classList.add('hidden');
+                    state.currentStack = stackName;
+                    state.currentStackPosition = 0;
+                    
+                    await this.displayCurrentImage();
+                    this.updateActiveProxTab();
+                } catch (error) {
+                    Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
+                }
+            },
+            
+            async displayCurrentImage() {
+                const currentStackArray = state.stacks[state.currentStack];
+                if (!currentStackArray || currentStackArray.length === 0) {
+                    this.showEmptyState();
+                    return;
+                }
+                
+                if (state.currentStackPosition >= currentStackArray.length) {
+                    state.currentStackPosition = currentStackArray.length - 1;
+                }
+                if (state.currentStackPosition < 0) {
+                    state.currentStackPosition = 0;
+                }
+
+                const currentFile = currentStackArray[state.currentStackPosition];
+                if (!currentFile) {
+                    this.showEmptyState();
+                    return;
+                }
+
+                try {
+                    Utils.elements.detailsButton.style.display = 'flex';
+                    const existingSrc = Utils.elements.centerImage.src;
+                    if (existingSrc && existingSrc.startsWith('blob:')) {
+                        URL.revokeObjectURL(existingSrc);
+                    }
+                    await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
+                    
+                    const folderName = state.currentFolder.name;
+                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
+                    
+                    state.currentScale = 1;
+                    state.panOffset = { x: 0, y: 0 };
+                    this.applyTransform();
+
+                    if (currentFile.metadataStatus === 'pending') {
+                        App.processFileMetadata(currentFile);
+                    }
+                    
+                    this.updateImageCounters();
+                    this.updateFavoriteButton();
+                } catch (error) {
+                     Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
+                }
+            },
+
+            updateImageCounters() {
+                const stack = state.stacks[state.currentStack];
+                const total = stack ? stack.length : 0;
+                const current = total > 0 ? state.currentStackPosition + 1 : 0;
+                const counterText = total > 0 ? `Item ${current} / ${total}` : 'No items';
+                if (Utils.elements.normalImageCount) {
+                    Utils.elements.normalImageCount.textContent = counterText;
+                    Utils.elements.normalImageCount.setAttribute('aria-label', counterText);
+                }
+                if (Utils.elements.focusImageCount) {
+                    Utils.elements.focusImageCount.textContent = counterText;
+                    Utils.elements.focusImageCount.setAttribute('aria-label', counterText);
+                }
+                if (Utils.elements.focusStackName) {
+                    const stackLabel = STACK_NAMES[state.currentStack] || state.currentStack;
+                    Utils.elements.focusStackName.textContent = stackLabel;
+                    Utils.elements.focusStackName.setAttribute('aria-label', `Switch stack (current: ${stackLabel})`);
+                }
+            },
+
+            updateFavoriteButton() {
+                const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
+                if (!currentFile) {
+                    if (Utils.elements.focusFavoriteBtn) {
+                        Utils.elements.focusFavoriteBtn.classList.remove('favorited');
+                        Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', 'false');
+                    }
+                    return;
+                }
+                const isFavorite = Boolean(currentFile.favorite);
+                if (Utils.elements.focusFavoriteBtn) {
+                    Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
+                    Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
+                    const label = isFavorite ? 'Remove from favorites' : 'Add to favorites';
+                    Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
+                }
+            },
+            
+            applyTransform() {
+                const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
+                Utils.elements.centerImage.style.transform = transform;
+            },
+            
+            updateActiveProxTab() {
+                STACKS.forEach(stack => {
+                    const pill = document.getElementById(`pill-${stack}`);
+                    if (pill) pill.classList.remove('active');
+                });
+                
+                const currentPill = document.getElementById(`pill-${state.currentStack}`);
+                if (currentPill) currentPill.classList.add('active');
+            },
+            
+            async moveToStack(targetStack) {
+                const currentStackArray = state.stacks[state.currentStack];
+                if (!currentStackArray || currentStackArray.length === 0) return;
+                
+                const currentImage = currentStackArray[state.currentStackPosition];
+                if (!currentImage) return;
+
+                try {
+                    const originalStackName = state.currentStack;
+                    if (targetStack === originalStackName) {
+                        const otherImages = currentStackArray.filter(img => img.id !== currentImage.id);
+                        const minSequence = otherImages.length > 0 ? Math.min(...otherImages.map(img => img.stackSequence || 0)) : Date.now();
+                        const newSequence = minSequence - 1;
+                        await App.updateUserMetadata(currentImage.id, { stackSequence: newSequence });
+                        const [item] = currentStackArray.splice(state.currentStackPosition, 1);
+                        item.stackSequence = newSequence;
+                        currentStackArray.push(item);
+                    } else {
+                        const newSequence = Date.now();
+                        await App.updateUserMetadata(currentImage.id, { stack: targetStack, stackSequence: newSequence });
+                        const [item] = currentStackArray.splice(state.currentStackPosition, 1);
+                        item.stack = targetStack;
+                        item.stackSequence = newSequence;
+                        state.stacks[targetStack].unshift(item);
+                        state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
+                    }
+                    
+                    this.updateStackCounts();
+                    this.updateActiveProxTab();
+                    await this.displayCurrentImage();
+                } catch (error) {
+                    Utils.showToast(`Error moving image: ${error.message}`, 'error', true);
+                }
+            },
+            
+            showEmptyState() {
+                state.currentImageLoadId = null;
+                Utils.elements.centerImage.style.opacity = '0';
+                Utils.elements.detailsButton.style.display = 'none';
+                this.updateImageCounters();
+                setTimeout(() => {
+                    Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
+                    Utils.elements.centerImage.alt = 'No images in this stack';
+                    Utils.elements.emptyState.classList.remove('hidden');
+                    Utils.elements.centerImage.style.opacity = '1';
+                    UI.updateEmptyStateButtons();
+                }, 200);
+            }
+        };
+        const Grid = {
+            open(stack) {
+                Utils.showModal('grid-modal');
+                Utils.elements.gridTitle.textContent = STACK_NAMES[stack] || stack;
+                state.grid.stack = stack;
+                state.grid.isDirty = false;
+                const value = Utils.elements.gridSize.value;
+                Utils.elements.gridContainer.style.gridTemplateColumns = `repeat(${value}, 1fr)`;
+                state.grid.selected = []; state.grid.filtered = [];
+                Utils.elements.gridContainer.innerHTML = '';
+                this.initializeLazyLoad(stack);
+                this.updateSelectionUI();
+                Core.updateStackCounts();
+            },
+            
+            async close() {
+                try {
+                    if (state.grid.isDirty) {
+                        await this.reorderStackOnClose();
+                    }
+                    Utils.hideModal('grid-modal');
+                    this.resetSearch(); this.destroyLazyLoad();
+                    const selectedImages = state.grid.selected;
+                    if (selectedImages.length === 1) {
+                        const selectedFileId = selectedImages[0];
+                        const stackArray = state.stacks[state.currentStack];
+                        const selectedIndex = stackArray.findIndex(f => f.id === selectedFileId);
+                        if (selectedIndex !== -1) { state.currentStackPosition = selectedIndex; }
+                    }
+                    await Core.displayCurrentImage();
+                    state.grid.stack = null; state.grid.selected = [];
+                } catch (error) {
+                    Utils.showToast(`Error closing grid: ${error.message}`, 'error', true);
+                }
+            },
+
+            handleIntersection(entries) {
+                if (entries[0].isIntersecting) { this.renderBatch(); }
+            },
+
+            initializeLazyLoad(stack) {
+                const lazyState = state.grid.lazyLoadState;
+                lazyState.allFiles = state.grid.filtered.length > 0 ? state.grid.filtered : state.stacks[stack];
+                lazyState.renderedCount = 0;
+                Utils.elements.selectAllBtn.textContent = lazyState.allFiles.length;
+                this.renderBatch();
+                if (lazyState.observer) lazyState.observer.disconnect();
+                lazyState.observer = new IntersectionObserver(this.handleIntersection.bind(this), { 
+                    root: Utils.elements.gridContent, rootMargin: "400px"
+                });
+                const sentinel = document.getElementById('grid-sentinel');
+                if (sentinel) { lazyState.observer.observe(sentinel); }
+            },
+
+            destroyLazyLoad() {
+                const lazyState = state.grid.lazyLoadState;
+                if (lazyState.observer) { lazyState.observer.disconnect(); lazyState.observer = null; }
+                lazyState.allFiles = []; lazyState.renderedCount = 0;
+            },
+
+            renderBatch() {
+                const lazyState = state.grid.lazyLoadState;
+                const container = Utils.elements.gridContainer;
+                const filesToRender = lazyState.allFiles.slice(lazyState.renderedCount, lazyState.renderedCount + lazyState.batchSize);
+
+                const oldSentinel = document.getElementById('grid-sentinel');
+                if (oldSentinel && lazyState.observer) {
+                    lazyState.observer.unobserve(oldSentinel); oldSentinel.remove();
+                }
+
+                filesToRender.forEach(file => {
+                    const div = document.createElement('div');
+                    div.className = 'grid-item'; div.dataset.fileId = file.id;
+                    if (state.grid.selected.includes(file.id)) { div.classList.add('selected'); }
+                    const img = document.createElement('img');
+                    img.className = 'grid-image'; img.alt = file.name || 'Image';
+                    img.dataset.src = Utils.getPreferredImageUrl(file);
+                    img.onload = () => img.classList.add('loaded');
+                    img.onerror = async () => {
+                        img.onerror = null;
+                        try {
+                            const blobUrl = await Utils.getAuthenticatedImageBlob(file);
+                            img.src = blobUrl;
+                        } catch (authError) {
+                            img.src = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='150' height='150' viewBox='0 0 150 150' fill='none'%3E%3Crect width='150' height='150' fill='%23E5E7EB'/%3E%3Cpath d='M65 60H85V90H65V60Z' fill='%239CA3AF'/%3E%3Ccircle cx='75' cy='45' r='10' fill='%239CA3AF'/%3E%3C/svg%3E";
+                        } finally {
+                            img.classList.add('loaded');
+                        }
+                    };
+                    div.addEventListener('click', e => this.toggleSelection(e, file.id));
+                    const overlay = document.createElement('div');
+                    overlay.className = 'filename-overlay';
+                    overlay.textContent = file.name;
+                    div.appendChild(img);
+                    div.appendChild(overlay);
+                    container.appendChild(div);
+                });
+                container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
+                lazyState.renderedCount += filesToRender.length;
+
+                if (lazyState.renderedCount < lazyState.allFiles.length) {
+                    const sentinel = document.createElement('div');
+                    sentinel.id = 'grid-sentinel';
+                    container.appendChild(sentinel);
+                    if (lazyState.observer) { lazyState.observer.observe(sentinel); }
+                }
+            },
+            
+            toggleSelection(e, fileId) {
+                const gridItem = e.currentTarget;
+                const index = state.grid.selected.indexOf(fileId);
+                if (index === -1) { state.grid.selected.push(fileId); gridItem.classList.add('selected');
+                } else { state.grid.selected.splice(index, 1); gridItem.classList.remove('selected'); }
+                state.grid.isDirty = true;
+                this.updateSelectionUI();
+            },
+            
+            updateSelectionUI() {
+                const count = state.grid.selected.length;
+                const buttons = [Utils.elements.tagSelected, Utils.elements.moveSelected, Utils.elements.deleteSelected, 
+                               Utils.elements.exportSelected, Utils.elements.folderSelected];
+                Utils.elements.selectionText.textContent = `${count} selected`;
+                buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
+            },
+            
+            selectAll() {
+                const filesToSelect = state.grid.lazyLoadState.allFiles;
+                state.grid.selected = filesToSelect.map(f => f.id);
+                document.querySelectorAll('#grid-container .grid-item').forEach(item => {
+                    item.classList.add('selected');
+                });
+                state.grid.isDirty = true;
+                this.updateSelectionUI();
+            },
+            
+            deselectAll() {
+                document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
+                state.grid.selected = [];
+                this.updateSelectionUI();
+            },
+            
+            performSearch() {
+                const query = Utils.elements.omniSearch.value.trim();
+                Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
+                state.grid.selected = [];
+                if (!query) { this.resetSearch(); return; }
+                state.grid.filtered = this.searchImages(query);
+                
+                Utils.elements.gridContainer.innerHTML = '';
+                if (state.grid.filtered.length === 0) {
+                    Utils.elements.gridEmptyState.classList.remove('hidden');
+                    Utils.elements.selectAllBtn.textContent = '0';
+                } else {
+                    Utils.elements.gridEmptyState.classList.add('hidden');
+                }
+
+                this.initializeLazyLoad(state.grid.stack);
+                this.updateSelectionUI();
+                state.grid.isDirty = true;
+            },
+
+            resetSearch() {
+                Utils.elements.omniSearch.value = '';
+                Utils.elements.clearSearchBtn.style.display = 'none';
+                Utils.elements.gridEmptyState.classList.add('hidden');
+                state.grid.filtered = [];
+                Utils.elements.gridContainer.innerHTML = '';
+                this.initializeLazyLoad(state.grid.stack);
+                Core.updateStackCounts();
+                this.deselectAll();
+            },
+            
+            searchImages(query) {
+                const lowerCaseQuery = query.toLowerCase();
+                const terms = lowerCaseQuery.split(/\s+/).filter(t => t);
+
+                const modifiers = terms.filter(t => t.startsWith('#'));
+                const exclusions = terms.filter(t => t.startsWith('-')).map(t => t.substring(1));
+                const inclusions = terms.filter(t => !t.startsWith('#') && !t.startsWith('-'));
+
+                let results = [...state.stacks[state.grid.stack]];
+
+                // 1. Pass: Modifiers
+                modifiers.forEach(mod => {
+                    if (mod === '#favorite') {
+                        results = results.filter(file => file.favorite === true);
+                    } else if (mod.startsWith('#quality:')) {
+                        const rating = parseInt(mod.split(':')[1]);
+                        if (!isNaN(rating)) {
+                            results = results.filter(file => file.qualityRating === rating);
+                        }
+                    } else if (mod.startsWith('#content:')) {
+                        const rating = parseInt(mod.split(':')[1]);
+                        if (!isNaN(rating)) {
+                            results = results.filter(file => file.contentRating === rating);
+                        }
+                    }
+                });
+
+                // 2. Pass: Inclusions
+                inclusions.forEach(term => {
+                    results = results.filter(file => {
+                        const searchableText = [
+                            file.name || '',
+                            file.tags?.join(' ') || '',
+                            file.notes || '',
+                            file.createdTime ? new Date(file.createdTime).toISOString().split('T')[0] : '',
+                            JSON.stringify(file.extractedMetadata || {})
+                        ].join(' ').toLowerCase();
+                        return searchableText.includes(term);
+                    });
+                });
+
+                // 3. Pass: Exclusions
+                exclusions.forEach(term => {
+                    results = results.filter(file => {
+                        const searchableText = [
+                            file.name || '',
+                            file.tags?.join(' ') || '',
+                            file.notes || '',
+                            file.createdTime ? new Date(file.createdTime).toISOString().split('T')[0] : '',
+                            JSON.stringify(file.extractedMetadata || {})
+                        ].join(' ').toLowerCase();
+                        return !searchableText.includes(term);
+                    });
+                });
+
+                return results;
+            },
+
+            async reorderStackOnClose() {
+                const stackArray = state.stacks[state.grid.stack];
+                let topItems = []; let bottomItems = [];
+
+                if (state.grid.filtered.length > 0) {
+                    const filteredIds = new Set(state.grid.filtered.map(f => f.id));
+                    topItems = state.grid.filtered.sort((a, b) => a.name.localeCompare(b.name));
+                    bottomItems = stackArray.filter(f => !filteredIds.has(f.id));
+                } else if (state.grid.selected.length > 0) {
+                    const selectedIds = new Set(state.grid.selected);
+                    topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
+                    bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
+                } else { return; }
+                
+                const newStack = [...topItems, ...bottomItems];
+                const timestamp = Date.now();
+                
+                newStack.forEach((file, i) => {
+                    file.stackSequence = timestamp - i;
+                });
+
+                for(const file of newStack) {
+                    await state.dbManager.saveMetadata(file.id, file);
+                }
+                await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
+
+                state.stacks[state.grid.stack] = newStack;
+                state.currentStackPosition = 0;
+                Utils.showToast('Stack order updated', 'success');
+            }
+        };
+        const Details = {
+            currentTab: 'info',
+            async show() {
+                try {
+                    const currentFile = state.stacks[state.currentStack][state.currentStackPosition];
+                    if (!currentFile) return;
+                    if (currentFile.metadataStatus !== 'loaded') {
+                        this.populateMetadataTab(currentFile);
+                        await App.processFileMetadata(currentFile);
+                    }
+                    this.populateAllTabs(currentFile);
+                    Utils.showModal('details-modal');
+                    this.switchTab('info');
+                } catch (error) {
+                    Utils.showToast(`Error showing details: ${error.message}`, 'error', true);
+                }
+            },
+            hide() { Utils.hideModal('details-modal'); },
+            switchTab(tabName) {
+                document.querySelectorAll('.tab-button').forEach(btn => { btn.classList.toggle('active', btn.dataset.tab === tabName); });
+                document.querySelectorAll('.tab-content').forEach(content => { content.classList.toggle('active', content.id === `tab-${tabName}`); });
+                this.currentTab = tabName;
+            },
+            populateAllTabs(file) {
+                this.populateInfoTab(file); this.populateTagsTab(file); this.populateNotesTab(file); this.populateMetadataTab(file);
+            },
+            populateInfoTab(file) {
+                const filename = file.name || 'Unknown';
+                Utils.elements.detailFilename.textContent = filename;
+                if (state.providerType === 'googledrive') { Utils.elements.detailFilenameLink.href = `https://drive.google.com/file/d/${file.id}/view`;
+                } else { Utils.elements.detailFilenameLink.href = Utils.getPersistentDownloadUrl(file) || '#'; }
+                Utils.elements.detailFilenameLink.style.display = 'inline';
+                const date = file.modifiedTime ? new Date(file.modifiedTime).toLocaleString() : file.createdTime ? new Date(file.createdTime).toLocaleString() : 'Unknown';
+                Utils.elements.detailDate.textContent = date;
+                const size = file.size ? Utils.formatFileSize(file.size) : 'Unknown';
+                Utils.elements.detailSize.textContent = size;
+            },
+            populateTagsTab(file) {
+                const tags = file.tags || [];
+                Utils.elements.detailTags.innerHTML = '';
+                tags.forEach(tag => {
+                    const tagElement = document.createElement('div');
+                    tagElement.className = 'tag-item';
+                    tagElement.innerHTML = `<span>${tag}</span><button class="tag-remove" data-tag="${tag}">×</button>`;
+                    Utils.elements.detailTags.appendChild(tagElement);
+                });
+                const addButton = document.createElement('div');
+                addButton.className = 'add-tag-btn'; addButton.textContent = '+ Add Tag';
+                addButton.addEventListener('click', () => this.showAddTagInput());
+                Utils.elements.detailTags.appendChild(addButton);
+                Utils.elements.detailTags.querySelectorAll('.tag-remove').forEach(btn => {
+                    btn.addEventListener('click', (e) => {
+                        const tagToRemove = e.target.dataset.tag;
+                        this.removeTag(file, tagToRemove);
+                    });
+                });
+            },
+            showAddTagInput() {
+                const input = document.createElement('input');
+                input.type = 'text'; input.className = 'tag-input';
+                input.placeholder = 'Enter tag name'; input.style.marginLeft = '8px';
+                const addButton = Utils.elements.detailTags.querySelector('.add-tag-btn');
+                addButton.parentNode.insertBefore(input, addButton);
+                input.focus();
+                input.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter') {
+                        const tagName = input.value.trim();
+                        if (tagName) {
+                            const currentFile = state.stacks[state.currentStack][state.currentStackPosition];
+                            const currentTags = currentFile.tags || [];
+                            const newTags = [...new Set([...currentTags, tagName])];
+                            App.updateUserMetadata(currentFile.id, { tags: newTags });
+                            state.tags.add(tagName);
+                            this.populateTagsTab(currentFile);
+                            input.remove();
+                        }
+                    } else if (e.key === 'Escape') { input.remove(); }
+                });
+                input.addEventListener('blur', () => { setTimeout(() => input.remove(), 100); });
+            },
+            removeTag(file, tagToRemove) {
+                const currentTags = file.tags || [];
+                const newTags = currentTags.filter(tag => tag !== tagToRemove);
+                App.updateUserMetadata(file.id, { tags: newTags });
+                this.populateTagsTab(file);
+            },
+            populateNotesTab(file) {
+                Utils.elements.detailNotes.value = file.notes || '';
+                const newNotesTextarea = Utils.elements.detailNotes.cloneNode(true);
+                Utils.elements.detailNotes.parentNode.replaceChild(newNotesTextarea, Utils.elements.detailNotes);
+                Utils.elements.detailNotes = newNotesTextarea;
+                Utils.elements.detailNotes.addEventListener('blur', () => {
+                    const currentFile = state.stacks[state.currentStack][state.currentStackPosition];
+                    if (currentFile.notes !== Utils.elements.detailNotes.value) {
+                        App.updateUserMetadata(currentFile.id, { notes: Utils.elements.detailNotes.value });
+                    }
+                });
+                this.setupStarRating('quality', file.qualityRating || 0);
+                this.setupStarRating('content', file.contentRating || 0);
+            },
+            setupStarRating(type, currentRating) {
+                const container = Utils.elements[`${type}Rating`]; if (!container) return;
+                let rating = currentRating;
+                const stars = container.querySelectorAll('.star');
+                const updateVisuals = (r) => { stars.forEach((star, index) => { star.classList.toggle('active', index < r); }); };
+                container.onmouseleave = () => updateVisuals(rating);
+                stars.forEach((star, index) => {
+                    star.onmouseenter = () => updateVisuals(index + 1);
+                    star.onclick = () => {
+                        const newRating = index + 1;
+                        if (newRating === rating) { rating = 0; } else { rating = newRating; }
+                        updateVisuals(rating);
+                        const currentFile = state.stacks[state.currentStack][state.currentStackPosition];
+                        if (!currentFile) return;
+                        const updatePayload = {};
+                        if (type === 'quality') { updatePayload.qualityRating = rating; } else { updatePayload.contentRating = rating; }
+                        App.updateUserMetadata(currentFile.id, updatePayload);
+                    };
+                });
+                updateVisuals(rating);
+            },
+            populateMetadataTab(file) {
+                Utils.elements.metadataTable.innerHTML = '';
+                if (file.metadataStatus !== 'loaded' && file.metadataStatus !== 'error') {
+                    Utils.elements.metadataTable.innerHTML = `<tr><td colspan="2" style="text-align:center; padding: 20px;"><div class="spinner" style="margin: 0 auto;"></div></td></tr>`;
+                    return;
+                }
+                const metadata = file.extractedMetadata || {};
+                if (Object.keys(metadata).length === 0) {
+                    this.addMetadataRow('Status', 'No embedded metadata found', false);
+                    return;
+                }
+                const priorityFields = ['prompt', 'Prompt', 'model', 'Model', 'seed', 'Seed', 'negative_prompt', 'Negative_Prompt', 'steps', 'Steps', 'cfg_scale', 'CFG_Scale', 'sampler', 'Sampler', 'scheduler', 'Scheduler', 'api_call', 'API_Call'];
+                priorityFields.forEach(field => { if (metadata[field]) { this.addMetadataRow(field, metadata[field], true); } });
+                const remainingFields = Object.entries(metadata).filter(([key, value]) => !priorityFields.includes(key) && !priorityFields.includes(key.toLowerCase()) && value );
+                if (priorityFields.some(field => metadata[field]) && remainingFields.length > 0) {
+                    const separatorRow = document.createElement('tr');
+                    separatorRow.innerHTML = `<td colspan="2" style="padding: 8px; background: #f0f0f0; text-align: center; font-size: 12px; color: #666; font-weight: bold;">Other Metadata</td>`;
+                    Utils.elements.metadataTable.appendChild(separatorRow);
+                }
+                remainingFields.forEach(([key, value]) => { this.addMetadataRow(key, value, false); });
+                if (Object.keys(metadata).length > 0) {
+                    const separatorRow = document.createElement('tr');
+                    separatorRow.innerHTML = `<td colspan="2" style="padding: 8px; background: #f0f0f0; text-align: center; font-size: 12px; color: #666; font-weight: bold;">File Information</td>`;
+                    Utils.elements.metadataTable.appendChild(separatorRow);
+                }
+                this.addMetadataRow('File Name', file.name || 'Unknown', false);
+                this.addMetadataRow('File Size', file.size ? Utils.formatFileSize(file.size) : 'Unknown', false);
+                this.addMetadataRow('MIME Type', file.mimeType || 'Unknown', false);
+                this.addMetadataRow('Created', file.createdTime ? new Date(file.createdTime).toLocaleString() : 'Unknown', false);
+                this.addMetadataRow('Modified', file.modifiedTime ? new Date(file.modifiedTime).toLocaleString() : 'Unknown', false);
+                this.addMetadataRow('Provider', state.providerType === 'googledrive' ? 'Google Drive' : 'OneDrive', false);
+            },
+            addMetadataRow(key, value, needsCopyButton = false) {
+                const row = document.createElement('tr');
+                const formattedKey = key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+                let formattedValue = String(value);
+                if (formattedValue.length > 200) { formattedValue = formattedValue.replace(/,\s+/g, ',\n').replace(/\.\s+/g, '.\n').replace(/;\s+/g, ';\n').trim();
+                } else if (formattedValue.length > 100) { formattedValue = formattedValue.replace(/\s+/g, ' ').trim(); }
+                const keyCell = document.createElement('td');
+                keyCell.className = 'key-cell'; keyCell.textContent = formattedKey;
+                const valueCell = document.createElement('td');
+                valueCell.className = 'value-cell';
+                if (formattedValue.length > 500) { valueCell.style.maxHeight = '120px'; valueCell.style.overflowY = 'auto'; valueCell.style.fontSize = '12px'; valueCell.style.lineHeight = '1.4'; }
+                valueCell.textContent = formattedValue;
+                if (needsCopyButton) {
+                    const copyButton = document.createElement('button');
+                    copyButton.className = 'copy-button copy-metadata'; copyButton.textContent = 'Copy';
+                    copyButton.dataset.value = String(value); copyButton.title = `Copy ${formattedKey} to clipboard`;
+                    valueCell.appendChild(copyButton);
+                }
+                row.appendChild(keyCell); row.appendChild(valueCell);
+                Utils.elements.metadataTable.appendChild(row);
+            },
+            copyToClipboard(text) {
+                navigator.clipboard.writeText(text).then(() => { Utils.showToast('📋 Copied to clipboard', 'success', true);
+                }).catch(() => {
+                    const textArea = document.createElement('textarea');
+                    textArea.value = text; textArea.style.position = 'fixed'; textArea.style.opacity = '0';
+                    document.body.appendChild(textArea); textArea.select();
+                    try { document.execCommand('copy'); Utils.showToast('📋 Copied to clipboard', 'success', true);
+                    } catch (err) { Utils.showToast('❌ Failed to copy', 'error', true); }
+                    document.body.removeChild(textArea);
+                });
+            }
+        };
+        const Modal = {
+            currentAction: null,
+            taggingState: {
+                tags: new Set()
+            },
+            show(type, options = {}) {
+                this.currentAction = type;
+                const { title, content, confirmText = 'Confirm', confirmClass = 'btn-primary' } = options;
+                Utils.elements.actionTitle.textContent = title || 'Action';
+                Utils.elements.actionContent.innerHTML = content || '';
+                Utils.elements.actionConfirm.textContent = confirmText;
+                Utils.elements.actionConfirm.className = `btn ${confirmClass}`;
+                Utils.elements.actionConfirm.disabled = false;
+                Utils.elements.actionCancel.textContent = "Cancel";
+                Utils.showModal('action-modal');
+            },
+            hide() { Utils.hideModal('action-modal'); this.currentAction = null; },
+            setupMoveAction() {
+                this.show('move', {
+                    title: 'Move to Stack',
+                    content: `<div style="display: flex; flex-direction: column; gap: 8px; margin-bottom: 16px;">${STACKS.map(stack => `<button class="move-option" data-stack="${stack}" style="width: 100%; text-align: left; padding: 8px 16px; border-radius: 6px; border: none; background: transparent; cursor: pointer; transition: background-color 0.2s;">${STACK_NAMES[stack]}</button>`).join('')}</div>`,
+                    confirmText: 'Cancel'
+                });
+                document.querySelectorAll('.move-option').forEach(option => {
+                    option.addEventListener('click', () => { this.executeMove(option.dataset.stack); });
+                });
+            },
+            setupTagAction() {
+                this.taggingState.tags.clear();
+                this.show('tag', {
+                    title: 'Add Tags',
+                    content: `<div style="margin-bottom: 16px;">
+                                <label style="display: block; font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 4px;">Enter tags</label>
+                                <div id="tag-chip-container"></div>
+                                <input type="text" id="modal-tag-input" class="tag-input" placeholder="nature, landscape, vacation">
+                             </div>
+                             <div id="modal-tag-suggestions" style="display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px;">
+                                ${Array.from(state.tags).map(tag => `<button class="tag-suggestion" data-tag="${tag}" style="background-color: #e5e7eb; color: #374151; padding: 4px 8px; border-radius: 6px; font-size: 12px; cursor: pointer; transition: background-color 0.2s; border: none;">${tag}</button>`).join('')}
+                             </div>`,
+                    confirmText: 'Apply'
+                });
+                const tagInput = document.getElementById('modal-tag-input');
+                tagInput.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter') {
+                        e.preventDefault();
+                        const tagValue = tagInput.value.trim();
+                        if (tagValue) {
+                            this.addTagChip(tagValue);
+                            tagInput.value = '';
+                        }
+                    }
+                });
+                document.querySelectorAll('.tag-suggestion').forEach(btn => {
+                    btn.addEventListener('click', () => this.addTagChip(btn.dataset.tag));
+                });
+            },
+            addTagChip(tag) {
+                if (this.taggingState.tags.has(tag)) return;
+                this.taggingState.tags.add(tag);
+                const container = document.getElementById('tag-chip-container');
+                const chip = document.createElement('div');
+                chip.className = 'tag-chip';
+                chip.innerHTML = `<span>${tag}</span><button class="tag-chip-remove" data-tag="${tag}">×</button>`;
+                container.appendChild(chip);
+                chip.querySelector('.tag-chip-remove').addEventListener('click', () => {
+                    this.removeTagChip(chip, tag);
+                });
+            },
+            removeTagChip(chipElement, tag) {
+                this.taggingState.tags.delete(tag);
+                chipElement.remove();
+            },
+            setupDeleteAction() {
+                const selectedCount = state.grid.selected.length;
+                const providerName = state.providerType === 'googledrive' ? 'Google Drive' : 'OneDrive';
+                const message = `Are you sure you want to move ${selectedCount} image(s) to your ${providerName} trash? This can be recovered from the provider's website.`;
+                this.show('delete', { title: 'Confirm Delete', content: `<p style="color: #4b5563; margin-bottom: 16px;">${message}</p>`, confirmText: `Move to ${providerName} Trash`, confirmClass: 'btn-danger' });
+            },
+            setupExportAction() {
+                this.show('export', {
+                    title: 'Export to Spreadsheet',
+                    content: `<p style="color: #4b5563; margin-bottom: 16px;">This will start the new Live Export process for ${state.grid.selected.length} selected image(s).</p><p style="color: #4b5563; margin-bottom: 16px;">It will fetch fresh data directly from the cloud to ensure 100% accuracy.</p>`,
+                    confirmText: 'Begin Export'
+                });
+            },
+            setupFocusStackSwitch() {
+                const availableStacks = STACKS.filter(stack => stack !== state.currentStack && (state.stacks[stack]?.length || 0) > 0);
+                let content = `<div style="display: flex; flex-direction: column; gap: 8px; margin-bottom: 16px;">`;
+                if (availableStacks.length > 0) {
+                    content += availableStacks.map(stack => `<button class="move-option" data-stack="${stack}" style="width: 100%; text-align: left; padding: 8px 16px; border-radius: 6px; border: none; background: transparent; cursor: pointer; transition: background-color 0.2s;">${STACK_NAMES[stack]} (${state.stacks[stack].length})</button>`).join('');
+                } else {
+                    content += `<p style="color: #4b5563; text-align: center;">No other stacks have images.</p>`;
+                }
+                content += `</div>`;
+                this.show('focus-stack-switch', { title: 'Switch Stack', content, confirmText: 'Cancel' });
+                document.querySelectorAll('.move-option').forEach(option => {
+                    option.addEventListener('click', () => {
+                        const targetStack = option.dataset.stack;
+                        UI.switchToStack(targetStack);
+                        Core.updateImageCounters();
+                        this.hide();
+                    });
+                });
+            },
+            setupFolderMoveAction() {
+                this.show('folder-move', {
+                    title: 'Move to Different Folder',
+                    content: `<p style="color: #4b5563; margin-bottom: 16px;">This will move ${state.grid.selected.length} image${state.grid.selected.length > 1 ? 's' : ''} to a different folder. The images will be removed from this stack and their metadata will move with them.</p><div style="margin-bottom: 16px;"><strong>Note:</strong> This action requires provider support and may not be available for all cloud storage providers.</div>`,
+                    confirmText: 'Choose Destination Folder'
+                });
+            },
+            async executeBulkAction(options) {
+                const { action, successMessage, updateGridOnSuccess = true } = options;
+                const confirmBtn = Utils.elements.actionConfirm;
+                const originalText = confirmBtn.textContent;
+                confirmBtn.disabled = true;
+                confirmBtn.textContent = 'Processing...';
+
+                try {
+                    const promises = state.grid.selected.map(fileId => action(fileId));
+                    await Promise.all(promises);
+
+                    Utils.showToast(successMessage.replace('{count}', promises.length), 'success', true);
+                    this.hide();
+                    Core.updateStackCounts();
+
+                    if (updateGridOnSuccess) {
+                        Utils.elements.gridContainer.innerHTML = '';
+                        Grid.initializeLazyLoad(state.grid.stack);
+                    }
+                    Grid.deselectAll();
+                    return true;
+                } catch (error) {
+                    Utils.showToast(`Failed to process some images: ${error.message}`, 'error', true);
+                    return false;
+                } finally {
+                    confirmBtn.disabled = false;
+                    confirmBtn.textContent = originalText;
+                }
+            },
+            async executeMove(targetStack) {
+                await this.executeBulkAction({
+                    action: async (fileId) => {
+                        const file = state.imageFiles.find(f => f.id === fileId);
+                        if (file) {
+                            const currentStack = file.stack;
+                            const newSequence = Date.now();
+                            await App.updateUserMetadata(fileId, { stack: targetStack, stackSequence: newSequence });
+                            const currentStackIndex = state.stacks[currentStack].findIndex(f => f.id === fileId);
+                            if (currentStackIndex !== -1) {
+                                state.stacks[currentStack].splice(currentStackIndex, 1);
+                            }
+                            file.stack = targetStack;
+                            file.stackSequence = newSequence;
+                            state.stacks[targetStack].unshift(file);
+                            state.stacks[targetStack] = Core.sortFiles(state.stacks[targetStack]);
+                        }
+                    },
+                    successMessage: `Moved {count} images to ${STACK_NAMES[targetStack]}`
+                });
+            },
+            async executeTag() {
+                const tagsToAdd = Array.from(this.taggingState.tags);
+                if (tagsToAdd.length === 0) {
+                    this.hide();
+                    return;
+                }
+                
+                await this.executeBulkAction({
+                    action: async (fileId) => {
+                        const file = state.imageFiles.find(f => f.id === fileId);
+                        if (file) {
+                            const currentTags = file.tags || [];
+                            const newTags = [...new Set([...currentTags, ...tagsToAdd])];
+                            await App.updateUserMetadata(fileId, { tags: newTags });
+                            tagsToAdd.forEach(tag => state.tags.add(tag));
+                        }
+                    },
+                    successMessage: `Tags added to {count} images`,
+                    updateGridOnSuccess: false
+                });
+            },
+            async executeDelete() {
+                await this.executeBulkAction({
+                    action: async (fileId) => {
+                        await App.deleteFile(fileId);
+                    },
+                    successMessage: `Moved {count} images to provider trash`
+                });
+            },
+            async executeExport() {
+                const fileIds = [...state.grid.selected];
+                const filesToExport = fileIds.map(id => state.imageFiles.find(f => f.id === id)).filter(f => f);
+                const total = filesToExport.length; const results = []; let failures = 0;
+                Utils.elements.actionTitle.textContent = `Live Export: 0 of ${total}`;
+                Utils.elements.actionContent.innerHTML = `<div style="background: #111; border: 1px solid #333; color: #eee; font-family: monospace; font-size: 12px; height: 250px; overflow-y: scroll; padding: 8px; white-space: pre-wrap;" id="export-log"></div>`;
+                const logEl = document.getElementById('export-log');
+                Utils.elements.actionConfirm.disabled = true; Utils.elements.actionCancel.textContent = "Close";
+                const log = (message) => { logEl.textContent += message + '\n'; logEl.scrollTop = logEl.scrollHeight; };
+                log(`Starting export for ${total} images...`);
+                for (let i = 0; i < filesToExport.length; i++) {
+                    const file = filesToExport[i];
+                    Utils.elements.actionTitle.textContent = `Live Export: ${i + 1} of ${total}`;
+                    log(`\n[${i+1}/${total}] Processing: ${file.name}`);
+                    let extractedMetadata = {}; let success = false;
+                    for (let attempt = 1; attempt <= 3; attempt++) {
+                        try {
+                            const metadata = await state.metadataExtractor.fetchMetadata(file, true);
+                            if (metadata.error) throw new Error(metadata.error);
+                            extractedMetadata = metadata; log(`  ✅ Success`); success = true; break;
+                        } catch (error) {
+                            log(`  ⚠️ Attempt ${attempt} failed: ${error.message}`);
+                            if (attempt < 3) { const delay = 1000 * attempt; log(`     Retrying in ${delay / 1000}s...`); await new Promise(res => setTimeout(res, delay));
+                            } else { log(`  ❌ FAILED permanently after 3 attempts.`); failures++; }
+                        }
+                    }
+                    results.push({ ...file, extractedMetadata: extractedMetadata });
+                }
+                log('\n-------------------------------------');
+                log('Export process complete.'); log(`Successfully processed: ${total - failures} files.`); log(`Failed: ${failures} files.`);
+                if (results.length > 0) { state.export.exportData(results); log('CSV file has been generated and downloaded.');
+                } else { log('No data to export.'); }
+                Utils.elements.actionTitle.textContent = `Export Complete`;
+                Utils.elements.actionConfirm.disabled = true; Utils.elements.actionCancel.textContent = "Close";
+            },
+            executeFolderMove() {
+                state.folderMoveMode = { active: true, files: [...state.grid.selected], };
+                this.hide(); Grid.close(); App.returnToFolderSelection();
+                Utils.showToast(`Select destination folder for ${state.folderMoveMode.files.length} images`, 'info', true);
+            }
+        };
+        const Gestures = {
+            startPos: { x: 0, y: 0 },
+            currentPos: { x: 0, y: 0 },
+            startTimestamp: 0,
+            gestureStarted: false,
+            edgeElements: [],
+            hubPressActive: false,
+            overlay: null,
+            lastHubTap: { time: 0, x: 0, y: 0 },
+            DOUBLE_TAP_MAX_INTERVAL: 320,
+            DOUBLE_TAP_MAX_DISTANCE: 28,
+            TAP_DISTANCE_THRESHOLD: 26,
+            TAP_DURATION_THRESHOLD: 260,
+            TRAIL_INTERVAL_MS: 12,
+            TRAIL_LIFETIME_MS: 1050,
+            trailThrottle: null,
+            init() {
+                this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
+                this.setupEventListeners();
+                this.setupPinchZoom();
+                this.initGestureOverlay();
+            },
+            setupEventListeners() {
+                Utils.elements.imageViewport.addEventListener('mousedown', this.handleStart.bind(this));
+                document.addEventListener('mousemove', this.handleMove.bind(this));
+                document.addEventListener('mouseup', this.handleEnd.bind(this));
+                Utils.elements.imageViewport.addEventListener('touchstart', this.handleStart.bind(this), { passive: false });
+                document.addEventListener('touchmove', this.handleMove.bind(this), { passive: false });
+                document.addEventListener('touchend', this.handleEnd.bind(this), { passive: false });
+                document.addEventListener('touchcancel', this.handleEnd.bind(this), { passive: false });
+            },
+            setupPinchZoom() {
+                Utils.elements.centerImage.addEventListener('touchstart', this.handleTouchStart.bind(this), { passive: false });
+                Utils.elements.centerImage.addEventListener('touchmove', this.handleTouchMove.bind(this), { passive: false });
+                Utils.elements.centerImage.addEventListener('touchend', this.handleTouchEnd.bind(this), { passive: false });
+                Utils.elements.centerImage.addEventListener('wheel', this.handleWheel.bind(this), { passive: false });
+            },
+            initGestureOverlay() {
+                this.overlay = {
+                    layer: Utils.elements.gestureLayer,
+                    screenA: Utils.elements.gestureScreenA,
+                    screenB: Utils.elements.gestureScreenB,
+                    tri: {
+                        up: Utils.elements.gestureTriUp,
+                        right: Utils.elements.gestureTriRight,
+                        down: Utils.elements.gestureTriDown,
+                        left: Utils.elements.gestureTriLeft
+                    },
+                    half: {
+                        left: Utils.elements.gestureHalfLeft,
+                        right: Utils.elements.gestureHalfRight
+                    }
+                };
+                this.updateGestureOverlayMode();
+            },
+            spawnTrail(clientX, clientY) {
+                if (!this.overlay?.layer) return;
+                const rect = this.overlay.layer.getBoundingClientRect();
+                const trail = document.createElement('div');
+                trail.className = 'comet-trail';
+                trail.style.left = `${clientX - rect.left}px`;
+                trail.style.top = `${clientY - rect.top}px`;
+                this.overlay.layer.appendChild(trail);
+                setTimeout(() => trail.remove(), this.TRAIL_LIFETIME_MS);
+            },
+            spawnRipple(clientX, clientY) {
+                if (!this.overlay?.layer) return;
+                const rect = this.overlay.layer.getBoundingClientRect();
+                const ripple = document.createElement('div');
+                ripple.className = 'tap-ripple';
+                ripple.style.left = `${clientX - rect.left}px`;
+                ripple.style.top = `${clientY - rect.top}px`;
+                this.overlay.layer.appendChild(ripple);
+                setTimeout(() => ripple.remove(), 560);
+            },
+            queueTrail(clientX, clientY) {
+                if (this.trailThrottle) return;
+                this.spawnTrail(clientX, clientY);
+                this.trailThrottle = setTimeout(() => { this.trailThrottle = null; }, this.TRAIL_INTERVAL_MS);
+            },
+            flashElement(el) {
+                if (!el) return;
+                if (el._glowTimeout) clearTimeout(el._glowTimeout);
+                if (el._deglowTimeout) clearTimeout(el._deglowTimeout);
+                el.classList.add('glow');
+                el.classList.remove('deglow');
+                el._glowTimeout = setTimeout(() => {
+                    el.classList.remove('glow');
+                    el.classList.add('deglow');
+                    el._deglowTimeout = setTimeout(() => { el.classList.remove('deglow'); }, 260);
+                }, 220);
+            },
+            highlightSortDirection(direction) {
+                if (!this.overlay || !this.overlay.tri) return;
+                this.flashElement(this.overlay.tri[direction]);
+            },
+            highlightFocusDirection(direction) {
+                if (!this.overlay || !this.overlay.half) return;
+                this.flashElement(this.overlay.half[direction]);
+            },
+            updateGestureOverlayMode() {
+                if (!this.overlay) return;
+                const focus = state.isFocusMode;
+                if (this.overlay.screenA) {
+                    this.overlay.screenA.toggleAttribute('hidden', focus);
+                    this.overlay.screenA.setAttribute('aria-hidden', focus ? 'true' : 'false');
+                }
+                if (this.overlay.screenB) {
+                    this.overlay.screenB.toggleAttribute('hidden', !focus);
+                    this.overlay.screenB.setAttribute('aria-hidden', focus ? 'false' : 'true');
+                }
+            },
+            isInHub(clientX, clientY) {
+                const viewport = Utils.elements.imageViewport;
+                if (!viewport) return false;
+                const rect = viewport.getBoundingClientRect();
+                if (!rect.width || !rect.height) return false;
+                const cx = rect.left + rect.width / 2;
+                const cy = rect.top + rect.height / 2;
+                const radius = Math.min(rect.width, rect.height) * 0.12;
+                return Math.hypot(clientX - cx, clientY - cy) <= radius;
+            },
+            pointInTriangle(px, py, ax, ay, bx, by, cx, cy) {
+                const v0x = cx - ax, v0y = cy - ay;
+                const v1x = bx - ax, v1y = by - ay;
+                const v2x = px - ax, v2y = py - ay;
+                const dot00 = v0x * v0x + v0y * v0y;
+                const dot01 = v0x * v1x + v0y * v1y;
+                const dot02 = v0x * v2x + v0y * v2y;
+                const dot11 = v1x * v1x + v1y * v1y;
+                const dot12 = v1x * v2x + v1y * v2y;
+                const invDen = 1 / (dot00 * dot11 - dot01 * dot01);
+                const u = (dot11 * dot02 - dot01 * dot12) * invDen;
+                const v = (dot00 * dot12 - dot01 * dot02) * invDen;
+                return (u >= 0) && (v >= 0) && (u + v <= 1);
+            },
+            hitTriangle(clientX, clientY) {
+                const viewport = Utils.elements.imageViewport;
+                if (!viewport) return null;
+                const rect = viewport.getBoundingClientRect();
+                if (!rect.width || !rect.height) return null;
+                const fx = (clientX - rect.left) / rect.width;
+                const fy = (clientY - rect.top) / rect.height;
+                const clamp = (val) => Math.max(0, Math.min(1, val));
+                const px = clamp(fx);
+                const py = clamp(fy);
+                const cx = 0.5, cy = 0.5;
+                const inUp = this.pointInTriangle(px, py, 0, 0, 1, 0, cx, cy);
+                const inRight = this.pointInTriangle(px, py, 1, 0, 1, 1, cx, cy);
+                const inDown = this.pointInTriangle(px, py, 0, 1, 1, 1, cx, cy);
+                const inLeft = this.pointInTriangle(px, py, 0, 0, 0, 1, cx, cy);
+                if (inUp && !inRight && !inDown && !inLeft) return 'up';
+                if (inRight && !inUp && !inDown && !inLeft) return 'right';
+                if (inDown && !inUp && !inRight && !inLeft) return 'down';
+                if (inLeft && !inUp && !inRight && !inDown) return 'left';
+                if (inUp || inRight || inDown || inLeft) {
+                    const dx = px - 0.5;
+                    const dy = py - 0.5;
+                    if (Math.abs(dx) > Math.abs(dy)) return dx > 0 ? 'right' : 'left';
+                    return dy > 0 ? 'down' : 'up';
+                }
+                return null;
+            },
+            handleTap(clientX, clientY) {
+                if (state.isFocusMode) {
+                    const viewport = Utils.elements.imageViewport;
+                    if (!viewport) return;
+                    const rect = viewport.getBoundingClientRect();
+                    if (!rect.width) return;
+                    const fx = (clientX - rect.left) / rect.width;
+                    const direction = fx < 0.5 ? 'left' : 'right';
+                    this.highlightFocusDirection(direction);
+                    if (direction === 'left') { this.prevImage(); }
+                    else { this.nextImage(); }
+                    return;
+                }
+                const dir = this.hitTriangle(clientX, clientY);
+                if (!dir) return;
+                this.highlightSortDirection(dir);
+                const mapped = dir === 'up' ? 'top' : dir === 'down' ? 'bottom' : dir;
+                const targetStack = this.directionToStack(mapped);
+                if (targetStack) this.executeFlick(targetStack);
+            },
+            showEdgeGlow(direction) {
+                this.edgeElements.forEach(edge => edge.classList.remove('active'));
+                if (Utils.elements[`edge${direction.charAt(0).toUpperCase() + direction.slice(1)}`]) {
+                    Utils.elements[`edge${direction.charAt(0).toUpperCase() + direction.slice(1)}`].classList.add('active');
+                }
+            },
+            hideAllEdgeGlows() { this.edgeElements.forEach(edge => edge.classList.remove('active')); },
+            determineSwipeDirection(deltaX, deltaY) {
+                if (Math.abs(deltaX) > Math.abs(deltaY)) { return deltaX > 0 ? 'right' : 'left'; } else { return deltaY > 0 ? 'bottom' : 'top'; }
+            },
+            directionToStack(direction) {
+                const mapping = { 'top': 'priority', 'bottom': 'trash', 'left': 'in', 'right': 'out', 'up': 'priority', 'down': 'trash' };
+                return mapping[direction];
+            },
+            async executeFlick(targetStack) {
+                if (state.stacks[state.currentStack].length === 0) return;
+                try {
+                    UI.acknowledgePillCounter(targetStack);
+                    if (state.haptic) { state.haptic.triggerFeedback('swipe'); }
+                    await Core.moveToStack(targetStack);
+                    this.hideAllEdgeGlows();
+                } catch(error) {
+                    Utils.showToast(`Flick failed: ${error.message}`, 'error', true);
+                }
+            },
+            handleStart(e) {
+                if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
+                if (state.currentScale > 1.1) return;
+                const point = e.touches ? e.touches[0] : e;
+                const hubInteraction = this.isInHub(point.clientX, point.clientY);
+                if (!hubInteraction && state.stacks[state.currentStack].length === 0) return;
+                this.startPos = { x: point.clientX, y: point.clientY };
+                this.currentPos = { x: point.clientX, y: point.clientY };
+                this.startTimestamp = performance.now();
+                this.gestureStarted = false;
+                state.isDragging = true;
+                this.hubPressActive = hubInteraction;
+                if (!hubInteraction) {
+                    Utils.elements.centerImage.classList.add('dragging');
+                }
+                this.spawnRipple(point.clientX, point.clientY);
+                this.queueTrail(point.clientX, point.clientY);
+            },
+            handleMove(e) {
+                if (!state.isDragging) return;
+                if (e.touches && e.touches.length > 1) {
+                    state.isDragging = false; Utils.elements.centerImage.classList.remove('dragging');
+                    this.hideAllEdgeGlows(); return;
+                }
+                e.preventDefault();
+                const point = e.touches ? e.touches[0] : e;
+                this.currentPos = { x: point.clientX, y: point.clientY };
+                this.queueTrail(point.clientX, point.clientY);
+                if (this.hubPressActive) { return; }
+                if (state.imageFiles.length === 0) return;
+                const deltaX = this.currentPos.x - this.startPos.x;
+                const deltaY = this.currentPos.y - this.startPos.y;
+                const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+                if (distance > 30) {
+                    this.gestureStarted = true;
+                    if(!state.isFocusMode) {
+                        const direction = this.determineSwipeDirection(deltaX, deltaY);
+                        if (direction) { this.hideAllEdgeGlows(); this.showEdgeGlow(direction); }
+                    }
+                } else {
+                    if(!state.isFocusMode) this.hideAllEdgeGlows();
+                }
+            },
+            handleEnd(e) {
+                if (!state.isDragging) return;
+                state.isDragging = false;
+                Utils.elements.centerImage.classList.remove('dragging');
+                const point = e.changedTouches && e.changedTouches.length ? e.changedTouches[0] : e;
+                if (point) { this.currentPos = { x: point.clientX, y: point.clientY }; }
+                this.spawnTrail(this.currentPos.x, this.currentPos.y);
+                const deltaX = this.currentPos.x - this.startPos.x;
+                const deltaY = this.currentPos.y - this.startPos.y;
+                const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+                const now = performance.now();
+                const duration = now - this.startTimestamp;
+                const isTap = distance < this.TAP_DISTANCE_THRESHOLD && duration < this.TAP_DURATION_THRESHOLD;
+
+                if (this.hubPressActive) {
+                    if (isTap) {
+                        if (this.lastHubTap.time && (now - this.lastHubTap.time) <= this.DOUBLE_TAP_MAX_INTERVAL) {
+                            const tapDistance = Math.hypot(this.lastHubTap.x - this.currentPos.x, this.lastHubTap.y - this.currentPos.y);
+                            if (tapDistance <= this.DOUBLE_TAP_MAX_DISTANCE) {
+                                this.spawnRipple(this.currentPos.x, this.currentPos.y);
+                                this.toggleFocusMode();
+                                if (state.haptic) { state.haptic.triggerFeedback('buttonPress'); }
+                                this.lastHubTap = { time: 0, x: 0, y: 0 };
+                            } else {
+                                this.lastHubTap = { time: now, x: this.currentPos.x, y: this.currentPos.y };
+                            }
+                        } else {
+                            this.lastHubTap = { time: now, x: this.currentPos.x, y: this.currentPos.y };
+                        }
+                    } else {
+                        this.lastHubTap = { time: 0, x: 0, y: 0 };
+                    }
+                    this.hideAllEdgeGlows();
+                    this.hubPressActive = false;
+                    this.gestureStarted = false;
+                    return;
+                }
+
+                if (distance > 80) {
+                    if (state.isFocusMode) {
+                        const direction = deltaX < 0 ? 'right' : 'left';
+                        this.highlightFocusDirection(direction);
+                        if (deltaX < 0) { this.nextImage(); }
+                        else { this.prevImage(); }
+                    } else {
+                        const direction = this.determineSwipeDirection(deltaX, deltaY);
+                        const targetStack = this.directionToStack(direction);
+                        if (targetStack && direction) {
+                            const triDir = direction === 'top' ? 'up' : direction === 'bottom' ? 'down' : direction;
+                            this.highlightSortDirection(triDir);
+                            this.executeFlick(targetStack);
+                        }
+                    }
+                } else if (!this.gestureStarted && isTap) {
+                    this.spawnRipple(this.currentPos.x, this.currentPos.y);
+                    this.handleTap(this.currentPos.x, this.currentPos.y);
+                }
+                this.hideAllEdgeGlows();
+                this.hubPressActive = false;
+                this.gestureStarted = false;
+            },
+            getDistance(touch1, touch2) { const dx = touch1.clientX - touch2.clientX; const dy = touch1.clientY - touch2.clientY; return Math.sqrt(dx * dx + dy * dy); },
+            getCenter(touch1, touch2) { return { x: (touch1.clientX + touch2.clientX) / 2, y: (touch1.clientY + touch2.clientY) / 2 }; },
+            handleTouchStart(e) {
+                if (e.touches.length === 2) {
+                    e.preventDefault(); state.isPinching = true;
+                    state.initialDistance = this.getDistance(e.touches[0], e.touches[1]);
+                    state.lastTouchPos = this.getCenter(e.touches[0], e.touches[1]);
+                } else if (e.touches.length === 1 && state.currentScale > 1) { state.lastTouchPos = { x: e.touches[0].clientX, y: e.touches[0].clientY }; }
+            },
+            handleTouchMove(e) {
+                if (e.touches.length === 2 && state.isPinching) {
+                    e.preventDefault();
+                    const currentDistance = this.getDistance(e.touches[0], e.touches[1]);
+                    const scaleFactor = currentDistance / state.initialDistance;
+                    let newScale = state.currentScale * scaleFactor;
+                    newScale = Math.max(state.minScale, Math.min(state.maxScale, newScale));
+                    state.currentScale = newScale; state.initialDistance = currentDistance; Core.applyTransform();
+                } else if (e.touches.length === 1 && state.currentScale > 1) {
+                    e.preventDefault();
+                    const deltaX = e.touches[0].clientX - state.lastTouchPos.x;
+                    const deltaY = e.touches[0].clientY - state.lastTouchPos.y;
+                    state.panOffset.x += deltaX / state.currentScale;
+                    state.panOffset.y += deltaY / state.currentScale;
+                    state.lastTouchPos = { x: e.touches[0].clientX, y: e.touches[0].clientY }; Core.applyTransform();
+                }
+            },
+            handleTouchEnd(e) {
+                if (e.touches.length < 2) { state.isPinching = false; }
+                if (state.currentScale < 1.1) { state.currentScale = 1; state.panOffset = { x: 0, y: 0 }; Core.applyTransform(); }
+            },
+            handleWheel(e) {
+                e.preventDefault();
+                const scaleChange = e.deltaY > 0 ? 0.9 : 1.1;
+                let newScale = state.currentScale * scaleChange;
+                newScale = Math.max(state.minScale, Math.min(state.maxScale, newScale));
+                state.currentScale = newScale;
+                if (state.currentScale <= 1.1) { state.currentScale = 1; state.panOffset = { x: 0, y: 0 }; }
+                Core.applyTransform();
+            },
+            toggleFocusMode() {
+                state.isFocusMode = !state.isFocusMode;
+                Utils.elements.appContainer.classList.toggle('focus-mode', state.isFocusMode);
+                this.updateGestureOverlayMode();
+                Core.updateImageCounters();
+                this.lastHubTap = { time: 0, x: 0, y: 0 };
+            },
+            async nextImage() {
+                const stack = state.stacks[state.currentStack];
+                if (stack.length === 0) return;
+                state.currentStackPosition = (state.currentStackPosition + 1) % stack.length;
+                await Core.displayCurrentImage();
+            },
+            async prevImage() {
+                const stack = state.stacks[state.currentStack];
+                if (stack.length === 0) return;
+                state.currentStackPosition = (state.currentStackPosition - 1 + stack.length) % stack.length;
+                await Core.displayCurrentImage();
+            },
+            async deleteCurrentImage() {
+                const currentStackArray = state.stacks[state.currentStack];
+                if (currentStackArray.length === 0) return;
+                const fileToDelete = currentStackArray[state.currentStackPosition];
+                try {
+                    await App.deleteFile(fileToDelete.id);
+                    Core.updateStackCounts();
+                    if (currentStackArray.length === 0) { this.toggleFocusMode(); Core.showEmptyState();
+                    } else { await Core.displayCurrentImage(); }
+                } catch (error) { Utils.showToast(`Failed to delete ${fileToDelete.name}`, 'error', true); }
+            }
+        };
+        const Folders = {
+            async load() {
+                const { folderList, folderTitle } = Utils.elements;
+                folderTitle.textContent = `${state.providerType === 'googledrive' ? 'Google Drive' : 'OneDrive'} - Select Folder`;
+                folderList.innerHTML = `<div style="display: flex; align-items: center; justify-content: center; padding: 40px; color: rgba(255, 255, 255, 0.7);"><div class="spinner"></div><span>Loading folders...</span></div>`;
+                try {
+                    const folders = await state.provider.getFolders();
+                    this.display(folders);
+                    this.updateNavigation();
+                } catch (error) {
+                    Utils.showToast(`Error loading folders: ${error.message}`, 'error', true);
+                    folderList.innerHTML = `<div style="text-align: center; padding: 40px; color: #ef4444;">
+                                                <span>Failed to load folders.</span>
+                                                <button id="retry-folders" class="folder-action-btn" style="margin-top: 15px;">Retry</button>
+                                            </div>`;
+                    document.getElementById('retry-folders').addEventListener('click', () => this.load());
+                }
+            },
+
+            display(folders) {
+                const { folderList } = Utils.elements;
+                folderList.innerHTML = '';
+                if (!folders || folders.length === 0) {
+                    folderList.innerHTML = `<div style="text-align: center; padding: 40px; color: rgba(255, 255, 255, 0.7);"><span>No folders found</span></div>`;
+                    return;
+                }
+
+                folders.forEach(folder => {
+                    const div = document.createElement('div');
+                    div.className = 'folder-item';
+
+                    let dateInfo = new Date(folder.modifiedTime).toLocaleDateString();
+                    if (folder.itemCount > 0) {
+                         dateInfo += ` • ${folder.itemCount} items`;
+                    }
+                    if (folder.hasChildren) {
+                        dateInfo += ` • Has subfolders`;
+                    }
+
+                    const iconColor = folder.hasChildren ? 'var(--accent)' : 'rgba(255, 255, 255, 0.6)';
+
+                    div.innerHTML = `<svg class="folder-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" style="color: ${iconColor};"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"></path></svg>
+                                     <div class="folder-info">
+                                         <div class="folder-name">${folder.name}</div>
+                                         <div class="folder-date">${dateInfo}</div>
+                                     </div>
+                                     <div class="folder-actions">
+                                         ${folder.hasChildren ? `<button class="folder-action-btn drill-btn" data-folder-id="${folder.id}" data-folder-name="${folder.name}">Browse →</button>` : ''}
+                                         <button class="folder-action-btn select-btn" data-folder-id="${folder.id}" data-folder-name="${folder.name}">Select</button>
+                                     </div>`;
+                    folderList.appendChild(div);
+                });
+
+                this.addEventListeners();
+            },
+
+            addEventListeners() {
+                document.querySelectorAll('#folder-list .drill-btn').forEach(btn => {
+                    btn.addEventListener('click', async (e) => {
+                        e.stopPropagation();
+                        try {
+                            const { folderId, folderName } = e.target.dataset;
+                            const subfolders = await state.provider.drillIntoFolder({ id: folderId, name: folderName });
+                            this.display(subfolders);
+                            this.updateNavigation();
+                        } catch (error) {
+                             Utils.showToast(`Error browsing folder: ${error.message}`, 'error', true);
+                        }
+                    });
+                });
+                document.querySelectorAll('#folder-list .select-btn').forEach(btn => {
+                    btn.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        const { folderId, folderName } = e.target.dataset;
+                        if (state.folderMoveMode.active) {
+                            this.handleFolderMoveSelection(folderId, folderName);
+                        } else {
+                            App.initializeWithProvider(state.providerType, folderId, folderName, state.provider);
+                        }
+                    });
+                });
+            },
+
+            updateNavigation() {
+                const { folderSubtitle, folderRefreshButton } = Utils.elements;
+                const provider = state.provider;
+
+                if (typeof provider.getCurrentPath === 'function' && provider.getCurrentPath()) {
+                    folderSubtitle.textContent = `Current: ${provider.getCurrentPath()}`;
+                    folderSubtitle.classList.remove('hidden');
+                } else {
+                    folderSubtitle.classList.add('hidden');
+                }
+
+                if (typeof provider.canGoUp === 'function' && provider.canGoUp()) {
+                    folderRefreshButton.textContent = '← Go Up';
+                } else {
+                    folderRefreshButton.textContent = 'Refresh';
+                }
+            },
+
+            async handleFolderMoveSelection(folderId, folderName) {
+                const filesToMove = state.folderMoveMode.files;
+                Utils.showScreen('loading-screen'); Utils.updateLoadingProgress(0, filesToMove.length);
+                try {
+                    for(let i = 0; i < filesToMove.length; i++) {
+                        const fileId = filesToMove[i];
+                        await state.provider.moveFileToFolder(fileId, folderId);
+                        const fileIndex = state.imageFiles.findIndex(f => f.id === fileId);
+                        if (fileIndex > -1) {
+                            const [file] = state.imageFiles.splice(fileIndex, 1);
+                            const stackIndex = state.stacks[file.stack].findIndex(f => f.id === fileId);
+                            if (stackIndex > -1) { state.stacks[file.stack].splice(stackIndex, 1); }
+                        }
+                        Utils.updateLoadingProgress(i + 1, filesToMove.length);
+                    }
+                    Utils.showToast(`Moved ${filesToMove.length} images to ${folderName}`, 'success', true);
+                    await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
+                    state.folderMoveMode = { active: false, files: [] };
+                    Core.initializeStacks(); Core.updateStackCounts(); App.returnToFolderSelection();
+                } catch (error) { Utils.showToast('Error moving files', 'error', true); App.returnToFolderSelection(); }
+            },
+            updateOneDriveNavigation() {
+                const currentPath = state.provider.getCurrentPath();
+                const canGoUp = state.provider.canGoUp();
+                Utils.elements.onedriveFolderSubtitle.textContent = `Current: ${currentPath}`;
+                const refreshBtn = Utils.elements.onedriveRefreshFolders;
+                if (canGoUp) {
+                    refreshBtn.textContent = '← Go Up';
+                    refreshBtn.onclick = async () => {
+                        try {
+                            const folders = await state.provider.navigateToParent();
+                            this.displayOneDriveFolders(folders); this.updateOneDriveNavigation();
+                        } catch (error) { Utils.showToast('Error navigating to parent folder', 'error', true); }
+                    };
+                } else {
+                    refreshBtn.textContent = 'Refresh';
+                    refreshBtn.onclick = () => this.loadOneDriveFolders();
+                }
+            }
+        };
+        const UI = {
+            updateEmptyStateButtons() {
+                const stacksWithImages = STACKS.filter(stack => state.stacks[stack].length > 0);
+                const hasOtherStacks = stacksWithImages.some(stack => stack !== state.currentStack);
+                Utils.elements.selectAnotherStackBtn.style.display = hasOtherStacks ? 'block' : 'none';
+                Utils.elements.selectAnotherFolderBtn.style.display = 'block';
+            },
+            acknowledgePillCounter(stackName) {
+                const pill = document.getElementById(`pill-${stackName}`);
+                if (pill) {
+                    pill.classList.remove('triple-ripple', 'glow-effect');
+                    pill.offsetHeight; pill.classList.add('triple-ripple');
+                    setTimeout(() => { pill.classList.add('glow-effect'); }, 100);
+                    setTimeout(() => { pill.classList.remove('triple-ripple', 'glow-effect'); }, 3000);
+                }
+            },
+            switchToStack(stackName) { Core.displayTopImageFromStack(stackName); },
+            cycleThroughPills() {
+                const stackOrder = ['in', 'out', 'priority', 'trash'];
+                const currentIndex = stackOrder.indexOf(state.currentStack);
+                const nextIndex = (currentIndex + 1) % stackOrder.length;
+                const nextStack = stackOrder[nextIndex];
+                this.switchToStack(nextStack);
+            }
+        };
+        const DraggableResizable = {
+            init(modal, header) {
+                let pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
+                let isDragging = false;
+                
+                header.onmousedown = dragMouseDown;
+
+                function dragMouseDown(e) {
+                    e = e || window.event;
+                    e.preventDefault();
+                    pos3 = e.clientX;
+                    pos4 = e.clientY;
+                    isDragging = true;
+                    document.onmouseup = closeDragElement;
+                    document.onmousemove = elementDrag;
+                }
+
+                function elementDrag(e) {
+                    if (!isDragging) return;
+                    e = e || window.event;
+                    e.preventDefault();
+                    pos1 = pos3 - e.clientX;
+                    pos2 = pos4 - e.clientY;
+                    pos3 = e.clientX;
+                    pos4 = e.clientY;
+                    
+                    let newTop = modal.offsetTop - pos2;
+                    let newLeft = modal.offsetLeft - pos1;
+
+                    // Boundary checks
+                    const parent = modal.parentElement;
+                    if (newTop < 0) newTop = 0;
+                    if (newLeft < 0) newLeft = 0;
+                    if (newTop + modal.offsetHeight > parent.clientHeight) newTop = parent.clientHeight - modal.offsetHeight;
+                    if (newLeft + modal.offsetWidth > parent.clientWidth) newLeft = parent.clientWidth - modal.offsetWidth;
+
+                    modal.style.top = newTop + "px";
+                    modal.style.left = newLeft + "px";
+                }
+
+                function closeDragElement() {
+                    isDragging = false;
+                    document.onmouseup = null;
+                    document.onmousemove = null;
+                }
+
+                header.ondblclick = () => {
+                     if (modal.id === 'details-modal') {
+                        modal.style.top = '50%';
+                        modal.style.left = '50%';
+                        modal.style.transform = 'translate(-50%, -50%)';
+                        modal.style.width = '800px';
+                        modal.style.height = '95vh';
+                    } else if (modal.id === 'grid-modal') {
+                        modal.style.top = '0px';
+                        modal.style.left = '0px';
+                        modal.style.width = '100%';
+                        modal.style.height = '100%';
+                        modal.style.maxHeight = '100vh';
+                        modal.style.maxWidth = '100vw';
+                        modal.style.transform = 'none';
+                        Utils.elements.gridContent.scrollTop = 0;
+                    }
+                };
+            }
+        };
+        const Events = {
+            init() {
+                this.setupProviderSelection(); this.setupSettings(); this.setupAuth();
+                this.setupFolderManagement(); this.setupLoadingScreen();
+                this.setupDetailsModal(); this.setupFocusMode(); this.setupTabs();
+                this.setupCopyButtons(); this.setupEmptyState(); this.setupPillCounters();
+                this.setupGridControls(); this.setupSearchFunctionality(); this.setupActionButtons();
+                this.setupKeyboardNavigation();
+                this.setupDraggables();
+            },
+            setupDraggables() {
+                DraggableResizable.init(Utils.elements.detailsModal.querySelector('.modal-content'), Utils.elements.detailsModalHeader);
+                DraggableResizable.init(Utils.elements.gridModal.querySelector('.modal-content'), Utils.elements.gridModalHeaderMain);
+            },
+            setupProviderSelection() {
+                Utils.elements.googleDriveBtn.addEventListener('click', () => App.selectProvider('googledrive'));
+                Utils.elements.onedriveBtn.addEventListener('click', () => App.selectProvider('onedrive'));
+            },
+            setupSettings() {
+                document.querySelectorAll('.intensity-btn').forEach(btn => {
+                    btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
+                });
+                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+            },
+            setupAuth() {
+                Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
+                Utils.elements.authBackButton.addEventListener('click', () => App.backToProviderSelection());
+            },
+            setupFolderManagement() {
+                Utils.elements.backButton.addEventListener('click', () => App.returnToFolderSelection());
+
+                Utils.elements.folderBackButton.addEventListener('click', () => App.backToProviderSelection());
+                Utils.elements.folderLogoutButton.addEventListener('click', async () => {
+                    try {
+                        if (state.provider) {
+                            await state.provider.disconnect();
+                        }
+                        App.backToProviderSelection();
+                    } catch (error) {
+                        Utils.showToast(`Logout failed: ${error.message}`, 'error', true);
+                    }
+                });
+
+                Utils.elements.folderRefreshButton.addEventListener('click', async () => {
+                    try {
+                        const provider = state.provider;
+                        if (typeof provider.canGoUp === 'function' && provider.canGoUp()) {
+                            const folders = await provider.navigateToParent();
+                            Folders.display(folders);
+                            Folders.updateNavigation();
+                        } else {
+                            await Folders.load();
+                        }
+                    } catch (error) {
+                        Utils.showToast(`Folder navigation failed: ${error.message}`, 'error', true);
+                    }
+                });
+            },
+            setupLoadingScreen() {
+                Utils.elements.cancelLoading.addEventListener('click', () => {
+                    if (state.metadataExtractor) { state.metadataExtractor.abort(); }
+                    state.activeRequests.abort();
+                    App.returnToFolderSelection();
+                    Utils.showToast('Loading cancelled', 'info', true);
+                });
+            },
+            setupDetailsModal() {
+                Utils.elements.detailsButton.addEventListener('click', () => { if (state.stacks[state.currentStack].length > 0) { Details.show(); } });
+                Utils.elements.detailsClose.addEventListener('click', () => Details.hide());
+            },
+            setupFocusMode() {
+                Utils.elements.centerTrashBtn.addEventListener('click', () => Core.moveToStack('trash'));
+                Utils.elements.focusStackName.addEventListener('click', () => Modal.setupFocusStackSwitch());
+                Utils.elements.focusDeleteBtn.addEventListener('click', () => Gestures.deleteCurrentImage());
+                Utils.elements.focusFavoriteBtn.addEventListener('click', async () => {
+                    try {
+                        const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
+                        if (!currentFile) return;
+                        const isFavorite = !currentFile.favorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        Core.updateFavoriteButton();
+                    } catch (error) {
+                         Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);
+                    }
+                });
+            },
+            setupTabs() { document.querySelectorAll('.tab-button').forEach(btn => { btn.addEventListener('click', () => Details.switchTab(btn.dataset.tab)); }); },
+            setupCopyButtons() {
+                document.addEventListener('click', (e) => {
+                    if (e.target.classList.contains('copy-metadata')) {
+                        const value = e.target.dataset.value; const button = e.target;
+                        button.classList.add('copied'); const originalText = button.textContent; button.textContent = '✓';
+                        Details.copyToClipboard(value);
+                        setTimeout(() => { button.classList.remove('copied'); button.textContent = originalText; }, 1000);
+                    }
+                });
+            },
+            setupEmptyState() {
+                Utils.elements.selectAnotherStackBtn.addEventListener('click', () => {
+                    const stacksWithImages = STACKS.filter(stack => state.stacks[stack].length > 0);
+                    if (stacksWithImages.length > 0) {
+                        const nextStack = stacksWithImages.find(stack => stack !== state.currentStack) || stacksWithImages[0];
+                        UI.switchToStack(nextStack);
+                    } else {
+                        Utils.elements.selectAnotherStackBtn.style.display = 'none';
+                        Utils.elements.selectAnotherFolderBtn.style.display = 'block';
+                    }
+                });
+                Utils.elements.selectAnotherFolderBtn.addEventListener('click', () => { App.returnToFolderSelection(); });
+            },
+            setupPillCounters() {
+                STACKS.forEach(stackName => {
+                    const pill = document.getElementById(`pill-${stackName}`);
+                    if (pill) {
+                        pill.addEventListener('click', (e) => {
+                            e.stopPropagation();
+                            if (state.haptic) { state.haptic.triggerFeedback('pillTap'); }
+                             if (state.currentStack === stackName) {
+                                Grid.open(stackName);
+                            } else {
+                                UI.switchToStack(stackName);
+                            }
+                            UI.acknowledgePillCounter(stackName);
+                        });
+                    }
+                });
+            },
+            setupGridControls() {
+                Utils.elements.closeGrid.addEventListener('click', () => Grid.close());
+                Utils.elements.selectAllBtn.addEventListener('click', () => Grid.selectAll());
+                Utils.elements.deselectAllBtn.addEventListener('click', () => Grid.deselectAll());
+                Utils.elements.gridSize.addEventListener('input', () => {
+                    const value = Utils.elements.gridSize.value;
+                    Utils.elements.gridSizeValue.textContent = value;
+                    Utils.elements.gridContainer.style.gridTemplateColumns = `repeat(${value}, 1fr)`;
+                });
+            },
+            setupSearchFunctionality() {
+                Utils.elements.omniSearch.addEventListener('input', () => Grid.performSearch());
+                Utils.elements.clearSearchBtn.addEventListener('click', () => Grid.resetSearch());
+                document.querySelectorAll('.modifier-link').forEach(link => {
+                    link.addEventListener('click', (e) => {
+                        e.preventDefault();
+                        const modifier = e.target.dataset.modifier;
+                        const searchInput = Utils.elements.omniSearch;
+                        searchInput.value += ` ${modifier} `;
+                        searchInput.focus();
+                        Grid.performSearch();
+                    });
+                });
+            },
+            setupActionButtons() {
+                Utils.elements.moveSelected.addEventListener('click', () => Modal.setupMoveAction());
+                Utils.elements.tagSelected.addEventListener('click', () => Modal.setupTagAction());
+                Utils.elements.deleteSelected.addEventListener('click', () => Modal.setupDeleteAction());
+                Utils.elements.exportSelected.addEventListener('click', () => Modal.setupExportAction());
+                Utils.elements.folderSelected.addEventListener('click', () => Modal.setupFolderMoveAction());
+                Utils.elements.actionCancel.addEventListener('click', () => Modal.hide());
+                Utils.elements.actionConfirm.addEventListener('click', async () => {
+                    try {
+                        if (Modal.currentAction === 'move') { /* handled by buttons */
+                        } else if (Modal.currentAction === 'tag') { await Modal.executeTag();
+                        } else if (Modal.currentAction === 'delete') { await Modal.executeDelete();
+                        } else if (Modal.currentAction === 'export') { await Modal.executeExport();
+                        } else if (Modal.currentAction === 'folder-move') { Modal.executeFolderMove(); }
+                    } catch (error) {
+                        Utils.showToast(`Action failed: ${error.message}`, 'error', true);
+                    }
+                });
+            },
+            setupKeyboardNavigation() {
+                document.addEventListener('keydown', async (e) => {
+                    if (Utils.elements.appContainer.classList.contains('hidden')) return;
+                    if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
+                    if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
+                    if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
+                    
+                    try {
+                        if (state.isFocusMode) {
+                            if (e.key === 'ArrowRight') await Gestures.nextImage();
+                            if (e.key === 'ArrowLeft') await Gestures.prevImage();
+                            if (e.key === 'Escape') Gestures.toggleFocusMode();
+                            return;
+                        }
+                        const keyMap = { 'ArrowUp': 'priority', 'ArrowDown': 'trash', 'ArrowLeft': 'in', 'ArrowRight': 'out' };
+                        if (keyMap[e.key]) {
+                            e.preventDefault();
+                            const targetStack = keyMap[e.key];
+                            if (state.stacks[state.currentStack].length > 0) { 
+                                UI.acknowledgePillCounter(targetStack); 
+                                await Core.moveToStack(targetStack); 
+                            }
+                            return;
+                        }
+                        switch (e.key) {
+                            case 'Tab': e.preventDefault(); UI.cycleThroughPills(); break;
+                            case 'Escape': await App.returnToFolderSelection(); break;
+                        }
+                    } catch (error) {
+                        Utils.showToast(`Keyboard command failed: ${error.message}`, 'error', true);
+                    }
+                });
+            }
+        };
+        async function initApp() {
+            try {
+                Utils.init();
+                state.visualCues = new VisualCueManager();
+                state.haptic = new HapticFeedbackManager();
+                state.export = new ExportSystem();
+                state.dbManager = new DBManager();
+                await state.dbManager.init();
+                state.syncManager = new SyncManager();
+                state.metadataExtractor = new MetadataExtractor();
+                Utils.showScreen('provider-screen');
+                Events.init();
+                Gestures.init();
+                Core.updateActiveProxTab();
+            } catch (error) {
+                console.error("Fatal initialization error:", error);
+                const body = document.body;
+                body.innerHTML = `<div style="color: red; padding: 20px; font-family: sans-serif; text-align: center;">
+                                    <h1>Application Failed to Start</h1>
+                                    <p>A critical error occurred: ${error.message}</p>
+                                    <p>Please try refreshing the page or clearing application data.</p>
+                                  </div>`;
+            }
+        }
+        document.addEventListener('DOMContentLoaded', initApp);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show cached images instantly when a folder opens but always follow with a cloud sync to reconcile updates
- preserve the current selection while background refreshes merge cloud changes and retry OneDrive authentication if tokens expire
- refresh folder, auth, and footer timestamps to the latest build marker

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cebaae5cf0832da0500ae6eefa9c36