### PR TITLE
Ensure flush persists pending manifest updates

### DIFF
--- a/ui-v9.html
+++ b/ui-v9.html
@@ -3008,11 +3008,11 @@
                     return 'beacon';
                 }
                 const result = await this.processQueue(reason);
-                if (this.lastSyncAppliedCount > 0 && state.folderSyncCoordinator) {
+                if (state.folderSyncCoordinator && (this.lastSyncAppliedCount > 0 || this.pendingManifestUpdates.size > 0)) {
                     const timestamp = Date.now();
                     if (this.pendingManifestUpdates.size > 0) {
                         await this.persistPendingManifestUpdates(timestamp);
-                    } else if (state.currentFolder?.id) {
+                    } else if (this.lastSyncAppliedCount > 0 && state.currentFolder?.id) {
                         await state.folderSyncCoordinator.recordLocalFlush(state.currentFolder.id, { timestamp });
                     }
                 }


### PR DESCRIPTION
## Summary
- ensure SyncManager.flush persists pending manifest updates whenever they exist
- retain the recordLocalFlush fallback for applied queue entries without manifest payloads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7a0592704832d9ecce248722d9b9a