### PR TITLE
Process cached metadata before rendering stacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1815,13 +1815,10 @@
                 }
 
                 state.imageFiles = cachedFiles;
+                await this.processAllMetadata(state.imageFiles);
                 Utils.showScreen('app-container');
                 Core.initializeStacks();
                 Core.initializeImageDisplay();
-                const pendingPngs = state.imageFiles.filter(file => file.mimeType === 'image/png' && file.metadataStatus === 'pending');
-                if (pendingPngs.length > 0) {
-                    this.extractMetadataInBackground(pendingPngs);
-                }
             },
             mergeCloudWithCache(cloudFiles, cachedFiles) {
                 const cachedMap = new Map(cachedFiles.map(file => [file.id, file]));


### PR DESCRIPTION
## Summary
- process cached folder entries through metadata merging before rendering so persisted metadata is applied
- remove the redundant pending PNG scan because metadata processing triggers background extraction

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf9970d96c832db6dbd3b0a1fac2d8