### PR TITLE
Port viewport sizing and focus toggle changes to ui-v3

### DIFF
--- a/ui-v3.html
+++ b/ui-v3.html
@@ -16,12 +16,15 @@
             --dark: linear-gradient(135deg, #0f0f0f 0%, #1a1a1a 100%);
             --glow: 0.6;
             --ripple: 1500ms;
+            --app-height: 100vh;
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
-            margin: 0; padding: 0; height: 100%;
+            margin: 0; padding: 0;
+            height: var(--app-height);
+            min-height: var(--app-height);
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
@@ -165,11 +168,11 @@
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
         
-        .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
+        .app-container { position: relative; width: 100vw; height: var(--app-height); background: var(--dark); overflow: hidden; }
         
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
-            max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
+            max-width: 100vw; max-height: var(--app-height); width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
             transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94), opacity 0.2s ease; transform-origin: center center; cursor: grab;
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
@@ -254,7 +257,7 @@
         .modal.hidden { display: none !important; }
         .modal-content {
             background: white; border-radius: 8px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-            width: 100%; height: 100%; max-width: 1152px; max-height: 90vh; margin: 16px;
+            width: 100%; height: 100%; max-width: 1152px; max-height: calc(var(--app-height) * 0.9); margin: 16px;
             display: flex; flex-direction: column;
             position: absolute; /* For dragging */
         }
@@ -373,8 +376,8 @@
             opacity: 1;
         }
         
-        .details-modal-content { 
-            max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
+        .details-modal-content {
+            max-width: 800px; max-height: calc(var(--app-height) * 0.95); height: calc(var(--app-height) * 0.95); display: flex; flex-direction: column;
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
         .details-header { 
@@ -463,6 +466,11 @@
             cursor: pointer;
             position: absolute;
         }
+        .ui-button[aria-disabled="true"] {
+            opacity: 0.5;
+            cursor: default;
+            pointer-events: none;
+        }
 
         /* Applying standardized UI styles */
         #back-button { top: 20px; left: 20px; }
@@ -515,7 +523,7 @@
         .hidden { display: none !important; }
         
         @supports (height: 100dvh) {
-            .app-container, .image-viewport { height: 100dvh; }
+            :root { --app-height: 100dvh; }
         }
 
         /* Gesture overlay inspired by ui.html */
@@ -563,19 +571,6 @@
             right: 12px;
             border-radius: 16px;
             background: transparent;
-        }
-        .gesture-layer .hub {
-            position: absolute;
-            left: 50%;
-            top: 50%;
-            transform: translate(-50%, -50%);
-            width: min(18vw, 18vh);
-            height: min(18vw, 18vh);
-            border-radius: 50%;
-            border: 1px solid transparent;
-            background: transparent;
-            pointer-events: none;
-            z-index: 40;
         }
         .gesture-layer .glow {
             opacity: 0 !important;
@@ -675,7 +670,7 @@
     
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
-        <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
+        <div class="card" style="max-height: calc(var(--app-height) * 0.8); display: flex; flex-direction: column;">
             <h2 class="title" id="folder-title">Select Folder</h2>
             <div class="subtitle" id="folder-subtitle">Choose a folder containing images</div>
             <div class="folder-list" id="folder-list"></div>
@@ -716,18 +711,16 @@
         <!-- Gesture overlay (triangular sort zones + focus halves) -->
         <div class="gesture-layer" id="gesture-layer">
             <div id="gesture-screen-a" class="stage" role="application"
-                 aria-label="Sort mode. Triangular flick zones. Double-tap center hub to enter focus mode.">
+                 aria-label="Sort mode. Triangular flick zones. Tap the item counter to enter focus mode.">
                 <div id="gesture-tri-up" class="tri up"></div>
                 <div id="gesture-tri-right" class="tri right"></div>
                 <div id="gesture-tri-down" class="tri down"></div>
                 <div id="gesture-tri-left" class="tri left"></div>
-                <div class="hub" id="gesture-hub-a"></div>
             </div>
             <div id="gesture-screen-b" class="stage" role="application"
-                 aria-label="Focus mode. Left/right review halves. Double-tap center hub to return to sort mode." hidden>
+                 aria-label="Focus mode. Left/right review halves. Tap the item counter to return to sort mode." hidden>
                 <div id="gesture-half-left" class="half left"></div>
                 <div id="gesture-half-right" class="half right"></div>
-                <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
         
@@ -748,7 +741,7 @@
         </div>
         
         <!-- Center Stage UI -->
-        <div id="normal-image-count" class="ui-button"></div>
+        <div id="normal-image-count" class="ui-button" role="button" tabindex="0" aria-pressed="false" aria-disabled="true"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
@@ -2582,6 +2575,7 @@
                 if (Utils.elements.normalImageCount) {
                     Utils.elements.normalImageCount.textContent = counterText;
                     Utils.elements.normalImageCount.setAttribute('aria-label', counterText);
+                    Utils.elements.normalImageCount.setAttribute('aria-disabled', total > 0 ? 'false' : 'true');
                 }
                 if (Utils.elements.focusImageCount) {
                     Utils.elements.focusImageCount.textContent = counterText;
@@ -3353,11 +3347,7 @@
             startTimestamp: 0,
             gestureStarted: false,
             edgeElements: [],
-            hubPressActive: false,
             overlay: null,
-            lastHubTap: { time: 0, x: 0, y: 0 },
-            DOUBLE_TAP_MAX_INTERVAL: 320,
-            DOUBLE_TAP_MAX_DISTANCE: 28,
             TAP_DISTANCE_THRESHOLD: 26,
             TAP_DURATION_THRESHOLD: 260,
             TRAIL_INTERVAL_MS: 12,
@@ -3459,16 +3449,6 @@
                     this.overlay.screenB.setAttribute('aria-hidden', focus ? 'false' : 'true');
                 }
             },
-            isInHub(clientX, clientY) {
-                const viewport = Utils.elements.imageViewport;
-                if (!viewport) return false;
-                const rect = viewport.getBoundingClientRect();
-                if (!rect.width || !rect.height) return false;
-                const cx = rect.left + rect.width / 2;
-                const cy = rect.top + rect.height / 2;
-                const radius = Math.min(rect.width, rect.height) * 0.12;
-                return Math.hypot(clientX - cx, clientY - cy) <= radius;
-            },
             pointInTriangle(px, py, ax, ay, bx, by, cx, cy) {
                 const v0x = cx - ax, v0y = cy - ay;
                 const v1x = bx - ax, v1y = by - ay;
@@ -3559,17 +3539,13 @@
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
                 const point = e.touches ? e.touches[0] : e;
-                const hubInteraction = this.isInHub(point.clientX, point.clientY);
-                if (!hubInteraction && state.stacks[state.currentStack].length === 0) return;
+                if (state.stacks[state.currentStack].length === 0) return;
                 this.startPos = { x: point.clientX, y: point.clientY };
                 this.currentPos = { x: point.clientX, y: point.clientY };
                 this.startTimestamp = performance.now();
                 this.gestureStarted = false;
                 state.isDragging = true;
-                this.hubPressActive = hubInteraction;
-                if (!hubInteraction) {
-                    Utils.elements.centerImage.classList.add('dragging');
-                }
+                Utils.elements.centerImage.classList.add('dragging');
                 this.spawnRipple(point.clientX, point.clientY);
                 this.queueTrail(point.clientX, point.clientY);
             },
@@ -3583,7 +3559,6 @@
                 const point = e.touches ? e.touches[0] : e;
                 this.currentPos = { x: point.clientX, y: point.clientY };
                 this.queueTrail(point.clientX, point.clientY);
-                if (this.hubPressActive) { return; }
                 if (state.imageFiles.length === 0) return;
                 const deltaX = this.currentPos.x - this.startPos.x;
                 const deltaY = this.currentPos.y - this.startPos.y;
@@ -3611,31 +3586,6 @@
                 const now = performance.now();
                 const duration = now - this.startTimestamp;
                 const isTap = distance < this.TAP_DISTANCE_THRESHOLD && duration < this.TAP_DURATION_THRESHOLD;
-
-                if (this.hubPressActive) {
-                    if (isTap) {
-                        if (this.lastHubTap.time && (now - this.lastHubTap.time) <= this.DOUBLE_TAP_MAX_INTERVAL) {
-                            const tapDistance = Math.hypot(this.lastHubTap.x - this.currentPos.x, this.lastHubTap.y - this.currentPos.y);
-                            if (tapDistance <= this.DOUBLE_TAP_MAX_DISTANCE) {
-                                this.spawnRipple(this.currentPos.x, this.currentPos.y);
-                                this.toggleFocusMode();
-                                if (state.haptic) { state.haptic.triggerFeedback('buttonPress'); }
-                                this.lastHubTap = { time: 0, x: 0, y: 0 };
-                            } else {
-                                this.lastHubTap = { time: now, x: this.currentPos.x, y: this.currentPos.y };
-                            }
-                        } else {
-                            this.lastHubTap = { time: now, x: this.currentPos.x, y: this.currentPos.y };
-                        }
-                    } else {
-                        this.lastHubTap = { time: 0, x: 0, y: 0 };
-                    }
-                    this.hideAllEdgeGlows();
-                    this.hubPressActive = false;
-                    this.gestureStarted = false;
-                    return;
-                }
-
                 if (distance > 80) {
                     if (state.isFocusMode) {
                         const direction = deltaX < 0 ? 'right' : 'left';
@@ -3656,7 +3606,6 @@
                     this.handleTap(this.currentPos.x, this.currentPos.y);
                 }
                 this.hideAllEdgeGlows();
-                this.hubPressActive = false;
                 this.gestureStarted = false;
             },
             getDistance(touch1, touch2) { const dx = touch1.clientX - touch2.clientX; const dy = touch1.clientY - touch2.clientY; return Math.sqrt(dx * dx + dy * dy); },
@@ -3703,7 +3652,9 @@
                 Utils.elements.appContainer.classList.toggle('focus-mode', state.isFocusMode);
                 this.updateGestureOverlayMode();
                 Core.updateImageCounters();
-                this.lastHubTap = { time: 0, x: 0, y: 0 };
+                if (Utils.elements.normalImageCount) {
+                    Utils.elements.normalImageCount.setAttribute('aria-pressed', state.isFocusMode ? 'true' : 'false');
+                }
             },
             async nextImage() {
                 const stack = state.stacks[state.currentStack];
@@ -3942,18 +3893,18 @@
                 }
 
                 header.ondblclick = () => {
-                     if (modal.id === 'details-modal') {
+                    if (modal.id === 'details-modal') {
                         modal.style.top = '50%';
                         modal.style.left = '50%';
                         modal.style.transform = 'translate(-50%, -50%)';
                         modal.style.width = '800px';
-                        modal.style.height = '95vh';
+                        modal.style.height = 'calc(var(--app-height) * 0.95)';
                     } else if (modal.id === 'grid-modal') {
                         modal.style.top = '0px';
                         modal.style.left = '0px';
                         modal.style.width = '100%';
                         modal.style.height = '100%';
-                        modal.style.maxHeight = '100vh';
+                        modal.style.maxHeight = 'var(--app-height)';
                         modal.style.maxWidth = '100vw';
                         modal.style.transform = 'none';
                         Utils.elements.gridContent.scrollTop = 0;
@@ -4046,6 +3997,21 @@
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);
                     }
                 });
+                if (Utils.elements.normalImageCount) {
+                    const toggleFocus = () => {
+                        const stack = state.stacks[state.currentStack];
+                        if (!stack || stack.length === 0) return;
+                        Gestures.toggleFocusMode();
+                        if (state.haptic) { state.haptic.triggerFeedback('buttonPress'); }
+                    };
+                    Utils.elements.normalImageCount.addEventListener('click', toggleFocus);
+                    Utils.elements.normalImageCount.addEventListener('keydown', (e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            toggleFocus();
+                        }
+                    });
+                }
             },
             setupTabs() { document.querySelectorAll('.tab-button').forEach(btn => { btn.addEventListener('click', () => Details.switchTab(btn.dataset.tab)); }); },
             setupCopyButtons() {
@@ -4165,6 +4131,23 @@
                 });
             }
         };
+        function setupAppHeight() {
+            const root = document.documentElement;
+            const setAppHeight = () => {
+                const viewport = window.visualViewport;
+                const height = viewport ? viewport.height : window.innerHeight;
+                if (height) {
+                    root.style.setProperty('--app-height', `${Math.round(height)}px`);
+                }
+            };
+            setAppHeight();
+            window.addEventListener('resize', setAppHeight);
+            window.addEventListener('orientationchange', setAppHeight);
+            window.addEventListener('pageshow', setAppHeight);
+            if (window.visualViewport) {
+                window.visualViewport.addEventListener('resize', setAppHeight);
+            }
+        }
         async function initApp() {
             try {
                 Utils.init();
@@ -4189,7 +4172,10 @@
                                   </div>`;
             }
         }
-        document.addEventListener('DOMContentLoaded', initApp);
+        document.addEventListener('DOMContentLoaded', () => {
+            setupAppHeight();
+            initApp();
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a dynamic `--app-height` viewport variable and runtime updater to `ui-v3.html`
- remove hub overlay markup/logic and hook the normal item counter up as the focus-mode toggle with accessibility updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cff64118bc832dbc4f69ef00529ebf