### PR TITLE
Enhance ui-v4 search helper and focus mode interactions

### DIFF
--- a/ui-v4.html
+++ b/ui-v4.html
@@ -315,21 +315,49 @@
         #clear-search-btn:hover { color: #6b7280; }
         
         /* NEW: Search Helper */
-        .search-helper { position: relative; }
-        .search-helper-icon { color: #9ca3af; cursor: pointer; display: flex; align-items: center; }
-        .search-helper-icon:hover { color: #6b7280; }
+        .search-helper { position: relative; display: flex; align-items: center; }
+        .search-helper-icon {
+            color: #9ca3af; cursor: pointer; display: flex; align-items: center; justify-content: center;
+            background: transparent; border: none; padding: 4px; border-radius: 9999px;
+        }
+        .search-helper-icon:hover, .search-helper-icon:focus-visible { color: #6b7280; }
+        .search-helper-icon:focus-visible {
+            outline: 2px solid #3b82f6; outline-offset: 2px;
+        }
         .search-helper-popup {
             display: none; position: absolute; right: 0; top: 100%; margin-top: 8px;
             background: white; border: 1px solid #e5e7eb; border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-            padding: 8px; width: 220px; z-index: 20;
+            padding: 8px; width: 240px; z-index: 20;
         }
-        .search-helper:hover .search-helper-popup { display: block; }
-        .search-helper-popup h4 { font-size: 13px; font-weight: 600; color: #374151; margin: 4px 0 8px; padding-bottom: 4px; border-bottom: 1px solid #f3f4f6; }
+        .search-helper.is-open .search-helper-popup { display: block; }
+        .search-helper-header {
+            display: flex; align-items: center; justify-content: space-between; gap: 8px;
+            margin-bottom: 8px;
+        }
+        .search-helper-popup h4 {
+            font-size: 13px; font-weight: 600; color: #374151; margin: 0; padding-bottom: 4px; border-bottom: 1px solid #f3f4f6;
+            flex: 1;
+        }
+        .search-helper-close {
+            background: none; border: none; color: #9ca3af; cursor: pointer; padding: 2px; border-radius: 4px;
+        }
+        .search-helper-close:hover, .search-helper-close:focus-visible { color: #6b7280; }
+        .search-helper-close:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
+        .search-helper-recent {
+            display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px;
+        }
+        .search-helper-recent.hidden { display: none; }
+        .modifier-pill {
+            background: #e5e7eb; border: none; border-radius: 9999px; padding: 4px 10px; font-size: 12px; color: #374151;
+            cursor: pointer;
+        }
+        .modifier-pill:hover, .modifier-pill:focus-visible { background: #d1d5db; }
+        .modifier-pill:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
         .search-helper-popup a {
             display: block; font-size: 12px; color: #3b82f6; text-decoration: none; padding: 4px 8px;
             border-radius: 4px; cursor: pointer;
         }
-        .search-helper-popup a:hover { background: #f3f4f6; }
+        .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
 
         .grid-row-4 {
@@ -802,12 +830,18 @@
                 
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
-                    <div class="search-helper">
-                        <div class="search-helper-icon">
+                    <div class="search-helper" id="search-helper">
+                        <button type="button" class="search-helper-icon" id="search-helper-icon" aria-label="Search modifiers" aria-haspopup="true" aria-expanded="false">
                             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                        </div>
-                        <div class="search-helper-popup">
-                            <h4>Special Modifiers</h4>
+                        </button>
+                        <div class="search-helper-popup" id="search-helper-popup" aria-hidden="true">
+                            <div class="search-helper-header">
+                                <h4>Special Modifiers</h4>
+                                <button type="button" class="search-helper-close" id="search-helper-close" aria-label="Close modifier helper">
+                                    <svg style="width: 14px; height: 14px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                                </button>
+                            </div>
+                            <div class="search-helper-recent hidden" id="search-helper-recent"></div>
                             <a class="modifier-link" data-modifier="#favorite">#favorite</a>
                             <a class="modifier-link" data-modifier="#quality:5">#quality:1-5</a>
                             <a class="modifier-link" data-modifier="#content:5">#content:1-5</a>
@@ -1038,6 +1072,11 @@
                     
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
+                    searchHelper: document.getElementById('search-helper'),
+                    searchHelperIcon: document.getElementById('search-helper-icon'),
+                    searchHelperPopup: document.getElementById('search-helper-popup'),
+                    searchHelperClose: document.getElementById('search-helper-close'),
+                    searchHelperRecent: document.getElementById('search-helper-recent'),
                     
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
@@ -2792,14 +2831,17 @@
                 if (entries[0].isIntersecting) { this.renderBatch(); }
             },
 
-            initializeLazyLoad(stack) {
+            initializeLazyLoad(stack, filesOverride = null) {
                 const lazyState = state.grid.lazyLoadState;
-                lazyState.allFiles = state.grid.filtered.length > 0 ? state.grid.filtered : state.stacks[stack];
+                const sourceFiles = Array.isArray(filesOverride)
+                    ? filesOverride
+                    : (state.grid.filtered.length > 0 ? state.grid.filtered : state.stacks[stack]);
+                lazyState.allFiles = sourceFiles;
                 lazyState.renderedCount = 0;
-                Utils.elements.selectAllBtn.textContent = lazyState.allFiles.length;
+                Utils.elements.selectAllBtn.textContent = sourceFiles.length;
                 this.renderBatch();
                 if (lazyState.observer) lazyState.observer.disconnect();
-                lazyState.observer = new IntersectionObserver(this.handleIntersection.bind(this), { 
+                lazyState.observer = new IntersectionObserver(this.handleIntersection.bind(this), {
                     root: Utils.elements.gridContent, rootMargin: "400px"
                 });
                 const sentinel = document.getElementById('grid-sentinel');
@@ -2889,19 +2931,22 @@
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
-                state.grid.selected = [];
                 if (!query) { this.resetSearch(); return; }
-                state.grid.filtered = this.searchImages(query);
-                
-                Utils.elements.gridContainer.innerHTML = '';
-                if (state.grid.filtered.length === 0) {
+
+                const results = this.searchImages(query);
+                state.grid.filtered = results;
+
+                if (results.length === 0) {
+                    state.grid.selected = [];
                     Utils.elements.gridEmptyState.classList.remove('hidden');
                     Utils.elements.selectAllBtn.textContent = '0';
                 } else {
+                    state.grid.selected = results.map(file => file.id);
                     Utils.elements.gridEmptyState.classList.add('hidden');
                 }
 
-                this.initializeLazyLoad(state.grid.stack);
+                Utils.elements.gridContainer.innerHTML = '';
+                this.initializeLazyLoad(state.grid.stack, results);
                 this.updateSelectionUI();
                 state.grid.isDirty = true;
             },
@@ -3216,6 +3261,25 @@
                     option.addEventListener('click', () => { this.executeMove(option.dataset.stack); });
                 });
             },
+            setupFocusStackSwitch() {
+                const availableStacks = STACKS.filter(stack => stack !== state.currentStack && state.stacks[stack].length > 0);
+                let content = `<div style="display: flex; flex-direction: column; gap: 8px; margin-bottom: 16px;">`;
+                if (availableStacks.length > 0) {
+                    content += availableStacks.map(stack => `<button class="move-option" data-stack="${stack}" style="width: 100%; text-align: left; padding: 8px 16px; border-radius: 6px; border: none; background: transparent; cursor: pointer; transition: background-color 0.2s;">${STACK_NAMES[stack]} (${state.stacks[stack].length})</button>`).join('');
+                } else {
+                    content += `<p style="color: #4b5563; text-align: center;">No other stacks have images.</p>`;
+                }
+                content += `</div>`;
+                this.show('focus-stack-switch', { title: 'Switch Stack', content, confirmText: 'Cancel' });
+                document.querySelectorAll('.move-option').forEach(option => {
+                    option.addEventListener('click', () => {
+                        const targetStack = option.dataset.stack;
+                        UI.switchToStack(targetStack);
+                        Core.updateImageCounters();
+                        this.hide();
+                    });
+                });
+            },
             setupTagAction() {
                 const selectedIds = state.grid.selected.length > 0 ? [...state.grid.selected] : [];
                 const total = selectedIds.length;
@@ -3446,6 +3510,7 @@
             hubPressActive: false,
             overlay: null,
             lastHubTap: { time: 0, x: 0, y: 0 },
+            tapHandled: false,
             DOUBLE_TAP_MAX_INTERVAL: 320,
             DOUBLE_TAP_MAX_DISTANCE: 28,
             TAP_DISTANCE_THRESHOLD: 26,
@@ -3646,6 +3711,7 @@
                 }
             },
             handleStart(e) {
+                this.tapHandled = false;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
                 const point = e.touches ? e.touches[0] : e;
@@ -3742,8 +3808,11 @@
                         }
                     }
                 } else if (!this.gestureStarted && isTap) {
-                    this.spawnRipple(this.currentPos.x, this.currentPos.y);
-                    this.handleTap(this.currentPos.x, this.currentPos.y);
+                    if (!this.tapHandled) {
+                        this.tapHandled = true;
+                        this.spawnRipple(this.currentPos.x, this.currentPos.y);
+                        this.handleTap(this.currentPos.x, this.currentPos.y);
+                    }
                 }
                 this.hideAllEdgeGlows();
                 this.hubPressActive = false;
@@ -4181,7 +4250,6 @@
             setupGridControls() {
                 Utils.elements.closeGrid.addEventListener('click', () => Grid.close());
                 Utils.elements.selectAllBtn.addEventListener('click', () => Grid.selectAll());
-                Utils.elements.deselectAllBtn.addEventListener('click', () => Grid.deselectAll());
                 Utils.elements.gridSize.addEventListener('input', () => {
                     const value = Utils.elements.gridSize.value;
                     Utils.elements.gridSizeValue.textContent = value;
@@ -4189,18 +4257,153 @@
                 });
             },
             setupSearchFunctionality() {
-                Utils.elements.omniSearch.addEventListener('input', () => Grid.performSearch());
-                Utils.elements.clearSearchBtn.addEventListener('click', () => Grid.resetSearch());
-                document.querySelectorAll('.modifier-link').forEach(link => {
-                    link.addEventListener('click', (e) => {
-                        e.preventDefault();
-                        const modifier = e.target.dataset.modifier;
-                        const searchInput = Utils.elements.omniSearch;
-                        searchInput.value += ` ${modifier} `;
-                        searchInput.focus();
-                        Grid.performSearch();
+                const searchInput = Utils.elements.omniSearch;
+                const clearBtn = Utils.elements.clearSearchBtn;
+                if (searchInput) {
+                    searchInput.addEventListener('input', () => Grid.performSearch());
+                }
+                if (clearBtn) {
+                    clearBtn.addEventListener('click', () => Grid.resetSearch());
+                }
+
+                const {
+                    searchHelper,
+                    searchHelperIcon,
+                    searchHelperPopup,
+                    searchHelperClose,
+                    searchHelperRecent
+                } = Utils.elements;
+
+                const modifierLinks = document.querySelectorAll('.modifier-link');
+                const appendModifierToInput = (modifier) => {
+                    if (!searchInput) return;
+                    const baseValue = searchInput.value.replace(/\s+$/, '');
+                    const newValue = baseValue ? `${baseValue} ${modifier} ` : `${modifier} `;
+                    searchInput.value = newValue;
+                    searchInput.focus();
+                    Grid.performSearch();
+                };
+
+                if (!searchHelper || !searchHelperIcon || !searchHelperPopup) {
+                    modifierLinks.forEach(link => {
+                        link.addEventListener('click', (event) => {
+                            event.preventDefault();
+                            const modifier = link.dataset.modifier;
+                            if (!modifier) return;
+                            appendModifierToInput(modifier);
+                        });
                     });
-                });
+                } else {
+                    const hoverMedia = window.matchMedia('(hover: hover)');
+                    const setHelperState = (isOpen) => {
+                        const open = Boolean(isOpen);
+                        searchHelper.classList.toggle('is-open', open);
+                        searchHelperPopup.setAttribute('aria-hidden', String(!open));
+                        searchHelperIcon.setAttribute('aria-expanded', String(open));
+                    };
+                    const resetRecentModifier = () => {
+                        if (!searchHelperRecent) return;
+                        searchHelperRecent.innerHTML = '';
+                        searchHelperRecent.classList.add('hidden');
+                    };
+                    const closeHelper = (focusIcon = false) => {
+                        setHelperState(false);
+                        resetRecentModifier();
+                        if (focusIcon && searchHelperIcon) {
+                            searchHelperIcon.focus();
+                        }
+                    };
+                    const openHelper = () => setHelperState(true);
+
+                    if (hoverMedia.matches) {
+                        searchHelper.addEventListener('mouseenter', openHelper);
+                        searchHelperIcon.addEventListener('focus', openHelper);
+                        searchHelperIcon.addEventListener('click', (event) => {
+                            event.preventDefault();
+                            openHelper();
+                        });
+                    } else {
+                        searchHelperIcon.addEventListener('click', (event) => {
+                            event.preventDefault();
+                            if (searchHelper.classList.contains('is-open')) {
+                                closeHelper();
+                            } else {
+                                openHelper();
+                            }
+                        });
+                    }
+
+                    if (searchHelperClose) {
+                        searchHelperClose.addEventListener('click', (event) => {
+                            event.preventDefault();
+                            closeHelper(true);
+                        });
+                    }
+
+                    const showRecentModifier = (modifier) => {
+                        if (!searchHelperRecent) return;
+                        const pill = document.createElement('button');
+                        pill.type = 'button';
+                        pill.className = 'modifier-pill';
+                        pill.textContent = modifier;
+                        pill.addEventListener('click', () => {
+                            closeHelper(true);
+                        });
+                        searchHelperRecent.innerHTML = '';
+                        searchHelperRecent.appendChild(pill);
+                        searchHelperRecent.classList.remove('hidden');
+                    };
+
+                    const handleModifierSelection = (modifier) => {
+                        appendModifierToInput(modifier);
+                        if (hoverMedia.matches) {
+                            showRecentModifier(modifier);
+                            openHelper();
+                        } else {
+                            closeHelper();
+                        }
+                    };
+
+                    modifierLinks.forEach(link => {
+                        link.addEventListener('click', (event) => {
+                            event.preventDefault();
+                            const modifier = link.dataset.modifier;
+                            if (!modifier) return;
+                            handleModifierSelection(modifier);
+                        });
+                    });
+
+                    document.addEventListener('click', (event) => {
+                        if (!searchHelper.contains(event.target)) {
+                            closeHelper();
+                        }
+                    });
+
+                    const handleEscape = (event) => {
+                        if (event.key === 'Escape') {
+                            closeHelper(true);
+                        }
+                    };
+                    searchHelperIcon.addEventListener('keydown', handleEscape);
+                    searchHelperPopup.addEventListener('keydown', handleEscape);
+
+                    const handleMediaChange = () => closeHelper();
+                    if (typeof hoverMedia.addEventListener === 'function') {
+                        hoverMedia.addEventListener('change', handleMediaChange);
+                    } else if (typeof hoverMedia.addListener === 'function') {
+                        hoverMedia.addListener(handleMediaChange);
+                    }
+                }
+
+                if (Utils.elements.deselectAllBtn) {
+                    Utils.elements.deselectAllBtn.addEventListener('click', () => {
+                        if (Utils.elements.omniSearch.value.trim() || state.grid.filtered.length > 0) {
+                            Grid.resetSearch();
+                        } else {
+                            Grid.deselectAll();
+                        }
+                    });
+                }
             },
             setupActionButtons() {
                 Utils.elements.tagSelected.addEventListener('click', () => Modal.setupTagAction());


### PR DESCRIPTION
## Summary
- restore the interactive search helper popup with modifier controls, recent selections, and keyboard accessibility
- auto-select search results, reset the grid correctly on deselect, and surface empty-state feedback when nothing matches
- add the focus stack switcher modal hook in focus mode and prevent duplicate tap handling on image tiles

## Testing
- not run (HTML-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d29cab907c832d867236d07bfb41cd