### PR TITLE
Revamp modal drag and resize behaviors

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
+        body.modal-interacting { user-select: none; }
         
         .screen {
             position: fixed; inset: 0; background: var(--dark);
@@ -256,7 +257,9 @@
             background: white; border-radius: 8px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
             width: 100%; height: 100%; max-width: 1152px; max-height: 90vh; margin: 16px;
             display: flex; flex-direction: column;
-            position: absolute; /* For dragging */
+            position: relative;
+            transform: translate3d(0, 0, 0);
+            will-change: transform;
         }
         .action-modal { max-width: 448px; padding: 24px; }
         
@@ -418,10 +421,39 @@
             opacity: 1;
         }
         
-        .details-modal-content { 
-            max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
-            resize: both; overflow: auto; min-width: 400px; min-height: 400px;
+        .details-modal-content {
+            max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column;
+            overflow: auto; min-width: 400px; min-height: 400px;
         }
+        .modal-content.modal-content-flush {
+            margin: 0;
+            border-radius: 0;
+        }
+        .modal-resize-handle {
+            position: absolute; z-index: 30; touch-action: none;
+            background: transparent; transition: background 0.15s ease;
+        }
+        .modal-resize-handle:hover,
+        .modal-resize-handle:focus-visible {
+            background: rgba(59, 130, 246, 0.15);
+        }
+        .modal-resize-handle.edge-horizontal {
+            left: 16px; right: 16px; height: 12px;
+        }
+        .modal-resize-handle.edge-vertical {
+            top: 16px; bottom: 16px; width: 12px;
+        }
+        .modal-resize-handle.corner {
+            width: 16px; height: 16px;
+        }
+        .modal-resize-top { top: -6px; cursor: ns-resize; }
+        .modal-resize-bottom { bottom: -6px; cursor: ns-resize; }
+        .modal-resize-left { left: -6px; cursor: ew-resize; }
+        .modal-resize-right { right: -6px; cursor: ew-resize; }
+        .modal-resize-top-left { top: -8px; left: -8px; cursor: nwse-resize; }
+        .modal-resize-top-right { top: -8px; right: -8px; cursor: nesw-resize; }
+        .modal-resize-bottom-left { bottom: -8px; left: -8px; cursor: nesw-resize; }
+        .modal-resize-bottom-right { bottom: -8px; right: -8px; cursor: nwse-resize; }
         .details-header { 
             display: flex; align-items: center; justify-content: space-between; padding: 16px; 
             border-bottom: 1px solid #e5e7eb; flex-shrink: 0; cursor: move;
@@ -1009,7 +1041,8 @@
             tags: new Set(), loadingProgress: { current: 0, total: 0 },
             folderMoveMode: { active: false, files: [] },
             activeRequests: new AbortController(),
-            sessionVisitedFolders: new Set()
+            sessionVisitedFolders: new Set(),
+            modalLayout: {}
         };
         const Utils = {
             elements: {},
@@ -1144,7 +1177,13 @@
                 });
             },
             
-            showModal(id) { document.getElementById(id).classList.remove('hidden'); },
+            showModal(id) {
+                const modal = document.getElementById(id);
+                modal.classList.remove('hidden');
+                if (DraggableResizable && typeof DraggableResizable.onShow === 'function') {
+                    DraggableResizable.onShow(id);
+                }
+            },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
@@ -4341,72 +4380,425 @@
                 this.switchToStack(nextStack);
             }
         };
-        const DraggableResizable = {
-            init(modal, header) {
-                let pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
-                let isDragging = false;
-                
-                header.onmousedown = dragMouseDown;
+        const DraggableResizable = (() => {
+            const controllers = new Map();
+            const DEFAULT_MARGIN = 16;
+            const DEFAULT_MIN_WIDTH = 320;
+            const DEFAULT_MIN_HEIGHT = 240;
+            let viewportListenersRegistered = false;
 
-                function dragMouseDown(e) {
-                    e = e || window.event;
-                    e.preventDefault();
-                    pos3 = e.clientX;
-                    pos4 = e.clientY;
-                    isDragging = true;
-                    document.onmouseup = closeDragElement;
-                    document.onmousemove = elementDrag;
+            const clamp = (value, min, max) => {
+                if (min > max) return (min + max) / 2;
+                if (value < min) return min;
+                if (value > max) return max;
+                return value;
+            };
+
+            const getViewportMetrics = () => {
+                if (window.visualViewport) {
+                    return {
+                        width: window.visualViewport.width,
+                        height: window.visualViewport.height,
+                        left: window.visualViewport.offsetLeft,
+                        top: window.visualViewport.offsetTop
+                    };
+                }
+                return { width: window.innerWidth, height: window.innerHeight, left: 0, top: 0 };
+            };
+
+            const clampPosition = (x, y, width, height, margin = DEFAULT_MARGIN) => {
+                const viewport = getViewportMetrics();
+                const minX = viewport.left + margin;
+                const minY = viewport.top + margin;
+                const maxX = viewport.left + viewport.width - margin - width;
+                const maxY = viewport.top + viewport.height - margin - height;
+                const clampedX = maxX < minX ? viewport.left + (viewport.width - width) / 2 : clamp(x, minX, maxX);
+                const clampedY = maxY < minY ? viewport.top + (viewport.height - height) / 2 : clamp(y, minY, maxY);
+                return { x: clampedX, y: clampedY };
+            };
+
+            class ModalController {
+                constructor(id, modal, header) {
+                    this.id = id;
+                    this.modal = modal;
+                    this.header = header;
+                    const computed = getComputedStyle(modal);
+                    this.defaultMargin = parseFloat(computed.marginTop) || DEFAULT_MARGIN;
+                    const minWidth = parseFloat(computed.minWidth);
+                    const minHeight = parseFloat(computed.minHeight);
+                    this.minWidth = Number.isFinite(minWidth) ? minWidth : DEFAULT_MIN_WIDTH;
+                    this.minHeight = Number.isFinite(minHeight) ? minHeight : DEFAULT_MIN_HEIGHT;
+                    this.dragState = null;
+                    this.resizeState = null;
+                    this.handles = [];
+
+                    if (this.header) {
+                        this.header.style.touchAction = 'none';
+                    }
+
+                    this.setupDrag();
+                    this.setupResizeHandles();
+                    this.setupDoubleClick();
                 }
 
-                function elementDrag(e) {
-                    if (!isDragging) return;
-                    e = e || window.event;
-                    e.preventDefault();
-                    pos1 = pos3 - e.clientX;
-                    pos2 = pos4 - e.clientY;
-                    pos3 = e.clientX;
-                    pos4 = e.clientY;
-                    
-                    let newTop = modal.offsetTop - pos2;
-                    let newLeft = modal.offsetLeft - pos1;
-
-                    // Boundary checks
-                    const parent = modal.parentElement;
-                    if (newTop < 0) newTop = 0;
-                    if (newLeft < 0) newLeft = 0;
-                    if (newTop + modal.offsetHeight > parent.clientHeight) newTop = parent.clientHeight - modal.offsetHeight;
-                    if (newLeft + modal.offsetWidth > parent.clientWidth) newLeft = parent.clientWidth - modal.offsetWidth;
-
-                    modal.style.top = newTop + "px";
-                    modal.style.left = newLeft + "px";
+                getLayout() {
+                    if (!state.modalLayout[this.id]) {
+                        state.modalLayout[this.id] = {};
+                    }
+                    return state.modalLayout[this.id];
                 }
 
-                function closeDragElement() {
-                    isDragging = false;
-                    document.onmouseup = null;
-                    document.onmousemove = null;
+                getMargin(layout) {
+                    return typeof layout.margin === 'number' ? layout.margin : this.defaultMargin;
                 }
 
-                header.ondblclick = () => {
-                     if (modal.id === 'details-modal') {
-                        modal.style.top = '50%';
-                        modal.style.left = '50%';
-                        modal.style.transform = 'translate(-50%, -50%)';
-                        modal.style.width = '800px';
-                        modal.style.height = '95vh';
-                    } else if (modal.id === 'grid-modal') {
-                        modal.style.top = '0px';
-                        modal.style.left = '0px';
-                        modal.style.width = '100%';
-                        modal.style.height = '100%';
-                        modal.style.maxHeight = '100vh';
-                        modal.style.maxWidth = '100vw';
-                        modal.style.transform = 'none';
+                ensureLayout() {
+                    const layout = this.getLayout();
+                    const rect = this.modal.getBoundingClientRect();
+                    if (!Number.isFinite(layout.width)) {
+                        layout.width = Math.max(this.minWidth, rect.width || this.minWidth);
+                    }
+                    if (!Number.isFinite(layout.height)) {
+                        layout.height = Math.max(this.minHeight, rect.height || this.minHeight);
+                    }
+                    if (!Number.isFinite(layout.margin)) {
+                        layout.margin = this.defaultMargin;
+                    }
+
+                    layout.width = Math.max(this.minWidth, layout.width);
+                    layout.height = Math.max(this.minHeight, layout.height);
+
+                    const margin = this.getMargin(layout);
+                    const viewport = getViewportMetrics();
+                    const widthLimit = margin === 0 ? viewport.width : viewport.width - margin * 2;
+                    const heightLimit = margin === 0 ? viewport.height : viewport.height - margin * 2;
+
+                    if (Number.isFinite(widthLimit) && widthLimit > 0 && widthLimit >= this.minWidth) {
+                        layout.width = Math.min(layout.width, widthLimit);
+                    }
+                    if (Number.isFinite(heightLimit) && heightLimit > 0 && heightLimit >= this.minHeight) {
+                        layout.height = Math.min(layout.height, heightLimit);
+                    }
+
+                    if (!Number.isFinite(layout.x) || !Number.isFinite(layout.y)) {
+                        const defaultX = viewport.left + (viewport.width - layout.width) / 2;
+                        const defaultY = viewport.top + (viewport.height - layout.height) / 2;
+                        const clamped = clampPosition(defaultX, defaultY, layout.width, layout.height, margin);
+                        layout.x = clamped.x;
+                        layout.y = clamped.y;
+                    } else {
+                        const clamped = clampPosition(layout.x, layout.y, layout.width, layout.height, margin);
+                        layout.x = clamped.x;
+                        layout.y = clamped.y;
+                    }
+                    return layout;
+                }
+
+                applySize(width, height) {
+                    this.modal.style.width = `${width}px`;
+                    this.modal.style.height = `${height}px`;
+                    this.modal.style.maxWidth = 'none';
+                    this.modal.style.maxHeight = 'none';
+                }
+
+                applyMargin(layout) {
+                    const margin = this.getMargin(layout);
+                    this.modal.style.margin = `${margin}px`;
+                    if (margin === 0) {
+                        this.modal.classList.add('modal-content-flush');
+                    } else {
+                        this.modal.classList.remove('modal-content-flush');
+                    }
+                }
+
+                applyTransform(layout) {
+                    const viewport = getViewportMetrics();
+                    const baseX = viewport.left + (viewport.width - layout.width) / 2;
+                    const baseY = viewport.top + (viewport.height - layout.height) / 2;
+                    const translateX = layout.x - baseX;
+                    const translateY = layout.y - baseY;
+                    this.modal.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;
+                }
+
+                onShow() {
+                    const layout = this.ensureLayout();
+                    this.applySize(layout.width, layout.height);
+                    this.applyMargin(layout);
+                    this.applyTransform(layout);
+                }
+
+                isActive() {
+                    const container = this.modal.closest('.modal');
+                    return container && !container.classList.contains('hidden');
+                }
+
+                onViewportChange() {
+                    const layout = this.ensureLayout();
+                    this.applySize(layout.width, layout.height);
+                    this.applyMargin(layout);
+                    if (this.isActive()) {
+                        this.applyTransform(layout);
+                    }
+                }
+
+                setupDrag() {
+                    if (!this.header) return;
+                    this.onDragMove = (event) => {
+                        if (!this.dragState || event.pointerId !== this.dragState.pointerId) return;
+                        event.preventDefault();
+                        const layout = this.getLayout();
+                        const margin = this.getMargin(layout);
+                        const dx = event.clientX - this.dragState.startX;
+                        const dy = event.clientY - this.dragState.startY;
+                        let nextX = this.dragState.startLayout.x + dx;
+                        let nextY = this.dragState.startLayout.y + dy;
+                        const clamped = clampPosition(nextX, nextY, layout.width, layout.height, margin);
+                        layout.x = clamped.x;
+                        layout.y = clamped.y;
+                        this.applyTransform(layout);
+                    };
+                    this.onDragEnd = (event) => {
+                        if (!this.dragState || event.pointerId !== this.dragState.pointerId) return;
+                        if (this.dragState.target && this.dragState.target.releasePointerCapture) {
+                            this.dragState.target.releasePointerCapture(event.pointerId);
+                        }
+                        this.dragState = null;
+                        document.body.classList.remove('modal-interacting');
+                        window.removeEventListener('pointermove', this.onDragMove);
+                        window.removeEventListener('pointerup', this.onDragEnd);
+                        window.removeEventListener('pointercancel', this.onDragEnd);
+                    };
+                    this.header.addEventListener('pointerdown', (event) => {
+                        if (event.button !== undefined && event.pointerType === 'mouse' && event.button !== 0) return;
+                        event.preventDefault();
+                        const layout = this.ensureLayout();
+                        this.dragState = {
+                            pointerId: event.pointerId,
+                            startX: event.clientX,
+                            startY: event.clientY,
+                            startLayout: { x: layout.x, y: layout.y },
+                            target: event.currentTarget
+                        };
+                        if (event.currentTarget.setPointerCapture) {
+                            event.currentTarget.setPointerCapture(event.pointerId);
+                        }
+                        document.body.classList.add('modal-interacting');
+                        window.addEventListener('pointermove', this.onDragMove);
+                        window.addEventListener('pointerup', this.onDragEnd);
+                        window.addEventListener('pointercancel', this.onDragEnd);
+                    });
+                }
+
+                setupResizeHandles() {
+                    const directions = [
+                        { name: 'top', classes: ['edge-horizontal', 'modal-resize-top'] },
+                        { name: 'bottom', classes: ['edge-horizontal', 'modal-resize-bottom'] },
+                        { name: 'left', classes: ['edge-vertical', 'modal-resize-left'] },
+                        { name: 'right', classes: ['edge-vertical', 'modal-resize-right'] },
+                        { name: 'top-left', classes: ['corner', 'modal-resize-top-left'] },
+                        { name: 'top-right', classes: ['corner', 'modal-resize-top-right'] },
+                        { name: 'bottom-left', classes: ['corner', 'modal-resize-bottom-left'] },
+                        { name: 'bottom-right', classes: ['corner', 'modal-resize-bottom-right'] }
+                    ];
+
+                    this.onResizeMove = (event) => {
+                        if (!this.resizeState || event.pointerId !== this.resizeState.pointerId) return;
+                        event.preventDefault();
+                        const { startLayout, direction, margin } = this.resizeState;
+                        const viewport = getViewportMetrics();
+                        const dx = event.clientX - this.resizeState.startX;
+                        const dy = event.clientY - this.resizeState.startY;
+
+                        let left = startLayout.x;
+                        let right = startLayout.x + startLayout.width;
+                        let top = startLayout.y;
+                        let bottom = startLayout.y + startLayout.height;
+
+                        if (direction.includes('left')) {
+                            left = startLayout.x + dx;
+                            const minLeft = viewport.left + margin;
+                            const maxLeft = startLayout.x + startLayout.width - this.minWidth;
+                            left = clamp(left, minLeft, maxLeft);
+                        }
+                        if (direction.includes('right')) {
+                            right = startLayout.x + startLayout.width + dx;
+                            const minRightBase = direction.includes('left') ? left : startLayout.x;
+                            const minRight = minRightBase + this.minWidth;
+                            const maxRight = viewport.left + viewport.width - margin;
+                            right = clamp(right, minRight, maxRight);
+                        }
+                        if (direction.includes('top')) {
+                            top = startLayout.y + dy;
+                            const minTop = viewport.top + margin;
+                            const maxTop = startLayout.y + startLayout.height - this.minHeight;
+                            top = clamp(top, minTop, maxTop);
+                        }
+                        if (direction.includes('bottom')) {
+                            bottom = startLayout.y + startLayout.height + dy;
+                            const minBottomBase = direction.includes('top') ? top : startLayout.y;
+                            const minBottom = minBottomBase + this.minHeight;
+                            const maxBottom = viewport.top + viewport.height - margin;
+                            bottom = clamp(bottom, minBottom, maxBottom);
+                        }
+
+                        let newWidth = right - left;
+                        let newHeight = bottom - top;
+
+                        if (newWidth < this.minWidth) {
+                            newWidth = this.minWidth;
+                            if (direction.includes('left') && !direction.includes('right')) {
+                                left = right - newWidth;
+                            } else {
+                                right = left + newWidth;
+                            }
+                        }
+                        if (newHeight < this.minHeight) {
+                            newHeight = this.minHeight;
+                            if (direction.includes('top') && !direction.includes('bottom')) {
+                                top = bottom - newHeight;
+                            } else {
+                                bottom = top + newHeight;
+                            }
+                        }
+
+                        const clamped = clampPosition(left, top, newWidth, newHeight, margin);
+                        left = clamped.x;
+                        top = clamped.y;
+
+                        const layout = this.getLayout();
+                        layout.x = left;
+                        layout.y = top;
+                        layout.width = newWidth;
+                        layout.height = newHeight;
+                        layout.margin = margin;
+
+                        this.applySize(newWidth, newHeight);
+                        this.applyMargin(layout);
+                        this.applyTransform(layout);
+                    };
+
+                    this.onResizeEnd = (event) => {
+                        if (!this.resizeState || event.pointerId !== this.resizeState.pointerId) return;
+                        if (this.resizeState.handle && this.resizeState.handle.releasePointerCapture) {
+                            this.resizeState.handle.releasePointerCapture(event.pointerId);
+                        }
+                        this.resizeState = null;
+                        document.body.classList.remove('modal-interacting');
+                        window.removeEventListener('pointermove', this.onResizeMove);
+                        window.removeEventListener('pointerup', this.onResizeEnd);
+                        window.removeEventListener('pointercancel', this.onResizeEnd);
+                    };
+
+                    directions.forEach(({ name, classes }) => {
+                        const handle = document.createElement('div');
+                        handle.classList.add('modal-resize-handle', ...classes);
+                        handle.dataset.direction = name;
+                        handle.tabIndex = -1;
+                        handle.addEventListener('pointerdown', (event) => {
+                            if (event.button !== undefined && event.pointerType === 'mouse' && event.button !== 0) return;
+                            event.preventDefault();
+                            event.stopPropagation();
+                            const layout = this.ensureLayout();
+                            this.resizeState = {
+                                pointerId: event.pointerId,
+                                startX: event.clientX,
+                                startY: event.clientY,
+                                startLayout: { x: layout.x, y: layout.y, width: layout.width, height: layout.height },
+                                direction: name,
+                                handle,
+                                margin: this.getMargin(layout)
+                            };
+                            if (handle.setPointerCapture) {
+                                handle.setPointerCapture(event.pointerId);
+                            }
+                            document.body.classList.add('modal-interacting');
+                            window.addEventListener('pointermove', this.onResizeMove);
+                            window.addEventListener('pointerup', this.onResizeEnd);
+                            window.addEventListener('pointercancel', this.onResizeEnd);
+                        });
+                        this.modal.appendChild(handle);
+                        this.handles.push(handle);
+                    });
+                }
+
+                setupDoubleClick() {
+                    if (!this.header) return;
+                    this.header.addEventListener('dblclick', (event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        if (this.id === 'details-modal') {
+                            this.snapToMaxFit();
+                        } else if (this.id === 'grid-modal') {
+                            this.snapToFullscreen();
+                        }
+                    });
+                }
+
+                snapToMaxFit() {
+                    const layout = this.ensureLayout();
+                    const viewport = getViewportMetrics();
+                    const margin = this.defaultMargin;
+                    const availableWidth = Math.max(this.minWidth, viewport.width - margin * 2);
+                    const availableHeight = Math.max(this.minHeight, viewport.height - margin * 2);
+                    layout.width = availableWidth;
+                    layout.height = availableHeight;
+                    layout.margin = margin;
+                    const clamped = clampPosition(viewport.left + margin, viewport.top + margin, layout.width, layout.height, margin);
+                    layout.x = clamped.x;
+                    layout.y = clamped.y;
+                    this.applySize(layout.width, layout.height);
+                    this.applyMargin(layout);
+                    this.applyTransform(layout);
+                }
+
+                snapToFullscreen() {
+                    const layout = this.ensureLayout();
+                    const viewport = getViewportMetrics();
+                    layout.width = Math.max(this.minWidth, viewport.width);
+                    layout.height = Math.max(this.minHeight, viewport.height);
+                    layout.margin = 0;
+                    layout.x = viewport.left;
+                    layout.y = viewport.top;
+                    const clamped = clampPosition(layout.x, layout.y, layout.width, layout.height, layout.margin);
+                    layout.x = clamped.x;
+                    layout.y = clamped.y;
+                    this.applySize(layout.width, layout.height);
+                    this.applyMargin(layout);
+                    this.applyTransform(layout);
+                    if (Utils && Utils.elements && Utils.elements.gridContent) {
                         Utils.elements.gridContent.scrollTop = 0;
                     }
-                };
+                }
             }
-        };
+
+            const handleViewportChange = () => {
+                controllers.forEach(controller => controller.onViewportChange());
+            };
+
+            const ensureViewportListeners = () => {
+                if (viewportListenersRegistered) return;
+                viewportListenersRegistered = true;
+                window.addEventListener('resize', handleViewportChange);
+                if (window.visualViewport) {
+                    window.visualViewport.addEventListener('resize', handleViewportChange);
+                    window.visualViewport.addEventListener('scroll', handleViewportChange);
+                }
+            };
+
+            return {
+                register(id, modal, header) {
+                    if (!modal || !header || controllers.has(id)) return;
+                    const controller = new ModalController(id, modal, header);
+                    controllers.set(id, controller);
+                    ensureViewportListeners();
+                },
+                onShow(id) {
+                    const controller = controllers.get(id);
+                    if (!controller) return;
+                    controller.onShow();
+                }
+            };
+        })();
         const Events = {
             init() {
                 this.setupProviderSelection(); this.setupSettings(); this.setupAuth();
@@ -4418,8 +4810,8 @@
                 this.setupDraggables();
             },
             setupDraggables() {
-                DraggableResizable.init(Utils.elements.detailsModal.querySelector('.modal-content'), Utils.elements.detailsModalHeader);
-                DraggableResizable.init(Utils.elements.gridModal.querySelector('.modal-content'), Utils.elements.gridModalHeaderMain);
+                DraggableResizable.register('details-modal', Utils.elements.detailsModal.querySelector('.modal-content'), Utils.elements.detailsModalHeader);
+                DraggableResizable.register('grid-modal', Utils.elements.gridModal.querySelector('.modal-content'), Utils.elements.gridModalHeaderMain);
             },
             setupProviderSelection() {
                 Utils.elements.googleDriveBtn.addEventListener('click', () => App.selectProvider('googledrive'));


### PR DESCRIPTION
## Summary
- replace the legacy modal drag helper with a pointer-driven controller that stores modal bounds, clamps movement to the visual viewport, and applies transforms
- add resize handles that share the resize controller, enforce minimum sizes, and persist per-modal dimensions
- implement header double-click shortcuts for details (max-fit center) and grid (fullscreen with scroll reset) modals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d10b6862a8832da37835b6bb135aca