### PR TITLE
Expand favorite toggle hit area in focus mode

### DIFF
--- a/ui-v9.html
+++ b/ui-v9.html
@@ -527,18 +527,31 @@
             border: none;
             cursor: pointer;
             z-index: 20;
-            padding: 28px;
+            display: flex;
             align-items: center;
             justify-content: center;
+            padding: 32px;
             border-radius: 999px;
-            min-width: 84px;
-            min-height: 84px;
+            min-width: 108px;
+            min-height: 108px;
             touch-action: manipulation;
+            pointer-events: auto;
             color: #9ca3af; /* Standalone grey outline */
+        }
+        @media (max-width: 480px) {
+            #focus-favorite-btn {
+                padding: 36px;
+                min-width: 120px;
+                min-height: 120px;
+            }
         }
         #focus-favorite-btn svg { pointer-events: none; }
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
+        }
+        #focus-favorite-btn:focus-visible {
+            outline: 2px solid rgba(239, 68, 68, 0.6);
+            outline-offset: 4px;
         }
 
         #focus-filename-display,


### PR DESCRIPTION
## Summary
- enlarge the focus-mode favorite toggle hit target with flex layout and larger padding
- add mobile sizing adjustments and focus-visible outline for better accessibility

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7bc81d7ac832db37a4a1aff50555d