### PR TITLE
Fix IndexedDB initialization in ui-v3

### DIFF
--- a/ui-v3.html
+++ b/ui-v3.html
@@ -1209,17 +1209,22 @@
             constructor() { this.db = null; }
             async init() {
                 return new Promise((resolve, reject) => {
-                    const request = indexedDB.open('Orbital8-Goji-V1', 1);
+                    const request = indexedDB.open('Orbital8-Goji-V1', 2);
                     request.onupgradeneeded = (event) => {
                         const db = event.target.result;
-                        if (!db.objectStoreNames.contains('folderCache')) {
+                        const oldVersion = event.oldVersion || 0;
+
+                        if (oldVersion < 1 && !db.objectStoreNames.contains('folderCache')) {
                             db.createObjectStore('folderCache', { keyPath: 'folderId' });
                         }
-                        if (!db.objectStoreNames.contains('metadata')) {
-                            db.createObjectStore('metadata', { keyPath: 'id' });
-                        }
-                        if (!db.objectStoreNames.contains('syncQueue')) {
-                            db.createObjectStore('syncQueue', { keyPath: 'id', autoIncrement: true });
+
+                        if (oldVersion < 2) {
+                            if (!db.objectStoreNames.contains('metadata')) {
+                                db.createObjectStore('metadata', { keyPath: 'id' });
+                            }
+                            if (!db.objectStoreNames.contains('syncQueue')) {
+                                db.createObjectStore('syncQueue', { keyPath: 'id', autoIncrement: true });
+                            }
                         }
                     };
                     request.onsuccess = (event) => { this.db = event.target.result; resolve(); };


### PR DESCRIPTION
## Summary
- align the ui-v3 DBManager init sequence with index.html by opening IndexedDB at version 2
- guard object store creation by oldVersion so existing folderCache, metadata, and syncQueue stores remain available

## Testing
- npm run build
- python - <<'PY' ... (Playwright smoke test verifying provider buttons reach the auth screen)


------
https://chatgpt.com/codex/tasks/task_e_68cfa7018a2c832d814362b29260ea66