### PR TITLE
Improve diagnostics modal persistence

### DIFF
--- a/new-poc.html
+++ b/new-poc.html
@@ -715,20 +715,45 @@
 
             function render() {
                 if (!isModalOpen) return;
-                if (!logs.length && !appState.lastDiagnosticsReport) {
+                const persistedLogs = appState.lastDiagnosticsReport?.logs || [];
+                const activeLogs = logs.length ? logs : persistedLogs;
+                if (!activeLogs.length && !appState.lastDiagnosticsReport) {
                     dom.diagnosticsOutput.textContent = 'No diagnostics captured yet.';
                     dom.diagnosticsOutput.classList.add('diagnostics-empty');
                     return;
                 }
                 dom.diagnosticsOutput.classList.remove('diagnostics-empty');
-                const logLines = logs.map(formatEntry).join('\n\n');
+                if (!activeLogs.length) {
+                    dom.diagnosticsOutput.textContent = 'No diagnostics captured yet.';
+                    dom.diagnosticsOutput.classList.add('diagnostics-empty');
+                    return;
+                }
+                const logLines = activeLogs.map(formatEntry).join('\n\n');
                 if (!appState.lastDiagnosticsReport) {
                     dom.diagnosticsOutput.textContent = logLines;
                     return;
                 }
                 const report = appState.lastDiagnosticsReport;
-                const summary = `Release: ${report.release}\nGenerated: ${new Date(report.createdAt).toISOString()}\nQueue entries: ${report.snapshot.queue.length}\nMetadata records: ${report.snapshot.metadata.length}`;
-                dom.diagnosticsOutput.textContent = `${summary}\n\n--- Logs ---\n${logLines}`;
+                const snapshot = report.snapshot || {};
+                const queueEntries = Array.isArray(snapshot.queue) ? snapshot.queue.length : 0;
+                const metadataRecords = Array.isArray(snapshot.metadata) ? snapshot.metadata.length : 0;
+                const summaryParts = [
+                    `Release: ${report.release}`,
+                    `Generated: ${new Date(report.createdAt).toISOString()}`,
+                    `Queue entries: ${queueEntries}`,
+                    `Metadata records: ${metadataRecords}`
+                ];
+                if (snapshot.provider) {
+                    summaryParts.push(`Provider: ${snapshot.provider}`);
+                }
+                if (snapshot.currentFolder) {
+                    const folderName = snapshot.currentFolder.name || snapshot.currentFolder.id || 'unknown';
+                    summaryParts.push(`Current folder: ${folderName}`);
+                }
+                if (!logs.length && persistedLogs.length) {
+                    summaryParts.push('Source: Last saved diagnostics snapshot');
+                }
+                dom.diagnosticsOutput.textContent = `${summaryParts.join('\n')}\n\n--- Logs ---\n${logLines}`;
             }
 
             function log(message, context = null, level = 'info') {
@@ -752,8 +777,35 @@
 
             async function copy() {
                 const text = dom.diagnosticsOutput.textContent || '';
-                await navigator.clipboard.writeText(text);
-                showStatus('Diagnostics copied to clipboard.', 'success');
+                if (!text.trim()) {
+                    showStatus('No diagnostics to copy yet.', 'info');
+                    return;
+                }
+                if (typeof navigator !== 'undefined' && navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+                    await navigator.clipboard.writeText(text);
+                    showStatus('Diagnostics copied to clipboard.', 'success');
+                    return;
+                }
+                const textarea = document.createElement('textarea');
+                textarea.value = text;
+                textarea.setAttribute('readonly', '');
+                textarea.style.position = 'fixed';
+                textarea.style.opacity = '0';
+                document.body.appendChild(textarea);
+                textarea.select();
+                try {
+                    const successful = document.execCommand('copy');
+                    if (!successful) {
+                        throw new Error('execCommand copy failed');
+                    }
+                    showStatus('Diagnostics copied to clipboard.', 'success');
+                } catch (error) {
+                    showStatus('Clipboard copy not supported.', 'error');
+                    log('Clipboard fallback failed', { error: error.message }, 'error');
+                    throw error;
+                } finally {
+                    document.body.removeChild(textarea);
+                }
             }
 
             function download() {


### PR DESCRIPTION
## Summary
- surface persisted diagnostics logs when reopening the modal so the previous session history remains visible
- add richer diagnostics summary metadata and guardrails for empty log displays
- harden the copy-to-clipboard action with no-log messaging and a fallback when the async clipboard API is unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d39edfa2fc832daa01d51727c2c8dd