### PR TITLE
Ensure provider flush completes before unbinding provider context

### DIFF
--- a/ui-v9.html
+++ b/ui-v9.html
@@ -2621,9 +2621,14 @@
                 this.isActive = true;
                 this.resumePendingQueue();
             }
-            stop() {
-                this.flush({ reason: 'stop' }).catch(() => {});
-                if (!this.isActive) return;
+            async stop() {
+                const flushResult = await this.flush({ reason: 'stop' });
+                if (!this.isActive) {
+                    this.provider = null;
+                    this.providerType = null;
+                    this.pendingManifestUpdates.clear();
+                    return flushResult;
+                }
                 document.removeEventListener('visibilitychange', this.lifecycleHandlers.visibility);
                 window.removeEventListener('pagehide', this.lifecycleHandlers.pagehide);
                 window.removeEventListener('beforeunload', this.lifecycleHandlers.beforeUnload);
@@ -2631,6 +2636,7 @@
                 this.provider = null;
                 this.providerType = null;
                 this.pendingManifestUpdates.clear();
+                return flushResult;
             }
             async resumePendingQueue() {
                 if (!this.dbManager) return;
@@ -3785,11 +3791,11 @@
                     authButton.textContent = `Connect ${isGoogle ? 'Drive' : 'OneDrive'}`;
                 }
             },
-            backToProviderSelection() {
+            async backToProviderSelection() {
                 if (state.syncManager) {
-                    state.syncManager.flush({ reason: 'provider-screen' });
+                    await state.syncManager.flush({ reason: 'provider-screen' });
+                    await state.syncManager.stop();
                     state.syncManager.setProviderContext({ provider: null, providerType: null });
-                    state.syncManager.stop();
                 }
                 state.folderSyncCoordinator?.setProviderContext({ provider: null, providerType: null });
                 state.provider = null;
@@ -6191,18 +6197,18 @@
             },
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
-                Utils.elements.authBackButton.addEventListener('click', () => App.backToProviderSelection());
+                Utils.elements.authBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });
             },
             setupFolderManagement() {
                 Utils.elements.backButton.addEventListener('click', () => App.returnToFolderSelection());
 
-                Utils.elements.folderBackButton.addEventListener('click', () => App.backToProviderSelection());
+                Utils.elements.folderBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });
                 Utils.elements.folderLogoutButton.addEventListener('click', async () => {
                     try {
                         if (state.provider) {
                             await state.provider.disconnect();
                         }
-                        App.backToProviderSelection();
+                        await App.backToProviderSelection();
                     } catch (error) {
                         Utils.showToast(`Logout failed: ${error.message}`, 'error', true);
                     }


### PR DESCRIPTION
## Summary
- make `SyncManager.stop()` async so it awaits a final flush before tearing down the provider context
- update the provider back-navigation flow to await flush and stop so pending work is committed before unbinding
- adjust UI back buttons and logout to await the asynchronous navigation helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d77d722d04832db9b276fa2329ccbf