### PR TITLE
Ensure center image anchors grid and streamline tagging UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,6 @@
-<!-- Orbital8-N-2025-09-18 04:40 AM -->
+<!-- Orbital8-O-2025-09-18 08:45 AM -->
+<!-- Version O Updates: Anchor-first grid sync, tag modal parity, streamlined search helper -->
+<!-- Version O Notes: Safe-click trash & favorite controls plus recycle-first deletions -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -16,6 +18,7 @@
             --dark: linear-gradient(135deg, #0f0f0f 0%, #1a1a1a 100%);
             --glow: 0.6;
             --ripple: 1500ms;
+            --safe-bottom: calc(20px + env(safe-area-inset-bottom, 0px));
         }
 
         * { box-sizing: border-box; }
@@ -197,7 +200,7 @@
         .pill-counter:not(.active) { background: rgba(128, 128, 128, 0.4); border: none; }
         .pill-counter:hover { opacity: 1; transform: scale(1.05); }
         .pill-counter.top { top: 10px; left: 50%; transform: translateX(-50%); }
-        .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
+        .pill-counter.bottom-center { bottom: var(--safe-bottom); left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
         
@@ -330,7 +333,7 @@
         .search-helper-popup {
             display: none; position: absolute; right: 0; top: 100%; margin-top: 8px;
             background: white; border: 1px solid #e5e7eb; border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-            padding: 8px; width: 240px; z-index: 20;
+            padding: 12px; width: 240px; z-index: 20;
         }
         .search-helper.is-open .search-helper-popup { display: block; }
         .search-helper-header {
@@ -346,21 +349,13 @@
         }
         .search-helper-close:hover, .search-helper-close:focus-visible { color: #6b7280; }
         .search-helper-close:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
-        .search-helper-recent {
-            display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px;
+        .modifier-list { display: flex; flex-direction: column; gap: 4px; }
+        .modifier-item {
+            width: 100%; border: none; background: transparent; border-radius: 0; padding: 6px 4px;
+            font-size: 13px; color: #111827; text-align: left; cursor: pointer; transition: background-color 0.2s ease;
         }
-        .search-helper-recent.hidden { display: none; }
-        .modifier-pill {
-            background: #e5e7eb; border: none; border-radius: 9999px; padding: 4px 10px; font-size: 12px; color: #374151;
-            cursor: pointer;
-        }
-        .modifier-pill:hover, .modifier-pill:focus-visible { background: #d1d5db; }
-        .modifier-pill:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
-        .search-helper-popup a {
-            display: block; font-size: 12px; color: #3b82f6; text-decoration: none; padding: 4px 8px;
-            border-radius: 4px; cursor: pointer;
-        }
-        .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
+        .modifier-item:hover, .modifier-item:focus-visible { background: #f3f4f6; }
+        .modifier-item:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
 
 
         .grid-row-4 {
@@ -471,26 +466,30 @@
         .tab-content.active { display: block; }
         
         .tags-container { margin-bottom: 16px; }
-        .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
-        .tags-container.tag-editor-container { display: flex; flex-direction: column; gap: 12px; min-height: 0; }
+        .tag-editor-container { display: flex; flex-direction: column; gap: 12px; min-height: 0; }
         .tag-chip-list { display: flex; flex-wrap: wrap; gap: 6px; min-height: 32px; }
+        .tag-section-title {
+            font-size: 12px; font-weight: 600; color: #4b5563; text-transform: uppercase; letter-spacing: 0.04em;
+        }
         .tag-chip {
             display: inline-flex; align-items: center; background: #e0e7ff; color: #3730a3; padding: 4px 8px;
             border-radius: 12px; font-size: 13px; font-weight: 500; gap: 6px;
         }
+        .tag-chip-button,
+        .tag-chip-apply {
+            background: transparent; border: none; color: inherit; font: inherit; cursor: pointer; padding: 0;
+            display: inline-flex; align-items: center;
+        }
+        .tag-chip-apply:hover { text-decoration: underline; }
+        .tag-chip-recent { background: #f3f4f6; color: #374151; }
         .tag-chip-remove {
             background: transparent; border: none; color: #4338ca; cursor: pointer; font-size: 14px; line-height: 1; padding: 0;
             width: 16px; height: 16px; display: flex; align-items: center; justify-content: center; border-radius: 50%;
             transition: background-color 0.2s;
         }
         .tag-chip-remove:hover { background: rgba(99, 102, 241, 0.1); }
-        .tag-suggestions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 4px; }
-        .tag-suggestions.hidden { display: none; }
-        .tag-suggestion {
-            background-color: #e5e7eb; color: #374151; padding: 4px 8px; border-radius: 6px;
-            font-size: 12px; cursor: pointer; transition: background-color 0.2s; border: none;
-        }
-        .tag-suggestion:hover { background-color: #d1d5db; }
+        .tag-chip-recent .tag-chip-remove { color: #6b7280; }
+        .tag-chip-recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
 
@@ -518,6 +517,7 @@
             color: rgba(255, 255, 255, 0.6); text-align: center;
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+            pointer-events: none;
         }
 
         /* NEW: Standardized UI Button */
@@ -536,13 +536,15 @@
             padding: 10px 16px;
             cursor: pointer;
             position: absolute;
+            min-height: 44px;
+            min-width: 44px;
         }
 
         /* Applying standardized UI styles */
         #back-button { top: 20px; left: 20px; }
         #details-button { top: 20px; right: 20px; }
-        #normal-image-count { bottom: 20px; left: 20px; }
-        #center-trash-btn { bottom: 20px; right: 20px; }
+        #normal-image-count { bottom: var(--safe-bottom); left: 20px; }
+        #center-trash-btn { bottom: var(--safe-bottom); right: 20px; }
 
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
@@ -551,11 +553,11 @@
             top: 20px; left: 50%; transform: translateX(-50%);
             color: #e5e7eb; font-size: 14px;
         }
-        #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
-        #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
+        #focus-image-count { bottom: var(--safe-bottom); left: 20px; color: #e5e7eb; }
+        #focus-delete-btn { bottom: var(--safe-bottom); right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
             position: absolute;
-            bottom: 20px;
+            bottom: var(--safe-bottom);
             left: 50%;
             transform: translateX(-50%);
             background: transparent;
@@ -729,7 +731,7 @@
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
+        <div class="app-footer">Orbital8-O-2025-09-18 08:45 AM</div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -744,7 +746,7 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
+        <div class="app-footer">Orbital8-O-2025-09-18 08:45 AM</div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -759,7 +761,7 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
+        <div class="app-footer">Orbital8-O-2025-09-18 08:45 AM</div>
     </div>
     
     <!-- Loading Screen -->
@@ -773,7 +775,7 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
+        <div class="app-footer">Orbital8-O-2025-09-18 08:45 AM</div>
     </div>
     
     <!-- Main App Container -->
@@ -843,7 +845,7 @@
         </button>
         
         <div id="toast" class="toast"></div>
-        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
+        <div class="app-footer">Orbital8-O-2025-09-18 08:45 AM</div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -890,10 +892,11 @@
                                     <svg style="width: 14px; height: 14px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                                 </button>
                             </div>
-                            <div class="search-helper-recent hidden" id="search-helper-recent"></div>
-                            <a class="modifier-link" data-modifier="#favorite">#favorite</a>
-                            <a class="modifier-link" data-modifier="#quality:5">#quality:1-5</a>
-                            <a class="modifier-link" data-modifier="#content:5">#content:1-5</a>
+                            <div class="modifier-list" role="list">
+                                <button type="button" class="modifier-item" data-modifier="#favorite" role="listitem">#favorite</button>
+                                <button type="button" class="modifier-item" data-modifier="#quality:5" role="listitem">#quality:1-5</button>
+                                <button type="button" class="modifier-item" data-modifier="#content:5" role="listitem">#content:1-5</button>
+                            </div>
                         </div>
                     </div>
                     <button id="clear-search-btn">
@@ -1035,7 +1038,7 @@
             isFocusMode: false, stacks: { in: [], out: [], priority: [], trash: [] },
             isDragging: false, isPinching: false, initialDistance: 0, currentScale: 1,
             maxScale: 4, minScale: 0.3, panOffset: { x: 0, y: 0 },
-            grid: { stack: null, selected: [], filtered: [], isDirty: false, isDragging: false,
+            grid: { stack: null, selected: [], filtered: [], anchorId: null, isDirty: false, isDragging: false,
                 dragSession: createDefaultGridDragSession(),
                 lazyLoadState: { allFiles: [], renderedCount: 0, observer: null, batchSize: 20 } },
             tags: new Set(), loadingProgress: { current: 0, total: 0 },
@@ -1136,7 +1139,6 @@
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    searchHelperRecent: document.getElementById('search-helper-recent'),
                     
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
@@ -1266,6 +1268,8 @@
             }
         };
 
+        const TAG_PLACEHOLDER_MESSAGE = 'Enter tags separated by commas - if a tag does not start with a # then PREPEND # before updating ASSIGNED TAGS WHEN THE USER HITS ENTER - if it does start with # then tag as is';
+
         const TagService = {
             normalizeIds(ids = []) {
                 return Array.from(new Set((ids || []).map(id => (id != null ? String(id) : '')).filter(Boolean)));
@@ -1338,17 +1342,23 @@
             },
             getSessionTags() {
                 return Array.from(state.tags);
+            },
+            removeSessionTag(tag) {
+                const trimmed = (tag || '').trim();
+                if (!trimmed) return this.getSessionTags();
+                state.tags.delete(trimmed);
+                return this.getSessionTags();
             }
         };
 
         class TagEditorInstance {
             constructor(options) {
-                const { container, input, suggestionContainer, targetIds = [], placeholder } = options;
+                const { container, input, suggestionContainer, recentContainer, targetIds = [], placeholder } = options;
                 this.container = container;
                 this.input = input;
-                this.suggestionContainer = suggestionContainer;
+                this.recentContainer = recentContainer || suggestionContainer || null;
                 this.targetIds = TagService.normalizeIds(targetIds);
-                this.placeholder = placeholder || 'Add tag and press Enter';
+                this.placeholder = placeholder || TAG_PLACEHOLDER_MESSAGE;
                 this.isProcessing = false;
                 this.handleKeydown = this.handleKeydown.bind(this);
             }
@@ -1360,13 +1370,13 @@
                     this.input.addEventListener('keydown', this.handleKeydown);
                 }
                 this.refresh();
-                this.renderSuggestions();
+                this.renderRecentTags();
             }
 
             setTargetIds(ids = []) {
                 this.targetIds = TagService.normalizeIds(ids);
                 this.refresh();
-                this.renderSuggestions();
+                this.renderRecentTags();
             }
 
             getTags() {
@@ -1377,10 +1387,19 @@
                 if (!this.input) return;
                 if (event.key === 'Enter') {
                     event.preventDefault();
-                    const value = this.input.value.trim();
-                    if (!value) return;
-                    this.input.value = '';
-                    await this.addTag(value);
+                    await this.commitInputValue();
+                }
+            }
+
+            async commitInputValue() {
+                if (!this.input) return;
+                const rawValue = this.input.value || '';
+                const segments = rawValue.split(',').map(part => part.trim()).filter(Boolean);
+                if (segments.length === 0) { return; }
+                this.input.value = '';
+                for (const segment of segments) {
+                    const normalized = segment.startsWith('#') ? segment : `#${segment}`;
+                    await this.addTag(normalized);
                 }
             }
 
@@ -1390,7 +1409,7 @@
                 try {
                     await TagService.addTag(tag, this.targetIds);
                     this.refresh();
-                    this.renderSuggestions();
+                    this.renderRecentTags();
                 } catch (error) {
                     Utils.showToast(`Failed to add tag: ${error.message}`, 'error', true);
                 } finally {
@@ -1405,7 +1424,7 @@
                 try {
                     await TagService.removeTag(tag, this.targetIds);
                     this.refresh();
-                    this.renderSuggestions();
+                    this.renderRecentTags();
                 } catch (error) {
                     Utils.showToast(`Failed to remove tag: ${error.message}`, 'error', true);
                 } finally {
@@ -1435,23 +1454,37 @@
                 });
             }
 
-            renderSuggestions() {
-                if (!this.suggestionContainer) return;
+            renderRecentTags() {
+                if (!this.recentContainer) return;
                 const tags = TagService.getSessionTags();
-                this.suggestionContainer.innerHTML = '';
+                this.recentContainer.innerHTML = '';
                 if (tags.length === 0) {
-                    this.suggestionContainer.classList.add('hidden');
+                    const empty = document.createElement('div');
+                    empty.className = 'tag-editor-note';
+                    empty.textContent = 'No recently used tags yet.';
+                    this.recentContainer.appendChild(empty);
                     return;
                 }
-                this.suggestionContainer.classList.remove('hidden');
                 tags.forEach(tag => {
-                    const button = document.createElement('button');
-                    button.type = 'button';
-                    button.className = 'tag-suggestion';
-                    button.dataset.tag = tag;
-                    button.textContent = tag;
-                    button.addEventListener('click', () => this.addTag(tag));
-                    this.suggestionContainer.appendChild(button);
+                    const chip = document.createElement('div');
+                    chip.className = 'tag-chip tag-chip-recent';
+                    const applyButton = document.createElement('button');
+                    applyButton.type = 'button';
+                    applyButton.className = 'tag-chip-apply';
+                    applyButton.textContent = tag;
+                    applyButton.addEventListener('click', () => this.addTag(tag));
+                    const removeButton = document.createElement('button');
+                    removeButton.type = 'button';
+                    removeButton.className = 'tag-chip-remove';
+                    removeButton.dataset.tag = tag;
+                    removeButton.textContent = '×';
+                    removeButton.addEventListener('click', () => {
+                        TagService.removeSessionTag(tag);
+                        this.renderRecentTags();
+                    });
+                    chip.appendChild(applyButton);
+                    chip.appendChild(removeButton);
+                    this.recentContainer.appendChild(chip);
                 });
             }
 
@@ -1462,8 +1495,8 @@
                 if (this.container) {
                     this.container.innerHTML = '';
                 }
-                if (this.suggestionContainer) {
-                    this.suggestionContainer.innerHTML = '';
+                if (this.recentContainer) {
+                    this.recentContainer.innerHTML = '';
                 }
             }
         }
@@ -1475,6 +1508,46 @@
                 return instance;
             }
         };
+
+        function createTagEditorLayout(root, options = {}) {
+            if (!root) { return null; }
+            const { scopeText } = options;
+            root.classList.add('tag-editor-container');
+            root.innerHTML = '';
+
+            if (scopeText) {
+                const scope = document.createElement('div');
+                scope.className = 'tag-editor-note';
+                scope.textContent = scopeText;
+                root.appendChild(scope);
+            }
+
+            const assignedTitle = document.createElement('div');
+            assignedTitle.className = 'tag-section-title';
+            assignedTitle.textContent = 'Assigned Tags';
+            root.appendChild(assignedTitle);
+
+            const chipList = document.createElement('div');
+            chipList.className = 'tag-chip-list';
+            root.appendChild(chipList);
+
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.className = 'tag-input';
+            input.placeholder = TAG_PLACEHOLDER_MESSAGE;
+            root.appendChild(input);
+
+            const recentTitle = document.createElement('div');
+            recentTitle.className = 'tag-section-title';
+            recentTitle.textContent = 'Recently Used Tags';
+            root.appendChild(recentTitle);
+
+            const recentList = document.createElement('div');
+            recentList.className = 'tag-chip-list';
+            root.appendChild(recentList);
+
+            return { chipList, input, recentList };
+        }
 
         class NotesEditorInstance {
             constructor(options) {
@@ -2747,12 +2820,20 @@
                     if (currentFile.metadataStatus === 'pending') {
                         App.processFileMetadata(currentFile);
                     }
-                    
+
                     this.updateImageCounters();
                     this.updateFavoriteButton();
+                    Grid.syncWithCurrentImage(currentFile.id);
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
+            },
+
+            getCurrentFile() {
+                const stackArray = state.stacks[state.currentStack];
+                if (!Array.isArray(stackArray) || stackArray.length === 0) { return null; }
+                const clampedIndex = Math.min(Math.max(state.currentStackPosition, 0), stackArray.length - 1);
+                return stackArray[clampedIndex] || null;
             },
 
             updateImageCounters() {
@@ -2811,11 +2892,15 @@
             async moveToStack(targetStack) {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                
+
                 const currentImage = currentStackArray[state.currentStackPosition];
                 if (!currentImage) return;
 
                 try {
+                    if (targetStack === 'trash') {
+                        await this.deleteFromCurrentStack();
+                        return;
+                    }
                     const originalStackName = state.currentStack;
                     if (targetStack === originalStackName) {
                         const otherImages = currentStackArray.filter(img => img.id !== currentImage.id);
@@ -2840,6 +2925,37 @@
                     await this.displayCurrentImage();
                 } catch (error) {
                     Utils.showToast(`Error moving image: ${error.message}`, 'error', true);
+                }
+            },
+
+            async deleteFromCurrentStack() {
+                const stackArray = state.stacks[state.currentStack];
+                if (!Array.isArray(stackArray) || stackArray.length === 0) {
+                    return { deleted: false, stackEmpty: true };
+                }
+                const fileToDelete = stackArray[state.currentStackPosition];
+                if (!fileToDelete) {
+                    return { deleted: false, stackEmpty: stackArray.length === 0 };
+                }
+                try {
+                    await App.deleteFile(fileToDelete.id);
+                    this.updateStackCounts();
+                    const updatedStack = state.stacks[state.currentStack];
+                    if (!updatedStack || updatedStack.length === 0) {
+                        state.grid.anchorId = null;
+                        state.grid.selected = [];
+                        Grid.syncWithCurrentImage(null);
+                        this.showEmptyState();
+                        return { deleted: true, stackEmpty: true };
+                    }
+                    if (state.currentStackPosition >= updatedStack.length) {
+                        state.currentStackPosition = updatedStack.length - 1;
+                    }
+                    await this.displayCurrentImage();
+                    return { deleted: true, stackEmpty: false };
+                } catch (error) {
+                    Utils.showToast(`Failed to delete ${fileToDelete.name}`, 'error', true);
+                    return { deleted: false, stackEmpty: stackArray.length === 0 };
                 }
             },
             
@@ -2867,7 +2983,10 @@
                 state.grid.isDirty = false;
                 const value = Utils.elements.gridSize.value;
                 Utils.elements.gridContainer.style.gridTemplateColumns = `repeat(${value}, 1fr)`;
-                state.grid.selected = []; state.grid.filtered = [];
+                const anchorSource = stack === state.currentStack ? Core.getCurrentFile() : (state.stacks[stack]?.[0] || null);
+                state.grid.anchorId = anchorSource ? anchorSource.id : null;
+                state.grid.filtered = [];
+                state.grid.selected = state.grid.anchorId ? [state.grid.anchorId] : [];
                 Utils.elements.gridContainer.innerHTML = '';
                 this.clearDragState();
                 this.initializeLazyLoad(stack);
@@ -2901,17 +3020,37 @@
                 if (entries[0].isIntersecting) { this.renderBatch(); }
             },
 
-            initializeLazyLoad(stack, filesOverride = null) {
+            initializeLazyLoad(stack, filesOverride = null, options = {}) {
+                const { preserveFilter = false } = options;
                 const lazyState = state.grid.lazyLoadState;
-                const sourceFiles = Array.isArray(filesOverride)
-                    ? filesOverride
-                    : (state.grid.filtered.length > 0 ? state.grid.filtered : state.stacks[stack]);
-                lazyState.allFiles = sourceFiles;
+                const usingOverride = Array.isArray(filesOverride);
+                let baseFiles;
+
+                if (usingOverride) {
+                    baseFiles = filesOverride.slice();
+                } else if (state.grid.filtered.length > 0) {
+                    baseFiles = state.grid.filtered.slice();
+                } else {
+                    baseFiles = (state.stacks[stack] || []).slice();
+                }
+
+                const ordered = this.orderWithAnchor(baseFiles);
+                lazyState.allFiles = ordered.slice();
                 lazyState.renderedCount = 0;
-                Utils.elements.selectAllBtn.textContent = sourceFiles.length;
+                Utils.elements.selectAllBtn.textContent = ordered.length;
+
+                if (usingOverride && !preserveFilter) {
+                    state.grid.filtered = ordered.slice();
+                } else if (!usingOverride && state.grid.filtered.length > 0 && !preserveFilter) {
+                    state.grid.filtered = ordered.slice();
+                }
+
+                Utils.elements.gridContainer.innerHTML = '';
+                this.ensureAnchorSelection(ordered);
                 this.renderBatch();
+                this.applySelectionToRenderedTiles();
                 if (lazyState.observer) lazyState.observer.disconnect();
-                lazyState.observer = new IntersectionObserver(this.handleIntersection.bind(this), { 
+                lazyState.observer = new IntersectionObserver(this.handleIntersection.bind(this), {
                     root: Utils.elements.gridContent, rootMargin: "400px"
                 });
                 const sentinel = document.getElementById('grid-sentinel');
@@ -2922,6 +3061,70 @@
                 const lazyState = state.grid.lazyLoadState;
                 if (lazyState.observer) { lazyState.observer.disconnect(); lazyState.observer = null; }
                 lazyState.allFiles = []; lazyState.renderedCount = 0;
+            },
+
+            isOpen() {
+                return !Utils.elements.gridModal.classList.contains('hidden');
+            },
+
+            orderWithAnchor(files = []) {
+                const list = Array.isArray(files) ? [...files] : [];
+                const anchorId = state.grid.anchorId;
+                if (!anchorId) { return list; }
+                const anchorIndex = list.findIndex(file => file && file.id === anchorId);
+                if (anchorIndex > 0) {
+                    const [anchorFile] = list.splice(anchorIndex, 1);
+                    list.unshift(anchorFile);
+                }
+                return list;
+            },
+
+            ensureAnchorSelection(files = null) {
+                const anchorId = state.grid.anchorId;
+                if (!anchorId) { return; }
+                const items = Array.isArray(files) ? files : state.grid.lazyLoadState.allFiles || [];
+                const hasAnchor = Array.isArray(items) && items.some(file => file && file.id === anchorId);
+                if (hasAnchor) {
+                    const filtered = state.grid.selected.filter(id => id !== anchorId);
+                    state.grid.selected = [anchorId, ...filtered];
+                } else {
+                    state.grid.selected = state.grid.selected.filter(id => id !== anchorId);
+                }
+            },
+
+            applySelectionToRenderedTiles() {
+                const selectedSet = new Set(state.grid.selected);
+                document.querySelectorAll('#grid-container .grid-item').forEach(item => {
+                    const fileId = item.dataset.fileId;
+                    if (selectedSet.has(fileId)) {
+                        item.classList.add('selected');
+                    } else {
+                        item.classList.remove('selected');
+                    }
+                });
+            },
+
+            syncWithCurrentImage(fileId) {
+                state.grid.anchorId = fileId || null;
+                if (!state.grid.stack) {
+                    this.ensureAnchorSelection();
+                    return;
+                }
+                if (!this.isOpen()) {
+                    this.ensureAnchorSelection();
+                    return;
+                }
+                const isFiltered = state.grid.filtered.length > 0;
+                const activeFiles = isFiltered
+                    ? state.grid.filtered.slice()
+                    : (state.stacks[state.grid.stack] || []).slice();
+                const ordered = this.orderWithAnchor(activeFiles);
+                if (isFiltered) {
+                    state.grid.filtered = ordered.slice();
+                }
+                this.ensureAnchorSelection(ordered);
+                this.initializeLazyLoad(state.grid.stack, ordered, { preserveFilter: true });
+                this.updateSelectionUI();
             },
 
             renderBatch() {
@@ -2992,6 +3195,8 @@
                     this.deselectAll();
                     state.grid.selected = [fileId];
                     gridItem.classList.add('selected');
+                    this.ensureAnchorSelection();
+                    this.applySelectionToRenderedTiles();
                     this.updateSelectionUI();
                 }
 
@@ -3140,9 +3345,17 @@
 
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
-                const index = state.grid.selected.indexOf(fileId);
-                if (index === -1) { state.grid.selected.push(fileId); gridItem.classList.add('selected');
-                } else { state.grid.selected.splice(index, 1); gridItem.classList.remove('selected'); }
+                const isSelected = state.grid.selected.includes(fileId);
+                if (isSelected) {
+                    if (fileId === state.grid.anchorId) { return; }
+                    state.grid.selected = state.grid.selected.filter(id => id !== fileId);
+                    gridItem.classList.remove('selected');
+                } else {
+                    state.grid.selected = [...state.grid.selected.filter(id => id !== fileId), fileId];
+                    gridItem.classList.add('selected');
+                }
+                this.ensureAnchorSelection();
+                this.applySelectionToRenderedTiles();
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
@@ -3156,39 +3369,41 @@
             },
             
             selectAll() {
-                const filesToSelect = state.grid.lazyLoadState.allFiles;
+                const filesToSelect = state.grid.lazyLoadState.allFiles || [];
                 state.grid.selected = filesToSelect.map(f => f.id);
-                document.querySelectorAll('#grid-container .grid-item').forEach(item => {
-                    item.classList.add('selected');
-                });
+                this.ensureAnchorSelection(filesToSelect);
+                this.applySelectionToRenderedTiles();
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
             
             deselectAll() {
-                document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
+                this.ensureAnchorSelection();
+                this.applySelectionToRenderedTiles();
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const searchInput = Utils.elements.omniSearch;
                 const query = searchInput.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
-                state.grid.selected = [];
                 if (!query) { this.resetSearch(); return; }
 
                 const results = this.searchImages(query);
-                state.grid.filtered = results;
+                const orderedResults = this.orderWithAnchor(results);
+                state.grid.filtered = orderedResults.slice();
+                state.grid.selected = orderedResults.map(file => file.id);
+                this.ensureAnchorSelection(orderedResults);
 
                 Utils.elements.gridContainer.innerHTML = '';
-                if (results.length === 0) {
+                if (orderedResults.length === 0) {
                     Utils.elements.gridEmptyState.classList.remove('hidden');
                 } else {
                     Utils.elements.gridEmptyState.classList.add('hidden');
                 }
 
-                this.initializeLazyLoad(state.grid.stack, results);
+                this.initializeLazyLoad(state.grid.stack, orderedResults);
                 this.updateSelectionUI();
                 state.grid.isDirty = true;
             },
@@ -3198,10 +3413,11 @@
                 Utils.elements.clearSearchBtn.style.display = 'none';
                 Utils.elements.gridEmptyState.classList.add('hidden');
                 state.grid.filtered = [];
-                Utils.elements.gridContainer.innerHTML = '';
                 this.initializeLazyLoad(state.grid.stack);
                 Core.updateStackCounts();
-                this.deselectAll();
+                this.ensureAnchorSelection();
+                this.applySelectionToRenderedTiles();
+                this.updateSelectionUI();
             },
 
             collectMetadataTokens(metadata, tokens) {
@@ -3455,30 +3671,18 @@
                     this.tagEditor = null;
                 }
                 const targetIds = this.getTargetFileIds(file?.id);
-                container.classList.add('tag-editor-container');
-                container.innerHTML = '';
-                const message = document.createElement('div');
-                message.className = 'tag-editor-note';
-                message.textContent = targetIds.length > 1 ? `Changes apply to ${targetIds.length} selected images.` : 'Changes apply to this image.';
-                container.appendChild(message);
-                const chipList = document.createElement('div');
-                chipList.className = 'tag-chip-list';
-                container.appendChild(chipList);
-                const input = document.createElement('input');
-                input.type = 'text';
-                input.className = 'tag-input';
-                input.placeholder = 'Add tag and press Enter';
-                container.appendChild(input);
-                const suggestions = document.createElement('div');
-                suggestions.className = 'tag-suggestions';
-                container.appendChild(suggestions);
+                const scopeText = targetIds.length > 1
+                    ? `Changes apply to ${targetIds.length} selected images.`
+                    : 'Changes apply to this image.';
+                const layout = createTagEditorLayout(container, { scopeText });
+                if (!layout) return;
                 this.tagEditor = TagEditor.create({
-                    container: chipList,
-                    input,
-                    suggestionContainer: suggestions,
+                    container: layout.chipList,
+                    input: layout.input,
+                    recentContainer: layout.recentList,
                     targetIds
                 });
-                input.focus();
+                if (layout.input) { layout.input.focus(); }
             },
             populateNotesTab(file) {
                 const tab = document.getElementById('tab-notes');
@@ -3617,29 +3821,25 @@
                 const scopeText = total > 1 ? `Changes apply to ${total} selected images.` : 'Changes apply to the selected image.';
                 this.show('tag', {
                     title: 'Edit Tags',
-                    content: `<div class="tag-editor-container">
-                                <div class="tag-editor-note">${scopeText}</div>
-                                <div id="bulk-tag-chips" class="tag-chip-list"></div>
-                                <input type="text" id="bulk-tag-input" class="tag-input" placeholder="Add tag and press Enter">
-                                <div id="bulk-tag-suggestions" class="tag-suggestions"></div>
-                             </div>`,
+                    content: '<div id="bulk-tag-editor"></div>',
                     hideConfirm: true,
                     cancelText: 'Close'
                 });
-                const chipsContainer = document.getElementById('bulk-tag-chips');
-                const input = document.getElementById('bulk-tag-input');
-                const suggestions = document.getElementById('bulk-tag-suggestions');
+                const editorRoot = document.getElementById('bulk-tag-editor');
+                if (!editorRoot) return;
+                const layout = createTagEditorLayout(editorRoot, { scopeText });
                 if (this.tagEditor) {
                     this.tagEditor.destroy();
                     this.tagEditor = null;
                 }
+                if (!layout) return;
                 this.tagEditor = TagEditor.create({
-                    container: chipsContainer,
-                    input,
-                    suggestionContainer: suggestions,
+                    container: layout.chipList,
+                    input: layout.input,
+                    recentContainer: layout.recentList,
                     targetIds: selectedIds
                 });
-                if (input) input.focus();
+                if (layout.input) layout.input.focus();
             },
             setupDeleteAction() {
                 const selectedCount = state.grid.selected.length;
@@ -4203,15 +4403,10 @@
                 await Core.displayCurrentImage();
             },
             async deleteCurrentImage() {
-                const currentStackArray = state.stacks[state.currentStack];
-                if (currentStackArray.length === 0) return;
-                const fileToDelete = currentStackArray[state.currentStackPosition];
-                try {
-                    await App.deleteFile(fileToDelete.id);
-                    Core.updateStackCounts();
-                    if (currentStackArray.length === 0) { this.toggleFocusMode(); Core.showEmptyState();
-                    } else { await Core.displayCurrentImage(); }
-                } catch (error) { Utils.showToast(`Failed to delete ${fileToDelete.name}`, 'error', true); }
+                const result = await Core.deleteFromCurrentStack();
+                if (result && result.stackEmpty && state.isFocusMode) {
+                    this.toggleFocusMode();
+                }
             }
         };
         const Folders = {
@@ -4870,7 +5065,7 @@
                 Utils.elements.detailsClose.addEventListener('click', () => Details.hide());
             },
             setupFocusMode() {
-                Utils.elements.centerTrashBtn.addEventListener('click', () => Core.moveToStack('trash'));
+                Utils.elements.centerTrashBtn.addEventListener('click', () => Core.deleteFromCurrentStack());
                 Utils.elements.focusStackName.addEventListener('click', () => Modal.setupFocusStackSwitch());
                 Utils.elements.focusDeleteBtn.addEventListener('click', () => Gestures.deleteCurrentImage());
                 Utils.elements.focusFavoriteBtn.addEventListener('click', async () => {
@@ -4950,25 +5145,32 @@
                     searchHelper,
                     searchHelperIcon,
                     searchHelperPopup,
-                    searchHelperClose,
-                    searchHelperRecent
+                    searchHelperClose
                 } = Utils.elements;
 
-                const modifierLinks = document.querySelectorAll('.modifier-link');
+                const modifierButtons = document.querySelectorAll('.modifier-item');
                 const appendModifierToInput = (modifier) => {
-                    if (!searchInput) return;
-                    const baseValue = searchInput.value.replace(/\s+$/, '');
-                    const newValue = baseValue ? `${baseValue} ${modifier} ` : `${modifier} `;
-                    searchInput.value = newValue;
+                    if (!searchInput) return false;
+                    const trimmedModifier = (modifier || '').trim();
+                    if (!trimmedModifier) return false;
+
+                    const currentValue = searchInput.value;
+                    const baseValue = currentValue.replace(/\s+$/, '');
+                    const tokens = baseValue.split(/\s+/).filter(Boolean);
+                    const alreadyPresent = tokens.includes(trimmedModifier);
+                    const nextTokens = alreadyPresent ? tokens : [...tokens, trimmedModifier];
+                    const finalTokens = nextTokens.length > 0 ? nextTokens : [trimmedModifier];
+                    searchInput.value = `${finalTokens.join(' ')} `;
                     searchInput.focus();
                     Grid.performSearch();
+                    return true;
                 };
 
                 if (!searchHelper || !searchHelperIcon || !searchHelperPopup) {
-                    modifierLinks.forEach(link => {
-                        link.addEventListener('click', (event) => {
+                    modifierButtons.forEach(button => {
+                        button.addEventListener('click', (event) => {
                             event.preventDefault();
-                            const modifier = link.dataset.modifier;
+                            const modifier = button.dataset.modifier;
                             if (!modifier) return;
                             appendModifierToInput(modifier);
                         });
@@ -4976,44 +5178,33 @@
                     return;
                 }
 
-                const hoverMedia = window.matchMedia('(hover: hover)');
-                const setHelperState = (isOpen) => {
-                    const open = Boolean(isOpen);
-                    searchHelper.classList.toggle('is-open', open);
-                    searchHelperPopup.setAttribute('aria-hidden', String(!open));
-                    searchHelperIcon.setAttribute('aria-expanded', String(open));
+                const setHelperState = (open) => {
+                    const isOpen = Boolean(open);
+                    searchHelper.classList.toggle('is-open', isOpen);
+                    searchHelperPopup.setAttribute('aria-hidden', String(!isOpen));
+                    searchHelperIcon.setAttribute('aria-expanded', String(isOpen));
                 };
-                const resetRecentModifier = () => {
-                    if (!searchHelperRecent) return;
-                    searchHelperRecent.innerHTML = '';
-                    searchHelperRecent.classList.add('hidden');
-                };
+
                 const closeHelper = (focusIcon = false) => {
                     setHelperState(false);
-                    resetRecentModifier();
                     if (focusIcon && searchHelperIcon) {
                         searchHelperIcon.focus();
                     }
                 };
-                const openHelper = () => setHelperState(true);
 
-                if (hoverMedia.matches) {
-                    searchHelper.addEventListener('mouseenter', openHelper);
-                    searchHelperIcon.addEventListener('focus', openHelper);
-                    searchHelperIcon.addEventListener('click', (event) => {
-                        event.preventDefault();
-                        openHelper();
-                    });
-                } else {
-                    searchHelperIcon.addEventListener('click', (event) => {
-                        event.preventDefault();
-                        if (searchHelper.classList.contains('is-open')) {
-                            closeHelper();
-                        } else {
-                            openHelper();
-                        }
-                    });
-                }
+                const toggleHelper = () => {
+                    const shouldOpen = !searchHelper.classList.contains('is-open');
+                    if (shouldOpen) {
+                        setHelperState(true);
+                    } else {
+                        closeHelper();
+                    }
+                };
+
+                searchHelperIcon.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    toggleHelper();
+                });
 
                 if (searchHelperClose) {
                     searchHelperClose.addEventListener('click', (event) => {
@@ -5022,41 +5213,18 @@
                     });
                 }
 
-                const showRecentModifier = (modifier) => {
-                    if (!searchHelperRecent) return;
-                    const pill = document.createElement('button');
-                    pill.type = 'button';
-                    pill.className = 'modifier-pill';
-                    pill.textContent = modifier;
-                    pill.addEventListener('click', () => {
-                        closeHelper(true);
-                    });
-                    searchHelperRecent.innerHTML = '';
-                    searchHelperRecent.appendChild(pill);
-                    searchHelperRecent.classList.remove('hidden');
-                };
-
-                const handleModifierSelection = (modifier) => {
-                    appendModifierToInput(modifier);
-                    if (hoverMedia.matches) {
-                        showRecentModifier(modifier);
-                        openHelper();
-                    } else {
-                        closeHelper();
-                    }
-                };
-
-                modifierLinks.forEach(link => {
-                    link.addEventListener('click', (event) => {
+                modifierButtons.forEach(button => {
+                    button.addEventListener('click', (event) => {
                         event.preventDefault();
-                        const modifier = link.dataset.modifier;
+                        const modifier = button.dataset.modifier;
                         if (!modifier) return;
-                        handleModifierSelection(modifier);
+                        appendModifierToInput(modifier);
+                        closeHelper(true);
                     });
                 });
 
                 document.addEventListener('click', (event) => {
-                    if (!searchHelper.contains(event.target)) {
+                    if (searchHelper && !searchHelper.contains(event.target)) {
                         closeHelper();
                     }
                 });
@@ -5068,13 +5236,6 @@
                 };
                 searchHelperIcon.addEventListener('keydown', handleEscape);
                 searchHelperPopup.addEventListener('keydown', handleEscape);
-
-                const handleMediaChange = () => closeHelper();
-                if (typeof hoverMedia.addEventListener === 'function') {
-                    hoverMedia.addEventListener('change', handleMediaChange);
-                } else if (typeof hoverMedia.addListener === 'function') {
-                    hoverMedia.addListener(handleMediaChange);
-                }
             },
             setupActionButtons() {
                 Utils.elements.tagSelected.addEventListener('click', () => Modal.setupTagAction());


### PR DESCRIPTION
## Summary
- ensure the grid always anchors and pre-selects the center-stage image while improving bottom controls with safe area spacing
- unify the tag editor layout and placeholder between bulk tagging and the details modal for consistent entry behavior
- simplify the search helper into a lightweight list that appends unique modifiers and closes after use, and refresh Version O metadata

## Testing
- not run (HTML-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d1294e03cc832d826484e61175ce29