### PR TITLE
Fix trash pill double-tap behavior in v9 UI

### DIFF
--- a/ui-v9.html
+++ b/ui-v9.html
@@ -6088,7 +6088,7 @@
                     setTimeout(() => { pill.classList.remove('triple-ripple', 'glow-effect'); }, 3000);
                 }
             },
-            switchToStack(stackName) { Core.displayTopImageFromStack(stackName); },
+            switchToStack(stackName) { return Core.displayTopImageFromStack(stackName); },
             cycleThroughPills() {
                 const stackOrder = ['in', 'out', 'priority', 'trash'];
                 const currentIndex = stackOrder.indexOf(state.currentStack);
@@ -6327,14 +6327,22 @@
                 STACKS.forEach(stackName => {
                     const pill = document.getElementById(`pill-${stackName}`);
                     if (pill) {
-                        pill.addEventListener('click', (e) => {
+                        pill.addEventListener('click', async (e) => {
                             e.stopPropagation();
                             if (state.haptic) { state.haptic.triggerFeedback('pillTap'); }
-                             if (state.currentStack === stackName) {
+
+                            if (stackName === 'trash') {
+                                if (state.currentStack !== stackName) {
+                                    await UI.switchToStack(stackName);
+                                } else {
+                                    Grid.open(stackName);
+                                }
+                            } else if (state.currentStack === stackName) {
                                 Grid.open(stackName);
                             } else {
                                 UI.switchToStack(stackName);
                             }
+
                             UI.acknowledgePillCounter(stackName);
                         });
                     }


### PR DESCRIPTION
## Summary
- make the trash pill listener await the stack switch before treating a second tap as a grid request
- return the display promise from `UI.switchToStack` so callers can await stack activation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7b606e688832db71aa6530984fe3a