### PR TITLE
Bump IndexedDB schema version and upgrade handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1166,17 +1166,22 @@
             constructor() { this.db = null; }
             async init() {
                 return new Promise((resolve, reject) => {
-                    const request = indexedDB.open('Orbital8-Goji-V1', 1);
+                    const request = indexedDB.open('Orbital8-Goji-V1', 2);
                     request.onupgradeneeded = (event) => {
                         const db = event.target.result;
-                        if (!db.objectStoreNames.contains('folderCache')) {
+                        const oldVersion = event.oldVersion || 0;
+
+                        if (oldVersion < 1 && !db.objectStoreNames.contains('folderCache')) {
                             db.createObjectStore('folderCache', { keyPath: 'folderId' });
                         }
-                        if (!db.objectStoreNames.contains('metadata')) {
-                            db.createObjectStore('metadata', { keyPath: 'id' });
-                        }
-                        if (!db.objectStoreNames.contains('syncQueue')) {
-                            db.createObjectStore('syncQueue', { keyPath: 'id', autoIncrement: true });
+
+                        if (oldVersion < 2) {
+                            if (!db.objectStoreNames.contains('metadata')) {
+                                db.createObjectStore('metadata', { keyPath: 'id' });
+                            }
+                            if (!db.objectStoreNames.contains('syncQueue')) {
+                                db.createObjectStore('syncQueue', { keyPath: 'id', autoIncrement: true });
+                            }
                         }
                     };
                     request.onsuccess = (event) => { this.db = event.target.result; resolve(); };


### PR DESCRIPTION
## Summary
- open the Orbital8 IndexedDB database at schema version 2
- gate object store creation logic on the previous schema version to ensure upgrades create missing stores

## Testing
- not run (requires manual browser testing)


------
https://chatgpt.com/codex/tasks/task_e_68cf976325ec832d8d84eb77764d2026