### PR TITLE
Add shared tag and notes editors for bulk updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,21 +393,10 @@
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
         
-        .tags-container { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; min-height: 40px; }
-        .tag-item { display: inline-flex; align-items: center; background: #dbeafe; color: #1e40af; padding: 4px 8px; border-radius: 12px; font-size: 12px; gap: 6px; }
-        .tag-remove {
-            background: transparent; border: none; color: #1e40af; cursor: pointer; font-size: 14px; line-height: 1; padding: 0;
-            width: 16px; height: 16px; display: flex; align-items: center; justify-content: center; border-radius: 50%; transition: background-color 0.2s;
-        }
-        .tag-remove:hover { background: rgba(59, 130, 246, 0.1); }
-        .add-tag-btn {
-            background: #f3f4f6; border: 1px dashed #d1d5db; border-radius: 12px; padding: 4px 12px;
-            font-size: 12px; color: #6b7280; cursor: pointer; transition: all 0.2s;
-        }
-        .add-tag-btn:hover { background: #e5e7eb; color: #374151; }
-        
-        /* NEW: Action Modal Tag Chips */
-        #tag-chip-container { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
+        .tags-container { margin-bottom: 16px; }
+        .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
+        .tags-container.tag-editor-container { display: flex; flex-direction: column; gap: 12px; min-height: 0; }
+        .tag-chip-list { display: flex; flex-wrap: wrap; gap: 6px; min-height: 32px; }
         .tag-chip {
             display: inline-flex; align-items: center; background: #e0e7ff; color: #3730a3; padding: 4px 8px;
             border-radius: 12px; font-size: 13px; font-weight: 500; gap: 6px;
@@ -418,6 +407,14 @@
             transition: background-color 0.2s;
         }
         .tag-chip-remove:hover { background: rgba(99, 102, 241, 0.1); }
+        .tag-suggestions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 4px; }
+        .tag-suggestions.hidden { display: none; }
+        .tag-suggestion {
+            background-color: #e5e7eb; color: #374151; padding: 4px 8px; border-radius: 6px;
+            font-size: 12px; cursor: pointer; transition: background-color 0.2s; border: none;
+        }
+        .tag-suggestion:hover { background-color: #d1d5db; }
+        .tag-editor-note { font-size: 12px; color: #6b7280; }
 
 
         .star-rating { display: flex; gap: 4px; }
@@ -824,6 +821,7 @@
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
+                        <button id="notes-selected" class="btn btn-primary">Notes</button>
                         <button id="move-selected" class="btn btn-primary">Move</button>
                         <button id="delete-selected" class="btn btn-danger">Delete</button>
                         <button id="export-selected" class="btn btn-primary">Export</button>
@@ -905,7 +903,7 @@
                     
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
-                        <div class="star-rating" id="quality-rating">
+                        <div class="star-rating" id="quality-rating" data-rating-type="quality">
                             <svg class="star" data-rating="1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                             <svg class="star" data-rating="2" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                             <svg class="star" data-rating="3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
@@ -916,7 +914,7 @@
                     
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
-                        <div class="star-rating" id="content-rating">
+                        <div class="star-rating" id="content-rating" data-rating-type="content">
                             <svg class="star" data-rating="1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                             <svg class="star" data-rating="2" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                             <svg class="star" data-rating="3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
@@ -1042,6 +1040,7 @@
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     
                     tagSelected: document.getElementById('tag-selected'),
+                    notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
@@ -1161,6 +1160,459 @@
                 }
             }
         };
+
+        const TagService = {
+            normalizeIds(ids = []) {
+                return Array.from(new Set((ids || []).map(id => (id != null ? String(id) : '')).filter(Boolean)));
+            },
+            getFiles(ids = []) {
+                const normalized = this.normalizeIds(ids);
+                return normalized.map(id => state.imageFiles.find(file => file.id === id)).filter(Boolean);
+            },
+            getDisplayTags(ids = []) {
+                const files = this.getFiles(ids);
+                const seen = new Set();
+                const tags = [];
+                files.forEach(file => {
+                    (file.tags || []).forEach(tag => {
+                        if (!seen.has(tag)) {
+                            seen.add(tag);
+                            tags.push(tag);
+                        }
+                        if (!state.tags.has(tag)) {
+                            state.tags.add(tag);
+                        }
+                    });
+                });
+                return tags;
+            },
+            async addTag(tag, ids = []) {
+                const trimmed = (tag || '').trim();
+                const targetIds = this.normalizeIds(ids);
+                if (!trimmed || targetIds.length === 0) {
+                    return this.getDisplayTags(targetIds);
+                }
+                const files = this.getFiles(targetIds);
+                let changed = false;
+                const tasks = files.map(file => {
+                    const currentTags = Array.isArray(file.tags) ? file.tags : [];
+                    if (!currentTags.includes(trimmed)) {
+                        changed = true;
+                        const newTags = [...currentTags, trimmed];
+                        return App.updateUserMetadata(file.id, { tags: newTags });
+                    }
+                    return null;
+                }).filter(Boolean);
+                if (tasks.length > 0) {
+                    await Promise.all(tasks);
+                }
+                if (changed && !state.tags.has(trimmed)) {
+                    state.tags.add(trimmed);
+                }
+                return this.getDisplayTags(targetIds);
+            },
+            async removeTag(tag, ids = []) {
+                const trimmed = (tag || '').trim();
+                const targetIds = this.normalizeIds(ids);
+                if (!trimmed || targetIds.length === 0) {
+                    return this.getDisplayTags(targetIds);
+                }
+                const files = this.getFiles(targetIds);
+                const tasks = files.map(file => {
+                    const currentTags = Array.isArray(file.tags) ? file.tags : [];
+                    if (currentTags.includes(trimmed)) {
+                        const newTags = currentTags.filter(t => t !== trimmed);
+                        return App.updateUserMetadata(file.id, { tags: newTags });
+                    }
+                    return null;
+                }).filter(Boolean);
+                if (tasks.length > 0) {
+                    await Promise.all(tasks);
+                }
+                return this.getDisplayTags(targetIds);
+            },
+            getSessionTags() {
+                return Array.from(state.tags);
+            }
+        };
+
+        class TagEditorInstance {
+            constructor(options) {
+                const { container, input, suggestionContainer, targetIds = [], placeholder } = options;
+                this.container = container;
+                this.input = input;
+                this.suggestionContainer = suggestionContainer;
+                this.targetIds = TagService.normalizeIds(targetIds);
+                this.placeholder = placeholder || 'Add tag and press Enter';
+                this.isProcessing = false;
+                this.handleKeydown = this.handleKeydown.bind(this);
+            }
+
+            init() {
+                if (this.input) {
+                    this.input.value = '';
+                    this.input.placeholder = this.placeholder;
+                    this.input.addEventListener('keydown', this.handleKeydown);
+                }
+                this.refresh();
+                this.renderSuggestions();
+            }
+
+            setTargetIds(ids = []) {
+                this.targetIds = TagService.normalizeIds(ids);
+                this.refresh();
+                this.renderSuggestions();
+            }
+
+            getTags() {
+                return TagService.getDisplayTags(this.targetIds);
+            }
+
+            async handleKeydown(event) {
+                if (!this.input) return;
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    const value = this.input.value.trim();
+                    if (!value) return;
+                    this.input.value = '';
+                    await this.addTag(value);
+                }
+            }
+
+            async addTag(tag) {
+                if (this.isProcessing) return;
+                this.isProcessing = true;
+                try {
+                    await TagService.addTag(tag, this.targetIds);
+                    this.refresh();
+                    this.renderSuggestions();
+                } catch (error) {
+                    Utils.showToast(`Failed to add tag: ${error.message}`, 'error', true);
+                } finally {
+                    this.isProcessing = false;
+                    if (this.input) this.input.focus();
+                }
+            }
+
+            async removeTag(tag) {
+                if (this.isProcessing) return;
+                this.isProcessing = true;
+                try {
+                    await TagService.removeTag(tag, this.targetIds);
+                    this.refresh();
+                    this.renderSuggestions();
+                } catch (error) {
+                    Utils.showToast(`Failed to remove tag: ${error.message}`, 'error', true);
+                } finally {
+                    this.isProcessing = false;
+                    if (this.input) this.input.focus();
+                }
+            }
+
+            refresh() {
+                if (!this.container) return;
+                const tags = this.getTags();
+                this.container.innerHTML = '';
+                tags.forEach(tag => {
+                    const chip = document.createElement('div');
+                    chip.className = 'tag-chip';
+                    const label = document.createElement('span');
+                    label.textContent = tag;
+                    const removeBtn = document.createElement('button');
+                    removeBtn.type = 'button';
+                    removeBtn.className = 'tag-chip-remove';
+                    removeBtn.dataset.tag = tag;
+                    removeBtn.textContent = '×';
+                    removeBtn.addEventListener('click', () => this.removeTag(tag));
+                    chip.appendChild(label);
+                    chip.appendChild(removeBtn);
+                    this.container.appendChild(chip);
+                });
+            }
+
+            renderSuggestions() {
+                if (!this.suggestionContainer) return;
+                const tags = TagService.getSessionTags();
+                this.suggestionContainer.innerHTML = '';
+                if (tags.length === 0) {
+                    this.suggestionContainer.classList.add('hidden');
+                    return;
+                }
+                this.suggestionContainer.classList.remove('hidden');
+                tags.forEach(tag => {
+                    const button = document.createElement('button');
+                    button.type = 'button';
+                    button.className = 'tag-suggestion';
+                    button.dataset.tag = tag;
+                    button.textContent = tag;
+                    button.addEventListener('click', () => this.addTag(tag));
+                    this.suggestionContainer.appendChild(button);
+                });
+            }
+
+            destroy() {
+                if (this.input) {
+                    this.input.removeEventListener('keydown', this.handleKeydown);
+                }
+                if (this.container) {
+                    this.container.innerHTML = '';
+                }
+                if (this.suggestionContainer) {
+                    this.suggestionContainer.innerHTML = '';
+                }
+            }
+        }
+
+        const TagEditor = {
+            create(options) {
+                const instance = new TagEditorInstance(options);
+                instance.init();
+                return instance;
+            }
+        };
+
+        class NotesEditorInstance {
+            constructor(options) {
+                const { root, targetIds = [], mode = 'immediate' } = options;
+                this.root = root;
+                this.targetIds = TagService.normalizeIds(targetIds);
+                this.mode = mode;
+                this.textarea = this.root ? this.root.querySelector('.notes-textarea') : null;
+                this.starContainers = {
+                    quality: this.root ? this.root.querySelector('.star-rating[data-rating-type="quality"]') : null,
+                    content: this.root ? this.root.querySelector('.star-rating[data-rating-type="content"]') : null
+                };
+                this.values = { notes: '', qualityRating: 0, contentRating: 0 };
+                this.lastCommitted = { notes: '', qualityRating: 0, contentRating: 0 };
+                this.isProcessing = false;
+                this.starHandlers = { quality: [], content: [] };
+                this.handleNotesInput = this.handleNotesInput.bind(this);
+                this.handleNotesBlur = this.handleNotesBlur.bind(this);
+            }
+
+            initialize(initialValues = {}) {
+                this.setValues(initialValues);
+                this.attachEvents();
+            }
+
+            setTargetIds(ids = []) {
+                this.targetIds = TagService.normalizeIds(ids);
+            }
+
+            setValues(values = {}) {
+                const normalized = {
+                    notes: values.notes ?? '',
+                    qualityRating: values.qualityRating ?? 0,
+                    contentRating: values.contentRating ?? 0
+                };
+                this.values = { ...normalized };
+                this.lastCommitted = { ...normalized };
+                if (this.textarea) {
+                    this.textarea.value = normalized.notes;
+                }
+                this.updateStarVisuals('quality', normalized.qualityRating);
+                this.updateStarVisuals('content', normalized.contentRating);
+            }
+
+            attachEvents() {
+                if (this.textarea) {
+                    this.textarea.addEventListener('input', this.handleNotesInput);
+                    this.textarea.addEventListener('blur', this.handleNotesBlur);
+                }
+                this.setupStars('quality');
+                this.setupStars('content');
+            }
+
+            handleNotesInput() {
+                if (!this.textarea) return;
+                this.values.notes = this.textarea.value;
+            }
+
+            async handleNotesBlur() {
+                if (this.mode !== 'immediate') return;
+                if (this.values.notes === this.lastCommitted.notes) return;
+                await this.commitImmediate({ notes: this.values.notes });
+            }
+
+            async commitImmediate(updates) {
+                if (this.isProcessing || this.targetIds.length === 0) return;
+                this.isProcessing = true;
+                try {
+                    const applied = await this.applyUpdates(updates);
+                    if (applied) {
+                        Object.entries(updates).forEach(([key, value]) => {
+                            this.lastCommitted[key] = value;
+                        });
+                    }
+                } finally {
+                    this.isProcessing = false;
+                }
+            }
+
+            setupStars(type) {
+                const container = this.starContainers[type];
+                if (!container) return;
+                const leaveHandler = () => this.updateStarVisuals(type, this.values[`${type}Rating`]);
+                container.addEventListener('mouseleave', leaveHandler);
+                this.starHandlers[type].push({ element: container, type: 'mouseleave', handler: leaveHandler });
+                const stars = Array.from(container.querySelectorAll('.star'));
+                stars.forEach(star => {
+                    const ratingValue = parseInt(star.dataset.rating, 10) || 0;
+                    const enterHandler = () => this.updateStarVisuals(type, ratingValue);
+                    const clickHandler = async () => {
+                        const current = this.values[`${type}Rating`];
+                        const newValue = current === ratingValue ? 0 : ratingValue;
+                        if (current === newValue) return;
+                        this.values[`${type}Rating`] = newValue;
+                        this.updateStarVisuals(type, newValue);
+                        if (this.mode === 'immediate') {
+                            await this.commitImmediate({ [`${type}Rating`]: newValue });
+                        }
+                    };
+                    star.addEventListener('mouseenter', enterHandler);
+                    star.addEventListener('click', clickHandler);
+                    this.starHandlers[type].push({ element: star, type: 'mouseenter', handler: enterHandler });
+                    this.starHandlers[type].push({ element: star, type: 'click', handler: clickHandler });
+                });
+                this.updateStarVisuals(type, this.values[`${type}Rating`]);
+            }
+
+            updateStarVisuals(type, rating) {
+                const container = this.starContainers[type];
+                if (!container) return;
+                const stars = container.querySelectorAll('.star');
+                stars.forEach((star, index) => {
+                    star.classList.toggle('active', index < rating);
+                });
+            }
+
+            async applyUpdates(updates) {
+                const files = TagService.getFiles(this.targetIds);
+                if (files.length === 0) return false;
+                const tasks = [];
+                files.forEach(file => {
+                    const payload = {};
+                    let changed = false;
+                    if ('notes' in updates) {
+                        const incomingNotes = updates.notes ?? '';
+                        if ((file.notes || '') !== incomingNotes) {
+                            payload.notes = incomingNotes;
+                            changed = true;
+                        }
+                    }
+                    if ('qualityRating' in updates) {
+                        const incomingQuality = updates.qualityRating ?? 0;
+                        if ((file.qualityRating || 0) !== incomingQuality) {
+                            payload.qualityRating = incomingQuality;
+                            changed = true;
+                        }
+                    }
+                    if ('contentRating' in updates) {
+                        const incomingContent = updates.contentRating ?? 0;
+                        if ((file.contentRating || 0) !== incomingContent) {
+                            payload.contentRating = incomingContent;
+                            changed = true;
+                        }
+                    }
+                    if (changed) {
+                        tasks.push(App.updateUserMetadata(file.id, payload));
+                    }
+                });
+                if (tasks.length === 0) return false;
+                try {
+                    await Promise.all(tasks);
+                    return true;
+                } catch (error) {
+                    Utils.showToast(`Failed to update notes: ${error.message}`, 'error', true);
+                    return false;
+                }
+            }
+
+            getPendingUpdates() {
+                const changes = {};
+                if (this.values.notes !== this.lastCommitted.notes) {
+                    changes.notes = this.values.notes;
+                }
+                if (this.values.qualityRating !== this.lastCommitted.qualityRating) {
+                    changes.qualityRating = this.values.qualityRating;
+                }
+                if (this.values.contentRating !== this.lastCommitted.contentRating) {
+                    changes.contentRating = this.values.contentRating;
+                }
+                return changes;
+            }
+
+            async commit() {
+                if (this.mode !== 'deferred') return false;
+                if (this.isProcessing || this.targetIds.length === 0) return false;
+                const updates = this.getPendingUpdates();
+                if (Object.keys(updates).length === 0) return false;
+                this.isProcessing = true;
+                try {
+                    const applied = await this.applyUpdates(updates);
+                    if (applied) {
+                        this.lastCommitted = { ...this.values };
+                    }
+                    return applied;
+                } finally {
+                    this.isProcessing = false;
+                }
+            }
+
+            destroy() {
+                if (this.textarea) {
+                    this.textarea.removeEventListener('input', this.handleNotesInput);
+                    this.textarea.removeEventListener('blur', this.handleNotesBlur);
+                }
+                Object.values(this.starHandlers).forEach(handlers => {
+                    handlers.forEach(({ element, type, handler }) => {
+                        element.removeEventListener(type, handler);
+                    });
+                });
+                this.starHandlers = { quality: [], content: [] };
+            }
+        }
+
+        const NotesEditor = {
+            create(options) {
+                const instance = new NotesEditorInstance(options);
+                instance.initialize(options.initialValues || {});
+                return instance;
+            }
+        };
+
+        function createNotesEditorElement({ textareaId } = {}) {
+            const wrapper = document.createElement('div');
+            const labelAttr = textareaId ? `for="${textareaId}"` : '';
+            const textareaAttr = textareaId ? `id="${textareaId}"` : '';
+            wrapper.innerHTML = `
+                <div style="margin-bottom: 24px;">
+                    <label ${labelAttr} style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
+                    <textarea ${textareaAttr} class="notes-textarea" placeholder="Add your notes here..."></textarea>
+                </div>
+                <div style="margin-bottom: 20px;">
+                    <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
+                    <div class="star-rating" data-rating-type="quality">
+                        <svg class="star" data-rating="1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        <svg class="star" data-rating="2" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        <svg class="star" data-rating="3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        <svg class="star" data-rating="4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    </div>
+                </div>
+                <div style="margin-bottom: 20px;">
+                    <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
+                    <div class="star-rating" data-rating-type="content">
+                        <svg class="star" data-rating="1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        <svg class="star" data-rating="2" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        <svg class="star" data-rating="3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        <svg class="star" data-rating="4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    </div>
+                </div>
+            `;
+            return wrapper;
+        }
 
         class DBManager {
             constructor() { this.db = null; }
@@ -2412,8 +2864,8 @@
             
             updateSelectionUI() {
                 const count = state.grid.selected.length;
-                const buttons = [Utils.elements.tagSelected, Utils.elements.moveSelected, Utils.elements.deleteSelected, 
-                               Utils.elements.exportSelected, Utils.elements.folderSelected];
+                const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
+                               Utils.elements.deleteSelected, Utils.elements.exportSelected, Utils.elements.folderSelected];
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
@@ -2555,6 +3007,8 @@
             }
         };
         const Details = {
+            tagEditor: null,
+            notesEditor: null,
             currentTab: 'info',
             async show() {
                 try {
@@ -2591,89 +3045,72 @@
                 const size = file.size ? Utils.formatFileSize(file.size) : 'Unknown';
                 Utils.elements.detailSize.textContent = size;
             },
+            getTargetFileIds(baseId) {
+                const selected = state.grid.selected && state.grid.selected.length > 0 ? [...state.grid.selected] : [];
+                if (baseId && !selected.includes(baseId)) {
+                    selected.push(baseId);
+                }
+                return TagService.normalizeIds(selected);
+            },
             populateTagsTab(file) {
-                const tags = file.tags || [];
-                Utils.elements.detailTags.innerHTML = '';
-                tags.forEach(tag => {
-                    const tagElement = document.createElement('div');
-                    tagElement.className = 'tag-item';
-                    tagElement.innerHTML = `<span>${tag}</span><button class="tag-remove" data-tag="${tag}">×</button>`;
-                    Utils.elements.detailTags.appendChild(tagElement);
-                });
-                const addButton = document.createElement('div');
-                addButton.className = 'add-tag-btn'; addButton.textContent = '+ Add Tag';
-                addButton.addEventListener('click', () => this.showAddTagInput());
-                Utils.elements.detailTags.appendChild(addButton);
-                Utils.elements.detailTags.querySelectorAll('.tag-remove').forEach(btn => {
-                    btn.addEventListener('click', (e) => {
-                        const tagToRemove = e.target.dataset.tag;
-                        this.removeTag(file, tagToRemove);
-                    });
-                });
-            },
-            showAddTagInput() {
+                const container = Utils.elements.detailTags;
+                if (!container) return;
+                if (this.tagEditor) {
+                    this.tagEditor.destroy();
+                    this.tagEditor = null;
+                }
+                const targetIds = this.getTargetFileIds(file?.id);
+                container.classList.add('tag-editor-container');
+                container.innerHTML = '';
+                const message = document.createElement('div');
+                message.className = 'tag-editor-note';
+                message.textContent = targetIds.length > 1 ? `Changes apply to ${targetIds.length} selected images.` : 'Changes apply to this image.';
+                container.appendChild(message);
+                const chipList = document.createElement('div');
+                chipList.className = 'tag-chip-list';
+                container.appendChild(chipList);
                 const input = document.createElement('input');
-                input.type = 'text'; input.className = 'tag-input';
-                input.placeholder = 'Enter tag name'; input.style.marginLeft = '8px';
-                const addButton = Utils.elements.detailTags.querySelector('.add-tag-btn');
-                addButton.parentNode.insertBefore(input, addButton);
-                input.focus();
-                input.addEventListener('keydown', (e) => {
-                    if (e.key === 'Enter') {
-                        const tagName = input.value.trim();
-                        if (tagName) {
-                            const currentFile = state.stacks[state.currentStack][state.currentStackPosition];
-                            const currentTags = currentFile.tags || [];
-                            const newTags = [...new Set([...currentTags, tagName])];
-                            App.updateUserMetadata(currentFile.id, { tags: newTags });
-                            state.tags.add(tagName);
-                            this.populateTagsTab(currentFile);
-                            input.remove();
-                        }
-                    } else if (e.key === 'Escape') { input.remove(); }
+                input.type = 'text';
+                input.className = 'tag-input';
+                input.placeholder = 'Add tag and press Enter';
+                container.appendChild(input);
+                const suggestions = document.createElement('div');
+                suggestions.className = 'tag-suggestions';
+                container.appendChild(suggestions);
+                this.tagEditor = TagEditor.create({
+                    container: chipList,
+                    input,
+                    suggestionContainer: suggestions,
+                    targetIds
                 });
-                input.addEventListener('blur', () => { setTimeout(() => input.remove(), 100); });
-            },
-            removeTag(file, tagToRemove) {
-                const currentTags = file.tags || [];
-                const newTags = currentTags.filter(tag => tag !== tagToRemove);
-                App.updateUserMetadata(file.id, { tags: newTags });
-                this.populateTagsTab(file);
+                input.focus();
             },
             populateNotesTab(file) {
-                Utils.elements.detailNotes.value = file.notes || '';
-                const newNotesTextarea = Utils.elements.detailNotes.cloneNode(true);
-                Utils.elements.detailNotes.parentNode.replaceChild(newNotesTextarea, Utils.elements.detailNotes);
-                Utils.elements.detailNotes = newNotesTextarea;
-                Utils.elements.detailNotes.addEventListener('blur', () => {
-                    const currentFile = state.stacks[state.currentStack][state.currentStackPosition];
-                    if (currentFile.notes !== Utils.elements.detailNotes.value) {
-                        App.updateUserMetadata(currentFile.id, { notes: Utils.elements.detailNotes.value });
+                const tab = document.getElementById('tab-notes');
+                if (!tab) return;
+                if (this.notesEditor) {
+                    this.notesEditor.destroy();
+                    this.notesEditor = null;
+                }
+                const targetIds = this.getTargetFileIds(file?.id);
+                let message = tab.querySelector('.tag-editor-note');
+                if (!message) {
+                    message = document.createElement('div');
+                    message.className = 'tag-editor-note';
+                    message.style.marginBottom = '12px';
+                    tab.insertBefore(message, tab.firstChild);
+                }
+                message.textContent = targetIds.length > 1 ? `Changes apply to ${targetIds.length} selected images.` : 'Changes apply to this image.';
+                this.notesEditor = NotesEditor.create({
+                    root: tab,
+                    targetIds,
+                    mode: 'immediate',
+                    initialValues: {
+                        notes: file.notes || '',
+                        qualityRating: file.qualityRating || 0,
+                        contentRating: file.contentRating || 0
                     }
                 });
-                this.setupStarRating('quality', file.qualityRating || 0);
-                this.setupStarRating('content', file.contentRating || 0);
-            },
-            setupStarRating(type, currentRating) {
-                const container = Utils.elements[`${type}Rating`]; if (!container) return;
-                let rating = currentRating;
-                const stars = container.querySelectorAll('.star');
-                const updateVisuals = (r) => { stars.forEach((star, index) => { star.classList.toggle('active', index < r); }); };
-                container.onmouseleave = () => updateVisuals(rating);
-                stars.forEach((star, index) => {
-                    star.onmouseenter = () => updateVisuals(index + 1);
-                    star.onclick = () => {
-                        const newRating = index + 1;
-                        if (newRating === rating) { rating = 0; } else { rating = newRating; }
-                        updateVisuals(rating);
-                        const currentFile = state.stacks[state.currentStack][state.currentStackPosition];
-                        if (!currentFile) return;
-                        const updatePayload = {};
-                        if (type === 'quality') { updatePayload.qualityRating = rating; } else { updatePayload.contentRating = rating; }
-                        App.updateUserMetadata(currentFile.id, updatePayload);
-                    };
-                });
-                updateVisuals(rating);
             },
             populateMetadataTab(file) {
                 Utils.elements.metadataTable.innerHTML = '';
@@ -2742,21 +3179,33 @@
         };
         const Modal = {
             currentAction: null,
-            taggingState: {
-                tags: new Set()
-            },
+            tagEditor: null,
+            notesEditor: null,
             show(type, options = {}) {
                 this.currentAction = type;
-                const { title, content, confirmText = 'Confirm', confirmClass = 'btn-primary' } = options;
+                const {
+                    title,
+                    content,
+                    confirmText = 'Confirm',
+                    confirmClass = 'btn-primary',
+                    cancelText = 'Cancel',
+                    hideConfirm = false
+                } = options;
                 Utils.elements.actionTitle.textContent = title || 'Action';
                 Utils.elements.actionContent.innerHTML = content || '';
                 Utils.elements.actionConfirm.textContent = confirmText;
                 Utils.elements.actionConfirm.className = `btn ${confirmClass}`;
                 Utils.elements.actionConfirm.disabled = false;
-                Utils.elements.actionCancel.textContent = "Cancel";
+                Utils.elements.actionConfirm.style.display = hideConfirm ? 'none' : 'inline-flex';
+                Utils.elements.actionCancel.textContent = cancelText;
                 Utils.showModal('action-modal');
             },
-            hide() { Utils.hideModal('action-modal'); this.currentAction = null; },
+            hide() {
+                Utils.hideModal('action-modal');
+                this.currentAction = null;
+                if (this.tagEditor) { this.tagEditor.destroy(); this.tagEditor = null; }
+                if (this.notesEditor) { this.notesEditor.destroy(); this.notesEditor = null; }
+            },
             setupMoveAction() {
                 this.show('move', {
                     title: 'Move to Stack',
@@ -2768,55 +3217,80 @@
                 });
             },
             setupTagAction() {
-                this.taggingState.tags.clear();
+                const selectedIds = state.grid.selected.length > 0 ? [...state.grid.selected] : [];
+                const total = selectedIds.length;
+                const scopeText = total > 1 ? `Changes apply to ${total} selected images.` : 'Changes apply to the selected image.';
                 this.show('tag', {
-                    title: 'Add Tags',
-                    content: `<div style="margin-bottom: 16px;">
-                                <label style="display: block; font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 4px;">Enter tags</label>
-                                <div id="tag-chip-container"></div>
-                                <input type="text" id="modal-tag-input" class="tag-input" placeholder="nature, landscape, vacation">
-                             </div>
-                             <div id="modal-tag-suggestions" style="display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px;">
-                                ${Array.from(state.tags).map(tag => `<button class="tag-suggestion" data-tag="${tag}" style="background-color: #e5e7eb; color: #374151; padding: 4px 8px; border-radius: 6px; font-size: 12px; cursor: pointer; transition: background-color 0.2s; border: none;">${tag}</button>`).join('')}
+                    title: 'Edit Tags',
+                    content: `<div class="tag-editor-container">
+                                <div class="tag-editor-note">${scopeText}</div>
+                                <div id="bulk-tag-chips" class="tag-chip-list"></div>
+                                <input type="text" id="bulk-tag-input" class="tag-input" placeholder="Add tag and press Enter">
+                                <div id="bulk-tag-suggestions" class="tag-suggestions"></div>
                              </div>`,
-                    confirmText: 'Apply'
+                    hideConfirm: true,
+                    cancelText: 'Close'
                 });
-                const tagInput = document.getElementById('modal-tag-input');
-                tagInput.addEventListener('keydown', (e) => {
-                    if (e.key === 'Enter') {
-                        e.preventDefault();
-                        const tagValue = tagInput.value.trim();
-                        if (tagValue) {
-                            this.addTagChip(tagValue);
-                            tagInput.value = '';
-                        }
-                    }
+                const chipsContainer = document.getElementById('bulk-tag-chips');
+                const input = document.getElementById('bulk-tag-input');
+                const suggestions = document.getElementById('bulk-tag-suggestions');
+                if (this.tagEditor) {
+                    this.tagEditor.destroy();
+                    this.tagEditor = null;
+                }
+                this.tagEditor = TagEditor.create({
+                    container: chipsContainer,
+                    input,
+                    suggestionContainer: suggestions,
+                    targetIds: selectedIds
                 });
-                document.querySelectorAll('.tag-suggestion').forEach(btn => {
-                    btn.addEventListener('click', () => this.addTagChip(btn.dataset.tag));
-                });
-            },
-            addTagChip(tag) {
-                if (this.taggingState.tags.has(tag)) return;
-                this.taggingState.tags.add(tag);
-                const container = document.getElementById('tag-chip-container');
-                const chip = document.createElement('div');
-                chip.className = 'tag-chip';
-                chip.innerHTML = `<span>${tag}</span><button class="tag-chip-remove" data-tag="${tag}">×</button>`;
-                container.appendChild(chip);
-                chip.querySelector('.tag-chip-remove').addEventListener('click', () => {
-                    this.removeTagChip(chip, tag);
-                });
-            },
-            removeTagChip(chipElement, tag) {
-                this.taggingState.tags.delete(tag);
-                chipElement.remove();
+                if (input) input.focus();
             },
             setupDeleteAction() {
                 const selectedCount = state.grid.selected.length;
                 const providerName = state.providerType === 'googledrive' ? 'Google Drive' : 'OneDrive';
                 const message = `Are you sure you want to move ${selectedCount} image(s) to your ${providerName} trash? This can be recovered from the provider's website.`;
                 this.show('delete', { title: 'Confirm Delete', content: `<p style="color: #4b5563; margin-bottom: 16px;">${message}</p>`, confirmText: `Move to ${providerName} Trash`, confirmClass: 'btn-danger' });
+            },
+            setupNotesAction() {
+                const selectedIds = state.grid.selected.length > 0 ? [...state.grid.selected] : [];
+                const total = selectedIds.length;
+                if (total === 0) return;
+                const files = TagService.getFiles(selectedIds);
+                const sharedNotes = files.length && files.every(file => (file.notes || '') === (files[0].notes || '')) ? (files[0].notes || '') : '';
+                const sharedQuality = files.length && files.every(file => (file.qualityRating || 0) === (files[0].qualityRating || 0)) ? (files[0].qualityRating || 0) : 0;
+                const sharedContent = files.length && files.every(file => (file.contentRating || 0) === (files[0].contentRating || 0)) ? (files[0].contentRating || 0) : 0;
+                const scopeText = total > 1 ? `Changes apply to ${total} selected images.` : 'Changes apply to the selected image.';
+                this.show('notes', {
+                    title: 'Edit Notes & Ratings',
+                    content: `<div class="tag-editor-container">
+                                <div class="tag-editor-note">${scopeText}</div>
+                                <div id="bulk-notes-editor"></div>
+                              </div>`,
+                    confirmText: 'Save',
+                    cancelText: 'Cancel'
+                });
+                const mount = document.getElementById('bulk-notes-editor');
+                if (!mount) return;
+                mount.innerHTML = '';
+                const editorElement = createNotesEditorElement({ textareaId: 'bulk-notes-input' });
+                mount.appendChild(editorElement);
+                if (this.notesEditor) {
+                    this.notesEditor.destroy();
+                    this.notesEditor = null;
+                }
+                this.notesEditor = NotesEditor.create({
+                    root: editorElement,
+                    targetIds: selectedIds,
+                    mode: 'deferred',
+                    initialValues: {
+                        notes: sharedNotes,
+                        qualityRating: sharedQuality,
+                        contentRating: sharedContent
+                    }
+                });
+                const textarea = editorElement.querySelector('.notes-textarea');
+                if (textarea) textarea.focus();
             },
             setupExportAction() {
                 this.show('export', {
@@ -2882,24 +3356,35 @@
                     successMessage: `Moved {count} images to ${STACK_NAMES[targetStack]}`
                 });
             },
-            async executeTag() {
-                const tagsToAdd = Array.from(this.taggingState.tags);
-                if (tagsToAdd.length === 0) {
+            async executeNotes() {
+                if (!this.notesEditor) {
                     this.hide();
                     return;
                 }
-                
+                const pending = this.notesEditor.getPendingUpdates();
+                if (Object.keys(pending).length === 0) {
+                    this.hide();
+                    return;
+                }
                 await this.executeBulkAction({
                     action: async (fileId) => {
                         const file = state.imageFiles.find(f => f.id === fileId);
-                        if (file) {
-                            const currentTags = file.tags || [];
-                            const newTags = [...new Set([...currentTags, ...tagsToAdd])];
-                            await App.updateUserMetadata(fileId, { tags: newTags });
-                            tagsToAdd.forEach(tag => state.tags.add(tag));
+                        if (!file) return;
+                        const updates = {};
+                        if ('notes' in pending && (file.notes || '') !== pending.notes) {
+                            updates.notes = pending.notes;
+                        }
+                        if ('qualityRating' in pending && (file.qualityRating || 0) !== pending.qualityRating) {
+                            updates.qualityRating = pending.qualityRating;
+                        }
+                        if ('contentRating' in pending && (file.contentRating || 0) !== pending.contentRating) {
+                            updates.contentRating = pending.contentRating;
+                        }
+                        if (Object.keys(updates).length > 0) {
+                            await App.updateUserMetadata(fileId, updates);
                         }
                     },
-                    successMessage: `Tags added to {count} images`,
+                    successMessage: 'Updated notes & ratings for {count} images',
                     updateGridOnSuccess: false
                 });
             },
@@ -3718,8 +4203,9 @@
                 });
             },
             setupActionButtons() {
-                Utils.elements.moveSelected.addEventListener('click', () => Modal.setupMoveAction());
                 Utils.elements.tagSelected.addEventListener('click', () => Modal.setupTagAction());
+                Utils.elements.notesSelected.addEventListener('click', () => Modal.setupNotesAction());
+                Utils.elements.moveSelected.addEventListener('click', () => Modal.setupMoveAction());
                 Utils.elements.deleteSelected.addEventListener('click', () => Modal.setupDeleteAction());
                 Utils.elements.exportSelected.addEventListener('click', () => Modal.setupExportAction());
                 Utils.elements.folderSelected.addEventListener('click', () => Modal.setupFolderMoveAction());
@@ -3727,7 +4213,7 @@
                 Utils.elements.actionConfirm.addEventListener('click', async () => {
                     try {
                         if (Modal.currentAction === 'move') { /* handled by buttons */
-                        } else if (Modal.currentAction === 'tag') { await Modal.executeTag();
+                        } else if (Modal.currentAction === 'notes') { await Modal.executeNotes();
                         } else if (Modal.currentAction === 'delete') { await Modal.executeDelete();
                         } else if (Modal.currentAction === 'export') { await Modal.executeExport();
                         } else if (Modal.currentAction === 'folder-move') { Modal.executeFolderMove(); }


### PR DESCRIPTION
## Summary
- create shared TagService, TagEditor, and NotesEditor utilities so chip inputs update immediately across selected items
- rewire the details panel and bulk tag modal to consume the new utilities while keeping the state.tags cache synchronized
- add a bulk Notes action that reuses the notes/ratings editor to commit changes to every selected image on save

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfe63462e4832d9e25cef28c922840