### PR TITLE
Add worker sync acknowledgements and error tracking

### DIFF
--- a/ui-v4.html
+++ b/ui-v4.html
@@ -938,6 +938,8 @@
         
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
+        const debugPopupEnabled = localStorage.getItem('orbital8_debug_popup') === 'true' || window.location.search.includes('debugPopup');
+        const debugSyncEnabled = debugPopupEnabled || localStorage.getItem('orbital8_debug_sync') === 'true' || window.location.search.includes('debugSync');
         const state = {
             provider: null, providerType: null, dbManager: null, metadataExtractor: null,
             syncManager: null, visualCues: null, haptic: null, export: null, currentFolder: { id: null, name: '' },
@@ -951,7 +953,8 @@
             tags: new Set(), loadingProgress: { current: 0, total: 0 },
             folderMoveMode: { active: false, files: [] },
             activeRequests: new AbortController(),
-            sessionVisitedFolders: new Set()
+            sessionVisitedFolders: new Set(),
+            debug: { sync: { enabled: debugSyncEnabled, popup: debugPopupEnabled, logs: [] } }
         };
         const Utils = {
             elements: {},
@@ -1244,13 +1247,22 @@
                 return new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('syncQueue', 'readwrite');
                     const store = transaction.objectStore('syncQueue');
+                    const now = Date.now();
                     const record = {
                         providerId: operation.providerId || 'unknown',
                         folderId: operation.folderId || 'unknown',
                         itemId: operation.itemId || null,
                         action: operation.action || 'update',
                         payload: operation.payload ?? null,
-                        timestamp: operation.timestamp || Date.now()
+                        timestamp: operation.timestamp || now,
+                        createdAt: now,
+                        status: 'pending',
+                        attemptCount: 0,
+                        lastAttemptAt: null,
+                        processingStartedAt: null,
+                        lastError: null,
+                        lastErrorAt: null,
+                        retryAfter: null
                     };
                     const request = store.add(record);
                     request.onsuccess = () => resolve(request.result);
@@ -1289,6 +1301,25 @@
                     request.onerror = () => reject(request.error);
                 });
             }
+            async updateSyncQueueRecord(id, updater) {
+                if (!this.db) return null;
+                if (typeof id === 'undefined' || id === null) return null;
+                return new Promise((resolve, reject) => {
+                    const transaction = this.db.transaction('syncQueue', 'readwrite');
+                    const store = transaction.objectStore('syncQueue');
+                    const getRequest = store.get(id);
+                    getRequest.onsuccess = () => {
+                        const current = getRequest.result;
+                        if (!current) { resolve(null); return; }
+                        const updated = typeof updater === 'function' ? updater({ ...current }) : { ...current, ...updater };
+                        if (!updated.id) { updated.id = current.id; }
+                        const putRequest = store.put(updated);
+                        putRequest.onsuccess = () => resolve(updated);
+                        putRequest.onerror = () => reject(putRequest.error);
+                    };
+                    getRequest.onerror = () => reject(getRequest.error);
+                });
+            }
         }
         class SyncQueueManager {
             constructor(dbManager) {
@@ -1308,43 +1339,360 @@
                     timestamp: operation.timestamp
                 });
             }
-            async getPending() {
+            async getPending(onlyReady = true) {
                 if (!this.dbManager) return [];
-                return this.dbManager.readSyncQueue();
+                const records = await this.dbManager.readSyncQueue();
+                if (!onlyReady) return records;
+                const now = Date.now();
+                return records.filter(record => {
+                    if (!record) return false;
+                    const status = record.status || 'pending';
+                    if (status === 'processing') return false;
+                    if (record.retryAfter && record.retryAfter > now) return false;
+                    return true;
+                });
             }
             async remove(id) {
                 if (!this.dbManager) return;
                 await this.dbManager.deleteFromSyncQueue(id);
             }
+            async markProcessing(id) {
+                if (!this.dbManager) return null;
+                return this.dbManager.updateSyncQueueRecord(id, (record) => {
+                    const updated = { ...record };
+                    const now = Date.now();
+                    updated.status = 'processing';
+                    updated.lastAttemptAt = now;
+                    updated.processingStartedAt = now;
+                    updated.attemptCount = (updated.attemptCount || 0) + 1;
+                    updated.lastError = null;
+                    updated.lastErrorAt = null;
+                    updated.retryAfter = null;
+                    return updated;
+                });
+            }
+            async markFailed(id, errorMessage, retryDelay = 5000) {
+                if (!this.dbManager) return null;
+                const safeDelay = Math.max(0, Number.isFinite(retryDelay) ? retryDelay : 5000);
+                return this.dbManager.updateSyncQueueRecord(id, (record) => {
+                    const updated = { ...record };
+                    const now = Date.now();
+                    updated.status = 'pending';
+                    updated.lastError = errorMessage ? String(errorMessage) : 'Unknown error';
+                    updated.lastErrorAt = now;
+                    updated.retryAfter = now + safeDelay;
+                    updated.processingStartedAt = null;
+                    return updated;
+                });
+            }
+        }
+        function createSyncWorker() {
+            const sourceLines = [
+                "const DEFAULT_RETRY_DELAY = 5000;",
+                "const MAX_RETRY_DELAY = 60000;",
+                "const googleHandler = (() => {",
+                "  async function refreshAccessToken(context) {",
+                "    if (!context.refreshToken || !context.clientId || !context.clientSecret) {",
+                "      throw new Error('Missing refresh credentials');",
+                "    }",
+                "    const response = await fetch('https://oauth2.googleapis.com/token', {",
+                "      method: 'POST',",
+                "      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },",
+                "      body: new URLSearchParams({",
+                "        client_id: context.clientId,",
+                "        client_secret: context.clientSecret,",
+                "        refresh_token: context.refreshToken,",
+                "        grant_type: 'refresh_token'",
+                "      })",
+                "    });",
+                "    if (!response.ok) {",
+                "      const text = await response.text();",
+                "      throw new Error('Failed to refresh Google token: ' + text);",
+                "    }",
+                "    const data = await response.json();",
+                "    context.accessToken = data.access_token;",
+                "    self.postMessage({ type: 'sync-token-update', provider: 'googledrive', accessToken: context.accessToken });",
+                "    return context.accessToken;",
+                "  }",
+                "  async function request(context, path, options = {}, expectJson = true) {",
+                "    if (!context.accessToken) { throw new Error('Missing Google access token'); }",
+                "    const base = context.apiBase || 'https://www.googleapis.com/drive/v3';",
+                "    const url = path.startsWith('http') ? path : base + path;",
+                "    const headers = Object.assign({}, options.headers || {}, { Authorization: 'Bearer ' + context.accessToken });",
+                "    const init = Object.assign({}, options, { headers });",
+                "    if (init.body && !(init.body instanceof FormData) && !headers['Content-Type']) {",
+                "      headers['Content-Type'] = 'application/json';",
+                "    }",
+                "    let response = await fetch(url, init);",
+                "    if (response.status === 401 && context.refreshToken) {",
+                "      const refreshed = await refreshAccessToken(context);",
+                "      headers.Authorization = 'Bearer ' + refreshed;",
+                "      response = await fetch(url, init);",
+                "    }",
+                "    if (!response.ok) {",
+                "      const errorText = await response.text();",
+                "      throw new Error('Google API ' + response.status + ': ' + errorText);",
+                "    }",
+                "    if (!expectJson || response.status === 204) { return true; }",
+                "    const text = await response.text();",
+                "    return text ? JSON.parse(text) : true;",
+                "  }",
+                "  return {",
+                "    async execute(operation, context) {",
+                "      const itemId = operation && operation.itemId;",
+                "      if (!itemId) { throw new Error('Missing item id'); }",
+                "      const action = (operation.action || '').toLowerCase();",
+                "      if (action === 'update') {",
+                "        const updates = (operation.payload && operation.payload.updates) || {};",
+                "        await request(context, '/files/' + itemId, { method: 'PATCH', body: JSON.stringify({ appProperties: updates }) });",
+                "      } else if (action === 'delete') {",
+                "        await request(context, '/files/' + itemId, { method: 'PATCH', body: JSON.stringify({ trashed: true }) });",
+                "      } else if (action === 'move') {",
+                "        const payload = operation.payload || {};",
+                "        const targetFolderId = payload.targetFolderId;",
+                "        if (!targetFolderId) { throw new Error('Missing target folder for move'); }",
+                "        const parents = await request(context, '/files/' + itemId + '?fields=parents');",
+                "        const previousParents = Array.isArray(parents.parents) ? parents.parents.join(',') : '';",
+                "        const encodedTarget = encodeURIComponent(targetFolderId);",
+                "        const encodedParents = previousParents ? previousParents.split(',').map(id => encodeURIComponent(id)).join(',') : '';",
+                "        await request(context, '/files/' + itemId + '?addParents=' + encodedTarget + '&removeParents=' + encodedParents + '&fields=id,parents', { method: 'PATCH' });",
+                "      } else {",
+                "        throw new Error('Unsupported Google Drive action: ' + action);",
+                "      }",
+                "    }",
+                "  };",
+                "})();",
+                "const oneDriveHandler = (() => {",
+                "  async function request(context, path, options = {}, expectJson = true) {",
+                "    if (!context.accessToken) { throw new Error('Missing OneDrive access token'); }",
+                "    const base = context.apiBase || 'https://graph.microsoft.com/v1.0';",
+                "    const url = path.startsWith('http') ? path : base + path;",
+                "    const headers = Object.assign({}, options.headers || {}, { Authorization: 'Bearer ' + context.accessToken });",
+                "    const init = Object.assign({}, options, { headers });",
+                "    if (init.body && !(init.body instanceof FormData) && !headers['Content-Type']) {",
+                "      headers['Content-Type'] = 'application/json';",
+                "    }",
+                "    const response = await fetch(url, init);",
+                "    if (!response.ok) {",
+                "      const errorText = await response.text();",
+                "      throw new Error('OneDrive API ' + response.status + ': ' + errorText);",
+                "    }",
+                "    if (!expectJson || response.status === 204) { return true; }",
+                "    const text = await response.text();",
+                "    return text ? JSON.parse(text) : true;",
+                "  }",
+                "  return {",
+                "    async execute(operation, context) {",
+                "      const itemId = operation && operation.itemId;",
+                "      if (!itemId) { throw new Error('Missing item id'); }",
+                "      const action = (operation.action || '').toLowerCase();",
+                "      if (action === 'update') {",
+                "        return true;",
+                "      } else if (action === 'delete') {",
+                "        await request(context, '/me/drive/items/' + itemId, { method: 'DELETE' }, false);",
+                "      } else if (action === 'move') {",
+                "        const payload = operation.payload || {};",
+                "        const targetFolderId = payload.targetFolderId;",
+                "        if (!targetFolderId) { throw new Error('Missing target folder for move'); }",
+                "        await request(context, '/me/drive/items/' + itemId, { method: 'PATCH', body: JSON.stringify({ parentReference: { id: targetFolderId } }) });",
+                "      } else {",
+                "        throw new Error('Unsupported OneDrive action: ' + action);",
+                "      }",
+                "    }",
+                "  };",
+                "})();",
+                "async function executeOperation(operation, context) {",
+                "  if (!operation || typeof operation !== 'object') { throw new Error('Invalid operation payload'); }",
+                "  const providerType = (context && context.type ? String(context.type) : '').toLowerCase();",
+                "  if (!providerType) { throw new Error('Provider context missing'); }",
+                "  if (providerType === 'googledrive') {",
+                "    await googleHandler.execute(operation, context);",
+                "    return;",
+                "  }",
+                "  if (providerType === 'onedrive') {",
+                "    await oneDriveHandler.execute(operation, context);",
+                "    return;",
+                "  }",
+                "  throw new Error('Unsupported provider ' + providerType);",
+                "}",
+                "self.onmessage = async (event) => {",
+                "  const message = event.data || {};",
+                "  if (message.type !== 'sync-operations') { return; }",
+                "  const operations = Array.isArray(message.operations) ? message.operations : [];",
+                "  const context = message.providerContext || {};",
+                "  for (const operation of operations) {",
+                "    if (!operation) { continue; }",
+                "    try {",
+                "      await executeOperation(operation, context);",
+                "      self.postMessage({ type: 'sync-complete', id: operation.id });",
+                "    } catch (error) {",
+                "      const attempt = operation.attemptCount || 0;",
+                "      const delayFactor = attempt > 1 ? attempt - 1 : 0;",
+                "      const retryDelay = Math.min(DEFAULT_RETRY_DELAY * Math.pow(2, delayFactor), MAX_RETRY_DELAY);",
+                "      const errorMessage = error && error.message ? error.message : String(error);",
+                "      self.postMessage({ type: 'sync-failed', id: operation.id, error: errorMessage, retryDelay });",
+                "    }",
+                "  }",
+                "};"
+            ];
+            const blob = new Blob([sourceLines.join('\n')], { type: 'application/javascript' });
+            const url = URL.createObjectURL(blob);
+            const worker = new Worker(url);
+            return { worker, url };
         }
         class SyncManager {
             constructor(queueManager) {
                 this.queueManager = queueManager;
                 this.worker = null;
                 this.isRunning = false;
+                this.workerUrl = null;
+                this.retryTimer = null;
             }
-            attachWorker(workerInstance) {
+            attachWorker(workerInstance, workerUrl = null) {
+                if (this.worker && this.worker !== workerInstance) {
+                    try { this.worker.terminate(); } catch (error) { console.warn('Failed to terminate existing worker', error); }
+                    if (this.workerUrl) { URL.revokeObjectURL(this.workerUrl); }
+                }
                 this.worker = workerInstance;
+                this.workerUrl = workerUrl;
+                if (this.worker) {
+                    this.worker.onmessage = (event) => {
+                        this.handleWorkerMessage(event.data).catch(err => console.error('Failed to handle worker message', err));
+                    };
+                    this.worker.onerror = (event) => {
+                        this.log(`Worker error: ${event.message}`, 'error');
+                    };
+                }
             }
-            start() { this.isRunning = true; }
+            start() {
+                this.isRunning = true;
+                if (!this.worker) {
+                    const { worker, url } = createSyncWorker();
+                    this.attachWorker(worker, url);
+                }
+                this.requestSync().catch(error => this.log(`Failed to request sync: ${error.message}`, 'error'));
+            }
             stop() {
                 this.isRunning = false;
+                if (this.retryTimer) { clearTimeout(this.retryTimer); this.retryTimer = null; }
                 if (this.worker && typeof this.worker.terminate === 'function') {
                     this.worker.terminate();
                 }
                 this.worker = null;
+                if (this.workerUrl) { URL.revokeObjectURL(this.workerUrl); this.workerUrl = null; }
             }
             async requestSync() {
                 if (!this.queueManager) return [];
                 const pending = await this.queueManager.getPending();
-                if (pending.length > 0) {
-                    if (this.worker && typeof this.worker.postMessage === 'function') {
-                        this.worker.postMessage({ type: 'sync-operations', operations: pending });
-                    } else {
-                        console.info('[SyncManager] Pending operations ready for worker', pending);
-                    }
+                if (pending.length === 0) { return pending; }
+                if (!this.worker || typeof this.worker.postMessage !== 'function') {
+                    this.log('Sync worker not available; pending operations remain queued', 'warn');
+                    return pending;
                 }
-                return pending;
+                const providerContext = await this.buildProviderContext();
+                if (!providerContext || !providerContext.type) {
+                    this.log('Provider context unavailable; deferring sync', 'warn');
+                    this.scheduleRetry();
+                    return pending;
+                }
+                const BATCH_SIZE = 10;
+                const ready = pending.slice(0, BATCH_SIZE);
+                const operationsToSend = [];
+                for (const operation of ready) {
+                    const updated = await this.queueManager.markProcessing(operation.id);
+                    operationsToSend.push(updated || operation);
+                }
+                if (operationsToSend.length === 0) { return []; }
+                this.worker.postMessage({ type: 'sync-operations', operations: operationsToSend, providerContext });
+                if (state.debug?.sync?.enabled) {
+                    this.log(`Dispatched ${operationsToSend.length} operation(s) to worker`, 'info');
+                }
+                return operationsToSend;
+            }
+            async buildProviderContext() {
+                if (!state.providerType || !state.provider) return null;
+                if (state.providerType === 'googledrive') {
+                    if (!state.provider.accessToken && typeof state.provider.refreshAccessToken === 'function') {
+                        try { await state.provider.refreshAccessToken(); }
+                        catch (error) {
+                            this.log(`Failed to refresh Google token: ${error.message}`, 'error');
+                            return null;
+                        }
+                    }
+                    if (!state.provider.accessToken) { return null; }
+                    return {
+                        type: 'googledrive',
+                        apiBase: state.provider.apiBase,
+                        accessToken: state.provider.accessToken,
+                        refreshToken: state.provider.refreshToken,
+                        clientId: state.provider.clientId,
+                        clientSecret: state.provider.clientSecret
+                    };
+                }
+                if (state.providerType === 'onedrive') {
+                    let accessToken = null;
+                    if (typeof state.provider.getAccessToken === 'function') {
+                        try { accessToken = await state.provider.getAccessToken(); }
+                        catch (error) { this.log(`Failed to acquire OneDrive token: ${error.message}`, 'error'); }
+                    }
+                    if (!accessToken) { return null; }
+                    return { type: 'onedrive', apiBase: state.provider.apiBase, accessToken };
+                }
+                return { type: state.providerType };
+            }
+            async handleWorkerMessage(message) {
+                if (!message || !message.type) return;
+                if (message.type === 'sync-token-update') {
+                    if (message.provider === 'googledrive' && state.providerType === 'googledrive' && state.provider) {
+                        state.provider.accessToken = message.accessToken;
+                        if (typeof state.provider.storeCredentials === 'function') { state.provider.storeCredentials(); }
+                    }
+                    return;
+                }
+                const id = message.id;
+                if (message.type === 'sync-complete') {
+                    if (typeof id !== 'undefined') {
+                        try { await this.queueManager.remove(id); }
+                        catch (error) { this.log(`Failed to remove queue item ${id}: ${error.message}`, 'error'); }
+                        if (state.debug?.sync?.enabled) {
+                            this.log(`Operation ${id} synced successfully`, 'info');
+                        }
+                    }
+                    await this.requestSync();
+                    return;
+                }
+                if (message.type === 'sync-failed') {
+                    const retryDelay = typeof message.retryDelay === 'number' ? message.retryDelay : 5000;
+                    let record = null;
+                    if (typeof id !== 'undefined') {
+                        record = await this.queueManager.markFailed(id, message.error, retryDelay);
+                    }
+                    this.log(`Operation ${id} failed: ${message.error}`, 'error', record);
+                    this.scheduleRetry(retryDelay);
+                    await this.requestSync();
+                }
+            }
+            scheduleRetry(delay = 5000) {
+                const safeDelay = Math.max(500, delay);
+                if (this.retryTimer) { clearTimeout(this.retryTimer); }
+                this.retryTimer = setTimeout(() => {
+                    this.retryTimer = null;
+                    this.requestSync().catch(error => this.log(`Retry sync failed: ${error.message}`, 'error'));
+                }, safeDelay);
+            }
+            log(message, level = 'info', details = null) {
+                const timestamp = Date.now();
+                const logEntry = { timestamp, level, message, details };
+                if (!state.debug) { state.debug = {}; }
+                if (!state.debug.sync) { state.debug.sync = { enabled: false, popup: false, logs: [] }; }
+                state.debug.sync.logs.push(logEntry);
+                if (state.debug.sync.logs.length > 200) { state.debug.sync.logs.splice(0, state.debug.sync.logs.length - 200); }
+                if (level === 'error') { console.error('[SyncManager]', message, details || ''); }
+                else if (level === 'warn') { console.warn('[SyncManager]', message, details || ''); }
+                else { console.info('[SyncManager]', message, details || ''); }
+                if (state.debug.sync.popup) {
+                    Utils.showToast(message, level === 'error' ? 'error' : 'info', true);
+                }
             }
         }
         class VisualCueManager {


### PR DESCRIPTION
## Summary
- add sync debug flags and extend queue records with status and retry metadata
- add an inline sync worker that acknowledges operations and reports failures to the UI
- update the sync manager to attach the worker, clear successful operations, and persist failure state for retries

## Testing
- not run (HTML changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d1101ecd28832d8d9dec74c1717dde