### PR TITLE
Fix Google Drive upload URL in v9 sync

### DIFF
--- a/ui-v9.html
+++ b/ui-v9.html
@@ -3266,7 +3266,14 @@
             }
             async makeApiCall(endpoint, options = {}, isJson = true) {
                 if (!this.accessToken) { throw new Error('Not authenticated'); }
-                const url = endpoint.startsWith('https://') ? endpoint : `${this.apiBase}${endpoint}`;
+                let url;
+                if (endpoint.startsWith('https://')) {
+                    url = endpoint;
+                } else if (endpoint.startsWith('/upload/drive/')) {
+                    url = `https://www.googleapis.com${endpoint}`;
+                } else {
+                    url = `${this.apiBase}${endpoint}`;
+                }
                 const headers = { 'Authorization': `Bearer ${this.accessToken}`, ...options.headers };
                 if(isJson) { headers['Content-Type'] = 'application/json'; }
                 let response = await fetch(url, { ...options, headers });


### PR DESCRIPTION
## Summary
- correct the Google Drive upload URL construction so manifest writes use the proper upload endpoint
- ensure sync operations no longer fail with "Failed to fetch" during manifest persistence

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d722e27f74832d97ca0043f3c64760