### PR TITLE
Recreate ui-v2 from v1 with gesture and favorite fixes

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -1,9 +1,4 @@
-diff --git a//dev/null b/ui-v6.html
-index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5e2d04e56 100644
---- a//dev/null
- b/ui-v6.html
-@@ -0,0 1,5327 @@
-<!-- Orbital8-O-2025-09-24 12:00 PM -->
+<!-- Orbital8-N-2025-09-18 04:40 AM -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -348,6 +343,16 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
         }
         .search-helper-close:hover, .search-helper-close:focus-visible { color: #6b7280; }
         .search-helper-close:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
+        .search-helper-recent {
+            display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px;
+        }
+        .search-helper-recent.hidden { display: none; }
+        .modifier-pill {
+            background: #e5e7eb; border: none; border-radius: 9999px; padding: 4px 10px; font-size: 12px; color: #374151;
+            cursor: pointer;
+        }
+        .modifier-pill:hover, .modifier-pill:focus-visible { background: #d1d5db; }
+        .modifier-pill:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
         .search-helper-popup a {
             display: block; font-size: 12px; color: #3b82f6; text-decoration: none; padding: 4px 8px;
             border-radius: 4px; cursor: pointer;
@@ -368,6 +373,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
         }
+        .grid-item.drop-target { outline: 3px solid #f97316; outline-offset: -3px; }
         .grid-item::before { content: ""; display: block; padding-top: 100%; }
         .grid-image {
             position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: contain;
@@ -376,6 +382,22 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
+
+        .grid-drag-handle {
+            position: absolute; top: 6px; right: 6px; width: 28px; height: 28px;
+            display: flex; align-items: center; justify-content: center; border-radius: 6px;
+            background: rgba(17, 24, 39, 0.7); color: #f9fafb; font-size: 16px; line-height: 1;
+            border: none; cursor: grab; touch-action: none; z-index: 3;
+        }
+        .grid-drag-handle:focus { outline: 2px solid #bfdbfe; outline-offset: 2px; }
+        .grid-drag-handle:active { cursor: grabbing; }
+
+        .grid-drag-ghost {
+            position: fixed; pointer-events: none; opacity: 0.9; transform: translate3d(0,0,0);
+            z-index: 9999; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.35);
+            border-radius: 8px; overflow: hidden;
+        }
+        .grid-drag-ghost .grid-drag-handle { display: none; }
 
         .filename-overlay {
             position: absolute;
@@ -418,30 +440,25 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
         
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
-        .tag-section { display: flex; flex-direction: column; gap: 6px; }
-        .tag-section-title {
-            font-size: 12px; font-weight: 600; color: #4b5563; text-transform: uppercase; letter-spacing: 0.04em;
-        }
+        .tags-container.tag-editor-container { display: flex; flex-direction: column; gap: 12px; min-height: 0; }
         .tag-chip-list { display: flex; flex-wrap: wrap; gap: 6px; min-height: 32px; }
         .tag-chip {
             display: inline-flex; align-items: center; background: #e0e7ff; color: #3730a3; padding: 4px 8px;
             border-radius: 12px; font-size: 13px; font-weight: 500; gap: 6px;
         }
-        .tag-chip--recent { background: #e5e7eb; color: #374151; }
-        .tag-chip-button {
-            background: transparent; border: none; color: inherit; cursor: pointer; font-size: inherit; padding: 0; display: flex;
-            align-items: center; gap: 6px;
-        }
-        .tag-chip-button:focus-visible {
-            outline: 2px solid #3b82f6; outline-offset: 2px;
-        }
         .tag-chip-remove {
-            background: transparent; border: none; color: inherit; cursor: pointer; font-size: 14px; line-height: 1; padding: 0;
+            background: transparent; border: none; color: #4338ca; cursor: pointer; font-size: 14px; line-height: 1; padding: 0;
             width: 16px; height: 16px; display: flex; align-items: center; justify-content: center; border-radius: 50%;
             transition: background-color 0.2s;
         }
-        .tag-chip-remove:hover { background: rgba(99, 102, 241, 0.12); }
-        .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
+        .tag-chip-remove:hover { background: rgba(99, 102, 241, 0.1); }
+        .tag-suggestions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 4px; }
+        .tag-suggestions.hidden { display: none; }
+        .tag-suggestion {
+            background-color: #e5e7eb; color: #374151; padding: 4px 8px; border-radius: 6px;
+            font-size: 12px; cursor: pointer; transition: background-color 0.2s; border: none;
+        }
+        .tag-suggestion:hover { background-color: #d1d5db; }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
 
@@ -469,25 +486,6 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             color: rgba(255, 255, 255, 0.6); text-align: center;
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
-        }
-        .app-footer .footer-link {
-            background: transparent;
-            border: none;
-            color: rgba(255, 255, 255, 0.65);
-            cursor: pointer;
-            font: inherit;
-            margin-left: 8px;
-            padding: 0;
-            text-decoration: none;
-            transition: color 0.2s ease;
-        }
-        .app-footer .footer-link:hover,
-        .app-footer .footer-link:focus-visible {
-            color: #f59e0b;
-            text-decoration: underline;
-        }
-        .app-footer .footer-link:focus-visible {
-            outline: none;
         }
 
         /* NEW: Standardized UI Button */
@@ -595,7 +593,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             top: 12px;
             bottom: 12px;
             left: 12px;
-            right: calc(50%  6px);
+            right: calc(50% + 6px);
             border-radius: 16px;
             background: transparent;
         }
@@ -603,7 +601,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             position: absolute;
             top: 12px;
             bottom: 12px;
-            left: calc(50%  6px);
+            left: calc(50% + 6px);
             right: 12px;
             border-radius: 16px;
             background: transparent;
@@ -699,7 +697,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">Orbital8-O-2025-09-24 12:00 PM</div>
+        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -714,7 +712,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">Orbital8-O-2025-09-24 12:00 PM</div>
+        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -729,7 +727,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">Orbital8-O-2025-09-24 12:00 PM</div>
+        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
     </div>
     
     <!-- Loading Screen -->
@@ -743,7 +741,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">Orbital8-O-2025-09-24 12:00 PM</div>
+        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
     </div>
     
     <!-- Main App Container -->
@@ -757,7 +755,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
-        <!-- Gesture overlay (triangular sort zones  focus halves) -->
+        <!-- Gesture overlay (triangular sort zones + focus halves) -->
         <div class="gesture-layer" id="gesture-layer">
             <div id="gesture-screen-a" class="stage" role="application"
                  aria-label="Sort mode. Triangular flick zones. Double-tap center hub to enter focus mode.">
@@ -813,7 +811,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
         </button>
         
         <div id="toast" class="toast"></div>
-        <div class="app-footer">Orbital8-O-2025-09-24 12:00 PM</div>
+        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -860,6 +858,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                                     <svg style="width: 14px; height: 14px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                                 </button>
                             </div>
+                            <div class="search-helper-recent hidden" id="search-helper-recent"></div>
                             <a class="modifier-link" data-modifier="#favorite">#favorite</a>
                             <a class="modifier-link" data-modifier="#quality:5">#quality:1-5</a>
                             <a class="modifier-link" data-modifier="#content:5">#content:1-5</a>
@@ -988,20 +987,29 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
         
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
+        const createDefaultGridDragSession = () => ({
+            active: false,
+            pointerId: null,
+            ghost: null,
+            offsetX: 0,
+            offsetY: 0,
+            dropTarget: null,
+            selectedIds: []
+        });
         const state = {
             provider: null, providerType: null, dbManager: null, metadataExtractor: null,
-            syncManager: null, syncLog: null, visualCues: null, haptic: null, export: null, currentFolder: { id: null, name: '' },
+            syncManager: null, visualCues: null, haptic: null, export: null, currentFolder: { id: null, name: '' },
             imageFiles: [], currentImageLoadId: null, currentStack: 'in', currentStackPosition: 0,
             isFocusMode: false, stacks: { in: [], out: [], priority: [], trash: [] },
             isDragging: false, isPinching: false, initialDistance: 0, currentScale: 1,
             maxScale: 4, minScale: 0.3, panOffset: { x: 0, y: 0 },
-            grid: { stack: null, selected: [], filtered: [], isDirty: false,
+            grid: { stack: null, selected: [], filtered: [], isDirty: false, isDragging: false,
+                dragSession: createDefaultGridDragSession(),
                 lazyLoadState: { allFiles: [], renderedCount: 0, observer: null, batchSize: 20 } },
             tags: new Set(), loadingProgress: { current: 0, total: 0 },
             folderMoveMode: { active: false, files: [] },
             activeRequests: new AbortController(),
-            sessionVisitedFolders: new Set(),
-            isImageTransitioning: false
+            sessionVisitedFolders: new Set()
         };
         const Utils = {
             elements: {},
@@ -1095,6 +1103,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
+                    searchHelperRecent: document.getElementById('search-helper-recent'),
                     
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
@@ -1151,7 +1160,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             },
             
             async setImageSrc(img, file) {
-                const loadId = file.id  '_'  Date.now();
+                const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
                 let imageUrl = this.getPreferredImageUrl(file);
                 return new Promise((resolve) => {
@@ -1165,7 +1174,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                         
                         img.onerror = () => {
                             if (state.currentImageLoadId !== loadId) return;
-                            img.src = 'data:image/svgxml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'150\' height=\'150\' viewBox=\'0 0 150 150\' fill=\'none\'%3E%3Crect width=\'150\' height=\'150\' fill=\'%23E5E7EB\'/%3E%3Cpath d=\'M65 60H85V90H65V60Z\' fill=\'%239CA3AF\'/%3E%3Ccircle cx=\'75\' cy=\'45\' r=\'10\' fill=\'%239CA3AF\'/%3E%3C/svg%3E';
+                            img.src = 'data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'150\' height=\'150\' viewBox=\'0 0 150 150\' fill=\'none\'%3E%3Crect width=\'150\' height=\'150\' fill=\'%23E5E7EB\'/%3E%3Cpath d=\'M65 60H85V90H65V60Z\' fill=\'%239CA3AF\'/%3E%3Ccircle cx=\'75\' cy=\'45\' r=\'10\' fill=\'%239CA3AF\'/%3E%3C/svg%3E';
                             resolve();
                         };
                         img.src = fallbackUrl;
@@ -1177,10 +1186,8 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
-                    if (file.thumbnailLink) {
-                        return file.thumbnailLink.replace('=s220', '=s1000');
-                    }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    const encodedId = encodeURIComponent(file.id);
+                    return `https://drive.google.com/uc?export=view&id=${encodedId}`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1191,7 +1198,8 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
 
             getFallbackImageUrl(file) {
                  if (state.providerType === 'googledrive') {
-                    return file.downloadUrl || `https://www.googleapis.com/drive/v3/files/${file.id}?alt=media`;
+                    const encodedId = encodeURIComponent(file.id);
+                    return `https://drive.google.com/uc?export=download&id=${encodedId}`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -1202,7 +1210,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 const k = 1024;
                 const sizes = ['Bytes', 'KB', 'MB', 'GB'];
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
-                return parseFloat((bytes / Math.pow(k, i)).toFixed(2))  ' '  sizes[i];
+                return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
             
             updateLoadingProgress(current, total, message = '') {
@@ -1222,21 +1230,6 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             normalizeIds(ids = []) {
                 return Array.from(new Set((ids || []).map(id => (id != null ? String(id) : '')).filter(Boolean)));
             },
-            normalizeTagValue(tag) {
-                const trimmed = (tag || '').trim();
-                if (!trimmed) return '';
-                return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
-            },
-            normalizeTagList(tags = []) {
-                const normalized = [];
-                (tags || []).forEach(tag => {
-                    const value = this.normalizeTagValue(tag);
-                    if (value && !normalized.includes(value)) {
-                        normalized.push(value);
-                    }
-                });
-                return normalized;
-            },
             getFiles(ids = []) {
                 const normalized = this.normalizeIds(ids);
                 return normalized.map(id => state.imageFiles.find(file => file.id === id)).filter(Boolean);
@@ -1244,30 +1237,33 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             getDisplayTags(ids = []) {
                 const files = this.getFiles(ids);
                 const seen = new Set();
+                const tags = [];
                 files.forEach(file => {
-                    const normalizedTags = this.normalizeTagList(file.tags || []);
-                    file.tags = normalizedTags;
-                    normalizedTags.forEach(tag => {
-                        seen.add(tag);
-                        state.tags.add(tag);
+                    (file.tags || []).forEach(tag => {
+                        if (!seen.has(tag)) {
+                            seen.add(tag);
+                            tags.push(tag);
+                        }
+                        if (!state.tags.has(tag)) {
+                            state.tags.add(tag);
+                        }
                     });
                 });
-                return Array.from(seen).sort((a, b) => a.localeCompare(b));
+                return tags;
             },
             async addTag(tag, ids = []) {
-                const normalizedTag = this.normalizeTagValue(tag);
+                const trimmed = (tag || '').trim();
                 const targetIds = this.normalizeIds(ids);
-                if (!normalizedTag || targetIds.length === 0) {
+                if (!trimmed || targetIds.length === 0) {
                     return this.getDisplayTags(targetIds);
                 }
                 const files = this.getFiles(targetIds);
                 let changed = false;
                 const tasks = files.map(file => {
-                    const currentTags = this.normalizeTagList(file.tags || []);
-                    if (!currentTags.includes(normalizedTag)) {
+                    const currentTags = Array.isArray(file.tags) ? file.tags : [];
+                    if (!currentTags.includes(trimmed)) {
                         changed = true;
-                        const newTags = [...currentTags, normalizedTag];
-                        file.tags = newTags;
+                        const newTags = [...currentTags, trimmed];
                         return App.updateUserMetadata(file.id, { tags: newTags });
                     }
                     return null;
@@ -1275,23 +1271,22 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 if (tasks.length > 0) {
                     await Promise.all(tasks);
                 }
-                if (changed) {
-                    state.tags.add(normalizedTag);
+                if (changed && !state.tags.has(trimmed)) {
+                    state.tags.add(trimmed);
                 }
                 return this.getDisplayTags(targetIds);
             },
             async removeTag(tag, ids = []) {
-                const normalizedTag = this.normalizeTagValue(tag);
+                const trimmed = (tag || '').trim();
                 const targetIds = this.normalizeIds(ids);
-                if (!normalizedTag || targetIds.length === 0) {
+                if (!trimmed || targetIds.length === 0) {
                     return this.getDisplayTags(targetIds);
                 }
                 const files = this.getFiles(targetIds);
                 const tasks = files.map(file => {
-                    const currentTags = this.normalizeTagList(file.tags || []);
-                    if (currentTags.includes(normalizedTag)) {
-                        const newTags = currentTags.filter(t => t !== normalizedTag);
-                        file.tags = newTags;
+                    const currentTags = Array.isArray(file.tags) ? file.tags : [];
+                    if (currentTags.includes(trimmed)) {
+                        const newTags = currentTags.filter(t => t !== trimmed);
                         return App.updateUserMetadata(file.id, { tags: newTags });
                     }
                     return null;
@@ -1302,23 +1297,18 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 return this.getDisplayTags(targetIds);
             },
             getSessionTags() {
-                return Array.from(state.tags).sort((a, b) => a.localeCompare(b));
-            },
-            removeSessionTag(tag) {
-                const normalized = this.normalizeTagValue(tag);
-                if (!normalized) return;
-                state.tags.delete(normalized);
+                return Array.from(state.tags);
             }
         };
 
         class TagEditorInstance {
             constructor(options) {
-                const { container, input, recentContainer, targetIds = [], placeholder } = options;
+                const { container, input, suggestionContainer, targetIds = [], placeholder } = options;
                 this.container = container;
                 this.input = input;
-                this.recentContainer = recentContainer;
+                this.suggestionContainer = suggestionContainer;
                 this.targetIds = TagService.normalizeIds(targetIds);
-                this.placeholder = placeholder || 'Enter tags separated by commas - non-# tags are auto-prefixed when you press Enter';
+                this.placeholder = placeholder || 'Add tag and press Enter';
                 this.isProcessing = false;
                 this.handleKeydown = this.handleKeydown.bind(this);
             }
@@ -1330,13 +1320,13 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                     this.input.addEventListener('keydown', this.handleKeydown);
                 }
                 this.refresh();
-                this.renderRecents();
+                this.renderSuggestions();
             }
 
             setTargetIds(ids = []) {
                 this.targetIds = TagService.normalizeIds(ids);
                 this.refresh();
-                this.renderRecents();
+                this.renderSuggestions();
             }
 
             getTags() {
@@ -1350,9 +1340,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                     const value = this.input.value.trim();
                     if (!value) return;
                     this.input.value = '';
-                    const values = value.split(',').map(v => v.trim()).filter(Boolean);
-                    if (values.length === 0) return;
-                    await this.addTag(values);
+                    await this.addTag(value);
                 }
             }
 
@@ -1360,12 +1348,9 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 if (this.isProcessing) return;
                 this.isProcessing = true;
                 try {
-                    const tagsToAdd = Array.isArray(tag) ? tag : [tag];
-                    for (const rawTag of tagsToAdd) {
-                        await TagService.addTag(rawTag, this.targetIds);
-                    }
+                    await TagService.addTag(tag, this.targetIds);
                     this.refresh();
-                    this.renderRecents();
+                    this.renderSuggestions();
                 } catch (error) {
                     Utils.showToast(`Failed to add tag: ${error.message}`, 'error', true);
                 } finally {
@@ -1380,7 +1365,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 try {
                     await TagService.removeTag(tag, this.targetIds);
                     this.refresh();
-                    this.renderRecents();
+                    this.renderSuggestions();
                 } catch (error) {
                     Utils.showToast(`Failed to remove tag: ${error.message}`, 'error', true);
                 } finally {
@@ -1410,43 +1395,23 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 });
             }
 
-            renderRecents() {
-                if (!this.recentContainer) return;
-                const assigned = new Set(this.getTags());
-                const tags = TagService.getSessionTags().filter(tag => !assigned.has(tag));
-                this.recentContainer.innerHTML = '';
-                const section = this.recentContainer.closest('.tag-section');
+            renderSuggestions() {
+                if (!this.suggestionContainer) return;
+                const tags = TagService.getSessionTags();
+                this.suggestionContainer.innerHTML = '';
                 if (tags.length === 0) {
-                    this.recentContainer.style.display = 'none';
-                    if (section) section.style.display = 'none';
+                    this.suggestionContainer.classList.add('hidden');
                     return;
                 }
-                this.recentContainer.style.display = '';
-                if (section) section.style.display = '';
+                this.suggestionContainer.classList.remove('hidden');
                 tags.forEach(tag => {
-                    const chip = document.createElement('div');
-                    chip.className = 'tag-chip tag-chip--recent';
-
-                    const applyButton = document.createElement('button');
-                    applyButton.type = 'button';
-                    applyButton.className = 'tag-chip-button';
-                    applyButton.textContent = tag;
-                    applyButton.addEventListener('click', () => this.addTag(tag));
-
-                    const removeBtn = document.createElement('button');
-                    removeBtn.type = 'button';
-                    removeBtn.className = 'tag-chip-remove';
-                    removeBtn.dataset.tag = tag;
-                    removeBtn.textContent = '×';
-                    removeBtn.addEventListener('click', (event) => {
-                        event.stopPropagation();
-                        TagService.removeSessionTag(tag);
-                        this.renderRecents();
-                    });
-
-                    chip.appendChild(applyButton);
-                    chip.appendChild(removeBtn);
-                    this.recentContainer.appendChild(chip);
+                    const button = document.createElement('button');
+                    button.type = 'button';
+                    button.className = 'tag-suggestion';
+                    button.dataset.tag = tag;
+                    button.textContent = tag;
+                    button.addEventListener('click', () => this.addTag(tag));
+                    this.suggestionContainer.appendChild(button);
                 });
             }
 
@@ -1457,11 +1422,8 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 if (this.container) {
                     this.container.innerHTML = '';
                 }
-                if (this.recentContainer) {
-                    this.recentContainer.innerHTML = '';
-                    this.recentContainer.style.display = '';
-                    const section = this.recentContainer.closest('.tag-section');
-                    if (section) section.style.display = '';
+                if (this.suggestionContainer) {
+                    this.suggestionContainer.innerHTML = '';
                 }
             }
         }
@@ -1717,164 +1679,6 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             return wrapper;
         }
 
-        class SyncActivityLogger {
-            constructor() {
-                this.entries = [];
-                this.maxEntries = 800;
-                this.logWindow = null;
-                this.footerLinks = [];
-            }
-            init() {
-                window.__orbitalSyncLogger = this;
-                this.attachFooterLinks();
-                this.log({ event: 'logger:init', level: 'info', details: 'Sync activity logger ready.' });
-            }
-            attachFooterLinks() {
-                const footers = document.querySelectorAll('.app-footer');
-                footers.forEach(footer => {
-                    if (footer.querySelector('.footer-link')) return;
-                    const button = document.createElement('button');
-                    button.type = 'button';
-                    button.className = 'footer-link';
-                    button.textContent = 'Sync Log';
-                    button.setAttribute('aria-label', 'Open sync activity log window');
-                    button.addEventListener('click', (event) => {
-                        event.preventDefault();
-                        this.openWindow();
-                    });
-                    footer.appendChild(button);
-                    this.footerLinks.push(button);
-                });
-            }
-            openWindow() {
-                if (this.logWindow && !this.logWindow.closed) {
-                    this.logWindow.focus();
-                    this.renderWindow();
-                    return;
-                }
-                const features = 'width=520,height=720,resizable=yes,scrollbars=yes';
-                this.logWindow = window.open('', 'orbital8-sync-log', features);
-                if (!this.logWindow) {
-                    alert('Popup blocked. Allow popups to view the sync activity log.');
-                    return;
-                }
-                const doc = this.logWindow.document;
-                doc.open();
-                doc.write(`<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Sync Activity Log</title><style>
-                    body{margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#0f172a;color:#e2e8f0;}
-                    header{display:flex;justify-content:space-between;align-items:center;padding:12px 16px;background:#111827;border-bottom:1px solid rgba(148,163,184,0.2);position:sticky;top:0;z-index:10;}
-                    header h1{font-size:16px;margin:0;letter-spacing:0.02em;}
-                    header .actions{display:flex;gap:8px;align-items:center;}
-                    header button{background:#f59e0b;border:none;color:#111827;font-weight:600;padding:6px 12px;border-radius:8px;cursor:pointer;box-shadow:0 4px 12px rgba(245,158,11,0.35);}
-                    header button.secondary{background:transparent;color:#e2e8f0;border:1px solid rgba(148,163,184,0.4);box-shadow:none;}
-                    header button:focus-visible{outline:2px solid #fbbf24;outline-offset:2px;}
-                    #sync-log-entries{padding:16px;display:flex;flex-direction:column;gap:12px;height:calc(100vh - 64px);overflow:auto;background:linear-gradient(180deg,#0f172a,#020617);}
-                    #sync-log-entries::-webkit-scrollbar{width:8px;}
-                    #sync-log-entries::-webkit-scrollbar-thumb{background:rgba(148,163,184,0.4);border-radius:6px;}
-                    .log-entry{padding:12px 14px;border-radius:10px;background:rgba(30,41,59,0.7);border:1px solid rgba(148,163,184,0.2);box-shadow:0 8px 24px rgba(2,6,23,0.35);}
-                    .log-entry.log-success{border-color:rgba(34,197,94,0.5);background:rgba(22,101,52,0.35);}
-                    .log-entry.log-warn{border-color:rgba(251,191,36,0.5);background:rgba(120,53,15,0.4);}
-                    .log-entry.log-error{border-color:rgba(248,113,113,0.5);background:rgba(127,29,29,0.35);}
-                    .log-meta{font-size:12px;color:rgba(148,163,184,0.9);margin-bottom:6px;}
-                    .log-message{font-size:13px;line-height:1.5;white-space:pre-wrap;word-break:break-word;}
-                    .log-data{margin-top:8px;background:rgba(15,23,42,0.8);padding:8px;border-radius:6px;font-size:12px;color:#cbd5f5;overflow:auto;}
-                </style></head><body><header><h1>Sync Activity Log</h1><div class="actions"><button id="sync-log-copy">Copy Log</button><button id="sync-log-clear" class="secondary">Clear</button></div></header><main id="sync-log-entries" role="log" aria-live="polite"></main></body></html>`);
-                doc.close();
-                this.bindWindowControls();
-                this.renderWindow();
-            }
-            bindWindowControls() {
-                if (!this.logWindow) return;
-                this.logWindow.addEventListener('beforeunload', () => { this.logWindow = null; });
-                const doc = this.logWindow.document;
-                const copyBtn = doc.getElementById('sync-log-copy');
-                if (copyBtn) { copyBtn.addEventListener('click', () => this.copyEntries()); }
-                const clearBtn = doc.getElementById('sync-log-clear');
-                if (clearBtn) { clearBtn.addEventListener('click', () => this.clear()); }
-            }
-            log(entry) {
-                const normalized = {
-                    id: entry.id || (window.crypto && window.crypto.randomUUID ? window.crypto.randomUUID() : `log-${Date.now()}-${Math.random().toString(16).slice(2)}`),
-                    timestamp: entry.timestamp ? new Date(entry.timestamp) : new Date(),
-                    level: entry.level || 'info',
-                    event: entry.event || 'log',
-                    direction: entry.direction || '',
-                    details: entry.details || '',
-                    fileId: entry.fileId || null,
-                    data: entry.data || null
-                };
-                this.entries.push(normalized);
-                if (this.entries.length > this.maxEntries) {
-                    this.entries.splice(0, this.entries.length - this.maxEntries);
-                }
-                this.renderWindow();
-            }
-            renderWindow() {
-                if (!this.logWindow || this.logWindow.closed) return;
-                const container = this.logWindow.document.getElementById('sync-log-entries');
-                if (!container) return;
-                container.innerHTML = '';
-                const fragment = this.logWindow.document.createDocumentFragment();
-                this.entries.slice().reverse().forEach(entry => {
-                    const row = this.logWindow.document.createElement('section');
-                    row.className = `log-entry log-${entry.level}`;
-                    const meta = this.logWindow.document.createElement('div');
-                    meta.className = 'log-meta';
-                    const parts = [entry.timestamp.toLocaleTimeString(), entry.event];
-                    if (entry.fileId) parts.push(`file:${entry.fileId}`);
-                    if (entry.direction) parts.push(entry.direction);
-                    meta.textContent = parts.join(' · ');
-                    const message = this.logWindow.document.createElement('div');
-                    message.className = 'log-message';
-                    message.innerHTML = this.escapeHtml(entry.details || '');
-                    row.appendChild(meta);
-                    row.appendChild(message);
-                    if (entry.data) {
-                        const pre = this.logWindow.document.createElement('pre');
-                        pre.className = 'log-data';
-                        pre.textContent = JSON.stringify(entry.data, null, 2);
-                        row.appendChild(pre);
-                    }
-                    fragment.appendChild(row);
-                });
-                container.appendChild(fragment);
-            }
-            copyEntries() {
-                const text = this.entries.map(entry => this.formatEntry(entry)).join('\n');
-                if (navigator.clipboard && navigator.clipboard.writeText) {
-                    navigator.clipboard.writeText(text).catch(() => this.fallbackCopy(text));
-                } else {
-                    this.fallbackCopy(text);
-                }
-            }
-            formatEntry(entry) {
-                const iso = entry.timestamp.toISOString();
-                const meta = [iso, entry.event];
-                if (entry.fileId) meta.push(`file:${entry.fileId}`);
-                if (entry.direction) meta.push(entry.direction);
-                const detail = entry.details || '';
-                const data = entry.data ? `\n${JSON.stringify(entry.data)}` : '';
-                return `${meta.join(' ')} :: ${detail}${data}`;
-            }
-            fallbackCopy(text) {
-                const textarea = document.createElement('textarea');
-                textarea.value = text;
-                textarea.style.position = 'fixed';
-                textarea.style.left = '-9999px';
-                document.body.appendChild(textarea);
-                textarea.select();
-                try { document.execCommand('copy'); } catch (_) { /* ignored */ }
-                textarea.remove();
-            }
-            clear() {
-                this.entries = [];
-                this.renderWindow();
-            }
-            escapeHtml(value) {
-                if (value == null) return '';
-                return String(value).replace(/[&<>"']/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[char] || char));
-            }
-        }
         class DBManager {
             constructor() { this.db = null; }
             async init() {
@@ -1951,416 +1755,15 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                     request.onerror = () => reject(request.error);
                 });
             }
-            async addToSyncQueue(operation) {
-                if (!this.db) return null;
-                const entry = {
-                    fileId: operation.fileId,
-                    updates: operation.updates || {},
-                    operationType: operation.operationType || 'metadata:update',
-                    origin: operation.origin || 'ui',
-                    localUpdatedAt: operation.localUpdatedAt || Date.now(),
-                    pendingFlush: Boolean(operation.pendingFlush),
-                    metadataSnapshot: operation.metadataSnapshot || null,
-                    retryCount: operation.retryCount || 0
-                };
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('syncQueue', 'readwrite');
-                    const store = transaction.objectStore('syncQueue');
-                    const request = store.add(entry);
-                    request.onsuccess = () => resolve(request.result);
-                    request.onerror = () => reject(request.error);
-                });
-            }
-            async readSyncQueue() {
-                if (!this.db) return [];
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('syncQueue', 'readonly');
-                    const store = transaction.objectStore('syncQueue');
-                    const request = store.getAll();
-                    request.onsuccess = () => {
-                        const results = request.result || [];
-                        results.sort((a, b) => (a.localUpdatedAt || 0) - (b.localUpdatedAt || 0));
-                        resolve(results);
-                    };
-                    request.onerror = () => reject(request.error);
-                });
-            }
-            async deleteFromSyncQueue(ids) {
-                if (!this.db) return;
-                const targetIds = Array.isArray(ids) ? ids : [ids];
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('syncQueue', 'readwrite');
-                    const store = transaction.objectStore('syncQueue');
-                    targetIds.forEach(id => { store.delete(id); });
-                    transaction.oncomplete = () => resolve();
-                    transaction.onerror = () => reject(transaction.error);
-                });
-            }
-            async updateSyncQueueEntry(id, updates) {
-                if (!this.db) return false;
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('syncQueue', 'readwrite');
-                    const store = transaction.objectStore('syncQueue');
-                    const getRequest = store.get(id);
-                    getRequest.onsuccess = () => {
-                        const entry = getRequest.result;
-                        if (!entry) { resolve(false); return; }
-                        Object.assign(entry, updates);
-                        const putRequest = store.put(entry);
-                        putRequest.onsuccess = () => resolve(true);
-                        putRequest.onerror = () => reject(putRequest.error);
-                    };
-                    getRequest.onerror = () => reject(getRequest.error);
-                });
-            }
-            async markPendingFlush(ids, pending = true) {
-                if (!this.db) return;
-                const targetIds = Array.isArray(ids) ? ids : [ids];
-                await Promise.all(targetIds.map(id => this.updateSyncQueueEntry(id, { pendingFlush: pending })));
-            }
+            async addToSyncQueue(operation) { return Promise.resolve(); }
+            async readSyncQueue() { return Promise.resolve([]); }
+            async deleteFromSyncQueue(id) { return Promise.resolve(); }
         }
         class SyncManager {
-            constructor({ dbManager, logger } = {}) {
-                this.dbManager = dbManager || null;
-                this.logger = logger || null;
-                this.pendingMutations = new Map();
-                this.debounceTimers = new Map();
-                this.debounceDelay = 750;
-                this.syncTimer = null;
-                this.isProcessing = false;
-                this.isActive = false;
-                this.hasPendingWork = false;
-                this.provider = null;
-                this.providerType = null;
-                this.lifecycleHandlers = {
-                    visibility: () => this.handleVisibilityChange(),
-                    pagehide: (event) => this.handlePageHide(event),
-                    beforeUnload: (event) => this.handleBeforeUnload(event)
-                };
-            }
-            setLogger(logger) { this.logger = logger; }
-            setDbManager(dbManager) { this.dbManager = dbManager; }
-            setProviderContext({ provider, providerType }) {
-                this.provider = provider || null;
-                this.providerType = providerType || null;
-                this.logger?.log({
-                    event: 'provider:context',
-                    level: 'info',
-                    details: this.provider ? `Bound to provider ${this.providerType}` : 'Cleared provider context.'
-                });
-            }
-            start() {
-                if (this.isActive) return;
-                document.addEventListener('visibilitychange', this.lifecycleHandlers.visibility);
-                window.addEventListener('pagehide', this.lifecycleHandlers.pagehide);
-                window.addEventListener('beforeunload', this.lifecycleHandlers.beforeUnload);
-                this.isActive = true;
-                this.resumePendingQueue();
-            }
-            stop() {
-                this.flush({ reason: 'stop' }).catch(() => {});
-                if (!this.isActive) return;
-                document.removeEventListener('visibilitychange', this.lifecycleHandlers.visibility);
-                window.removeEventListener('pagehide', this.lifecycleHandlers.pagehide);
-                window.removeEventListener('beforeunload', this.lifecycleHandlers.beforeUnload);
-                this.isActive = false;
-                this.provider = null;
-                this.providerType = null;
-            }
-            async resumePendingQueue() {
-                if (!this.dbManager) return;
-                try {
-                    const queue = await this.dbManager.readSyncQueue();
-                    if (queue.length > 0) {
-                        const pending = queue.filter(item => item.pendingFlush);
-                        if (pending.length > 0) {
-                            await this.dbManager.markPendingFlush(pending.map(item => item.id), false);
-                            this.logger?.log({ event: 'queue:resume', level: 'warn', details: `Resuming ${pending.length} pending flush entries.` });
-                        } else {
-                            this.logger?.log({ event: 'queue:resume', level: 'info', details: `Sync queue contains ${queue.length} entries.` });
-                        }
-                        this.hasPendingWork = true;
-                        this.scheduleProcess('resume');
-                    } else {
-                        this.hasPendingWork = this.pendingMutations.size > 0;
-                    }
-                } catch (error) {
-                    this.logger?.log({ event: 'queue:resume:error', level: 'error', details: `Failed to resume queue: ${error.message}` });
-                }
-            }
-            queueLocalChange(change, options = {}) {
-                if (!change || !change.fileId) return Promise.resolve();
-                const { debounce = true } = options;
-                const fileId = change.fileId;
-                const buffer = this.pendingMutations.get(fileId) || {
-                    updates: {},
-                    operationType: change.operationType || 'metadata:update',
-                    origin: change.origin || 'ui'
-                };
-                buffer.updates = { ...buffer.updates, ...(change.updates || {}) };
-                buffer.operationType = change.operationType || buffer.operationType;
-                buffer.origin = change.origin || buffer.origin;
-                buffer.localUpdatedAt = change.localUpdatedAt || Date.now();
-                if (change.metadataSnapshot) {
-                    buffer.metadataSnapshot = { ...(buffer.metadataSnapshot || {}), ...change.metadataSnapshot };
-                }
-                this.pendingMutations.set(fileId, buffer);
-                this.hasPendingWork = true;
-                const updateKeys = Object.keys(change.updates || {});
-                const descriptorParts = [];
-                if (change.operationType) descriptorParts.push(change.operationType);
-                if (change.updates?.stack) descriptorParts.push(`stack→${change.updates.stack}`);
-                if (change.updates?.stackSequence) descriptorParts.push(`seq=${change.updates.stackSequence}`);
-                if (descriptorParts.length === 0 && updateKeys.length > 0) {
-                    descriptorParts.push(updateKeys.join(', '));
-                }
-                const descriptor = descriptorParts.join(' · ') || 'update';
-                this.logger?.log({
-                    event: 'queue:buffer',
-                    level: 'info',
-                    fileId,
-                    details: `Buffered ${descriptor} (${debounce ? 'debounced' : 'immediate'})`,
-                    data: change
-                });
-
-                if (debounce) {
-                    clearTimeout(this.debounceTimers.get(fileId));
-                    this.debounceTimers.set(fileId, setTimeout(() => this.commitBufferedChange(fileId), this.debounceDelay));
-                    return Promise.resolve();
-                }
-                return this.commitBufferedChange(fileId);
-            }
-            async commitBufferedChange(fileId) {
-                const buffer = this.pendingMutations.get(fileId);
-                if (!buffer) return null;
-                this.pendingMutations.delete(fileId);
-                const timer = this.debounceTimers.get(fileId);
-                if (timer) {
-                    clearTimeout(timer);
-                    this.debounceTimers.delete(fileId);
-                }
-                if (!this.dbManager) return null;
-                const entry = {
-                    fileId,
-                    updates: buffer.updates,
-                    operationType: buffer.operationType,
-                    origin: buffer.origin,
-                    localUpdatedAt: buffer.localUpdatedAt,
-                    metadataSnapshot: buffer.metadataSnapshot
-                };
-                try {
-                    const id = await this.dbManager.addToSyncQueue(entry);
-                    const persistDescriptorParts = [];
-                    if (entry.operationType) persistDescriptorParts.push(entry.operationType);
-                    if (entry.updates?.stack) persistDescriptorParts.push(`stack→${entry.updates.stack}`);
-                    if (entry.updates?.stackSequence) persistDescriptorParts.push(`seq=${entry.updates.stackSequence}`);
-                    const persistDescriptor = persistDescriptorParts.join(' · ') || 'mutation';
-                    this.logger?.log({ event: 'queue:persist', level: 'info', fileId, details: `Persisted ${persistDescriptor} to syncQueue (#${id}).`, data: entry });
-                    this.scheduleProcess('buffer-commit');
-                    return id;
-                } catch (error) {
-                    this.logger?.log({ event: 'queue:error', level: 'error', fileId, details: `Failed to persist mutation: ${error.message}` });
-                    return null;
-                }
-            }
-            scheduleProcess(reason = 'auto') {
-                if (this.syncTimer) return;
-                this.syncTimer = setTimeout(() => {
-                    this.syncTimer = null;
-                    this.processQueue(reason);
-                }, 300);
-            }
-            async processQueue(reason = 'auto') {
-                if (!this.dbManager) return 'no-db';
-                if (this.isProcessing) {
-                    this.logger?.log({ event: 'sync:busy', level: 'warn', details: 'Sync loop already in progress.' });
-                    return 'busy';
-                }
-                this.isProcessing = true;
-                try {
-                    const queue = await this.dbManager.readSyncQueue();
-                    if (queue.length === 0) {
-                        this.hasPendingWork = this.pendingMutations.size > 0;
-                        this.logger?.log({ event: 'sync:idle', level: 'info', details: `Queue empty (${reason}).` });
-                        return 'empty';
-                    }
-                    this.logger?.log({ event: 'sync:start', level: 'info', details: `Processing ${queue.length} queued entries (${reason}).` });
-                    const merged = this.mergeQueue(queue);
-                    for (const entry of merged) {
-                        await this.processEntry(entry);
-                    }
-                    const remaining = await this.dbManager.readSyncQueue();
-                    this.hasPendingWork = remaining.length > 0 || this.pendingMutations.size > 0;
-                    const result = remaining.length > 0 ? 'partial' : 'done';
-                    if (result === 'done') {
-                        this.logger?.log({ event: 'sync:complete', level: 'success', details: `Sync loop complete (${reason}).` });
-                    } else {
-                        this.logger?.log({ event: 'sync:partial', level: 'warn', details: `Sync loop finished with ${remaining.length} entries remaining.` });
-                    }
-                    return result;
-                } catch (error) {
-                    this.logger?.log({ event: 'sync:error', level: 'error', details: `Queue processing failed: ${error.message}` });
-                    return 'error';
-                } finally {
-                    this.isProcessing = false;
-                }
-            }
-            mergeQueue(entries) {
-                const map = new Map();
-                entries.forEach(item => {
-                    const existing = map.get(item.fileId);
-                    if (!existing) {
-                        map.set(item.fileId, { ...item, queueIds: [item.id] });
-                        return;
-                    }
-                    existing.queueIds.push(item.id);
-                    existing.updates = { ...existing.updates, ...(item.updates || {}) };
-                    existing.localUpdatedAt = Math.max(existing.localUpdatedAt || 0, item.localUpdatedAt || 0);
-                    existing.pendingFlush = existing.pendingFlush || item.pendingFlush;
-                    if (item.metadataSnapshot) {
-                        existing.metadataSnapshot = { ...(existing.metadataSnapshot || {}), ...item.metadataSnapshot };
-                    }
-                });
-                return Array.from(map.values());
-            }
-            async processEntry(entry) {
-                const provider = this.provider || state.provider;
-                const providerType = this.providerType || state.providerType;
-                if (!provider || !providerType) {
-                    await this.dbManager.markPendingFlush(entry.queueIds, true);
-                    this.logger?.log({ event: 'sync:deferred', level: 'warn', fileId: entry.fileId, details: 'No provider bound. Marked pending flush.' });
-                    return;
-                }
-                const updates = entry.updates || {};
-                const metadataRecord = state.imageFiles.find(file => file.id === entry.fileId) || entry.metadataSnapshot || {};
-                const payload = { ...metadataRecord, ...updates, localUpdatedAt: entry.localUpdatedAt };
-                const stackLabel = updates.stack ? (STACK_NAMES[updates.stack] || updates.stack) : null;
-                const stackFragment = stackLabel ? ` (${stackLabel})` : '';
-                try {
-                    if (providerType === 'googledrive') {
-                        await provider.updateFileMetadata(entry.fileId, this.serializeGoogleMetadata(payload));
-                    } else if (providerType === 'onedrive') {
-                        await this.upsertOneDriveMetadata(entry.fileId, payload);
-                    } else if (typeof provider.updateFileMetadata === 'function') {
-                        await provider.updateFileMetadata(entry.fileId, payload);
-                    }
-                    await this.dbManager.deleteFromSyncQueue(entry.queueIds);
-                    this.logger?.log({ event: 'sync:success', level: 'success', fileId: entry.fileId, details: `Applied ${entry.operationType}${stackFragment} to ${providerType}.`, data: { updates, stackLabel } });
-                } catch (error) {
-                    await this.dbManager.markPendingFlush(entry.queueIds, true);
-                    this.logger?.log({ event: 'sync:error', level: 'error', fileId: entry.fileId, details: `Failed to sync ${entry.operationType}: ${error.message}`, data: { updates, stackLabel } });
-                }
-            }
-            serializeGoogleMetadata(payload) {
-                const tags = Array.isArray(payload.tags) ? payload.tags : [];
-                return {
-                    slideboxStack: payload.stack || 'in',
-                    slideboxTags: tags.join(','),
-                    qualityRating: String(payload.qualityRating ?? 0),
-                    contentRating: String(payload.contentRating ?? 0),
-                    notes: payload.notes || '',
-                    stackSequence: String(payload.stackSequence ?? 0),
-                    favorite: payload.favorite ? 'true' : 'false'
-                };
-            }
-            serializeGenericMetadata(payload) {
-                return {
-                    stack: payload.stack || 'in',
-                    tags: Array.isArray(payload.tags) ? payload.tags : [],
-                    notes: payload.notes || '',
-                    qualityRating: payload.qualityRating ?? 0,
-                    contentRating: payload.contentRating ?? 0,
-                    stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
-                    localUpdatedAt: payload.localUpdatedAt || Date.now()
-                };
-            }
-            async upsertOneDriveMetadata(fileId, payload) {
-                const provider = this.provider || state.provider;
-                if (!provider || typeof provider.getAccessToken !== 'function') {
-                    throw new Error('Active provider missing access token helper');
-                }
-                const token = await provider.getAccessToken();
-                const endpoint = `https://graph.microsoft.com/v1.0/me/drive/special/approot:/${fileId}.json:/content`;
-                const headers = { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' };
-                let existing = null;
-                try {
-                    const response = await fetch(endpoint, { method: 'GET', headers });
-                    if (response.ok) {
-                        existing = await response.json();
-                        this.logger?.log({ event: 'onedrive:metadata:get', level: 'info', fileId, details: 'Fetched existing metadata file.' });
-                    } else if (response.status !== 404) {
-                        const text = await response.text();
-                        throw new Error(`GET ${response.status}: ${text}`);
-                    }
-                } catch (error) {
-                    if (!/404/.test(error.message)) {
-                        throw error;
-                    }
-                }
-                const merged = { ...(existing || {}), ...this.serializeGenericMetadata(payload) };
-                const putResponse = await fetch(endpoint, { method: 'PUT', headers, body: JSON.stringify(merged) });
-                if (!putResponse.ok) {
-                    const text = await putResponse.text();
-                    throw new Error(`PUT ${putResponse.status}: ${text}`);
-                }
-                this.logger?.log({ event: 'onedrive:metadata:upsert', level: 'info', fileId, details: 'Upserted OneDrive metadata document.' });
-            }
-            async flush({ reason = 'manual', useBeacon = false } = {}) {
-                this.logger?.log({ event: 'flush:request', level: 'info', details: `Flush requested (${reason}).` });
-                const bufferedIds = Array.from(this.pendingMutations.keys());
-                if (bufferedIds.length > 0) {
-                    await Promise.all(bufferedIds.map(id => this.commitBufferedChange(id)));
-                }
-                if (!this.dbManager) return 'no-db';
-                if (useBeacon && await this.sendBeaconSnapshot(reason)) {
-                    return 'beacon';
-                }
-                return this.processQueue(reason);
-            }
-            requestSync(reason = 'manual-request') {
-                this.logger?.log({ event: 'sync:request', level: 'info', details: `Manual sync requested (${reason}).` });
-                this.scheduleProcess(reason);
-            }
-            handleVisibilityChange() {
-                if (document.visibilityState === 'hidden') {
-                    this.flush({ reason: 'visibilitychange', useBeacon: true });
-                }
-            }
-            handlePageHide() {
-                this.flush({ reason: 'pagehide', useBeacon: true });
-            }
-            handleBeforeUnload() {
-                if (!this.hasPendingWork) return;
-                this.flush({ reason: 'beforeunload', useBeacon: true });
-            }
-            async sendBeaconSnapshot(reason) {
-                if (!navigator.sendBeacon) return false;
-                try {
-                    const queue = await this.dbManager.readSyncQueue();
-                    if (queue.length === 0) return false;
-                    const payload = JSON.stringify({
-                        reason,
-                        timestamp: Date.now(),
-                        providerType: this.providerType || state.providerType || null,
-                        entries: this.mergeQueue(queue).map(entry => ({
-                            fileId: entry.fileId,
-                            updates: entry.updates,
-                            operationType: entry.operationType,
-                            localUpdatedAt: entry.localUpdatedAt
-                        }))
-                    });
-                    const ok = navigator.sendBeacon('/orbital8/sync-flush', payload);
-                    if (ok) {
-                        await this.dbManager.markPendingFlush(queue.map(item => item.id), true);
-                        this.logger?.log({ event: 'flush:beacon', level: 'warn', details: `Dispatching ${queue.length} entries via navigator.sendBeacon (${reason}).` });
-                        return true;
-                    }
-                } catch (error) {
-                    this.logger?.log({ event: 'flush:beacon:error', level: 'error', details: `Beacon fallback failed: ${error.message}` });
-                }
-                return false;
-            }
+            constructor() { this.worker = null; this.syncInterval = null; }
+            start() { /* Placeholder */ }
+            stop() { /* Placeholder */ }
+            requestSync() { /* Placeholder */ }
         }
         class VisualCueManager {
             constructor() {
@@ -2423,27 +1826,27 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 try {
                     while (pos < buffer.byteLength - 12) {
                         const chunkLength = view.getUint32(pos, false);
-                        pos = 4;
+                        pos += 4;
                         let chunkType = '';
-                        for (let i = 0; i < 4; i) { chunkType = String.fromCharCode(view.getUint8(pos  i)); }
-                        pos = 4;
+                        for (let i = 0; i < 4; i++) { chunkType += String.fromCharCode(view.getUint8(pos + i)); }
+                        pos += 4;
                         if (chunkType === 'tEXt') {
                             let keyword = '';
                             let value = '';
                             let nullFound = false;
-                            for (let i = 0; i < chunkLength; i) {
-                                const byte = view.getUint8(pos  i);
+                            for (let i = 0; i < chunkLength; i++) {
+                                const byte = view.getUint8(pos + i);
                                 if (!nullFound) {
-                                    if (byte === 0) { nullFound = true; } else { keyword = String.fromCharCode(byte); }
-                                } else { value = String.fromCharCode(byte); }
+                                    if (byte === 0) { nullFound = true; } else { keyword += String.fromCharCode(byte); }
+                                } else { value += String.fromCharCode(byte); }
                             }
                             metadata[keyword] = value;
                         } else if (chunkType === 'IHDR') {
                             const width = view.getUint32(pos, false);
-                            const height = view.getUint32(pos  4, false);
+                            const height = view.getUint32(pos + 4, false);
                             metadata._dimensions = { width, height };
                         } else if (chunkType === 'IEND') { break; }
-                        pos = chunkLength  4;
+                        pos += chunkLength + 4;
                         if (chunkLength > buffer.byteLength || pos > buffer.byteLength) { break; }
                     }
                 } catch (error) { /* Return what we have so far */ }
@@ -2501,7 +1904,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 super();
                 this.name = 'googledrive';
                 this.clientId = '567988062464-fa6c1ovesqeudqs5398vv4mbo6q068p9.apps.googleusercontent.com';
-                this.redirectUri = window.location.origin  window.location.pathname;
+                this.redirectUri = window.location.origin + window.location.pathname;
                 this.scope = 'https://www.googleapis.com/auth/drive';
                 this.apiBase = 'https://www.googleapis.com/drive/v3';
                 this.accessToken = null; this.refreshToken = null; this.clientSecret = null;
@@ -2604,7 +2007,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 do {
                     const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
                     let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,appProperties,parents),nextPageToken&pageSize=100`;
-                    if (nextPageToken) { url = `&pageToken=${nextPageToken}`; }
+                    if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
                     const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
                     const files = response.files.filter(file => file.mimeType && file.mimeType.startsWith('image/')).map(file => ({ id: file.id, name: file.name, type: 'file', mimeType: file.mimeType, size: file.size ? parseInt(file.size) : 0, createdTime: file.createdTime, modifiedTime: file.modifiedTime, thumbnailLink: file.thumbnailLink, downloadUrl: file.webContentLink, appProperties: file.appProperties || {}, parents: file.parents }));
                     allFiles.push(...files);
@@ -2671,7 +2074,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             }
             initMSAL() {
                 const msalConfig = {
-                    auth: { clientId: 'b407fd45-c551-4dbb-9da5-cab3a2c5a949', authority: 'https://login.microsoftonline.com/common', redirectUri: window.location.origin  window.location.pathname },
+                    auth: { clientId: 'b407fd45-c551-4dbb-9da5-cab3a2c5a949', authority: 'https://login.microsoftonline.com/common', redirectUri: window.location.origin + window.location.pathname },
                     cache: { cacheLocation: 'localStorage' }
                 };
                 this.msalInstance = new msal.PublicClientApplication(msalConfig);
@@ -2901,11 +2304,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 }
             },
             backToProviderSelection() {
-                if (state.syncManager) {
-                    state.syncManager.flush({ reason: 'provider-screen' });
-                    state.syncManager.setProviderContext({ provider: null, providerType: null });
-                    state.syncManager.stop();
-                }
+                if(state.syncManager) state.syncManager.stop();
                 state.provider = null;
                 state.providerType = null;
                 Utils.showScreen('provider-screen');
@@ -2920,10 +2319,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                     
                     await this.loadImages();
                     this.switchToCommonUI();
-                    if (state.syncManager) {
-                        state.syncManager.setProviderContext({ provider: state.provider, providerType: state.providerType });
-                        state.syncManager.start();
-                    }
+                    if(state.syncManager) state.syncManager.start();
                 } catch (error) {
                     Utils.showToast(`Initialization failed: ${error.message}`, 'error', true);
                     this.returnToFolderSelection();
@@ -3075,7 +2471,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             },
             async processAllMetadata(files, isFirstLoad = false) {
                  if (isFirstLoad) Utils.updateLoadingProgress(0, files.length, 'Processing files...');
-                 for (let i = 0; i < files.length; i) {
+                 for (let i = 0; i < files.length; i++) {
                     const file = files[i];
                     try {
                         const metadata = await state.dbManager.getMetadata(file.id);
@@ -3089,7 +2485,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                     } catch (error) {
                         console.error(`Failed to process metadata for ${file.name}:`, error);
                     }
-                    if(isFirstLoad) Utils.updateLoadingProgress(i  1, files.length);
+                    if(isFirstLoad) Utils.updateLoadingProgress(i + 1, files.length);
                 }
                 this.extractMetadataInBackground(files.filter(f => f.mimeType === 'image/png'));
             },
@@ -3122,7 +2518,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             async returnToFolderSelection() {
                 try {
                     if (state.syncManager) {
-                        await state.syncManager.flush({ reason: 'folder-switch' });
+                        state.syncManager.requestSync();
                     }
                     state.activeRequests.abort(); 
                     this.resetViewState();
@@ -3141,127 +2537,36 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 Core.showEmptyState();
                 Utils.elements.emptyState.classList.add('hidden');
             },
-            async updateUserMetadata(fileId, updates, options = {}) {
-                const { skipDebounce = false, operationType = 'metadata:update', origin = 'ui' } = options;
+            async updateUserMetadata(fileId, updates) {
                 try {
                     const file = state.imageFiles.find(f => f.id === fileId);
                     if (!file) return;
-                    const timestamp = Date.now();
-                    Object.assign(file, updates, { localUpdatedAt: timestamp });
+                    Object.assign(file, updates);
                     await state.dbManager.saveMetadata(file.id, file);
                     await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
-                    if (state.syncManager) {
-                        await state.syncManager.queueLocalChange({
-                            fileId,
-                            updates,
-                            operationType,
-                            origin,
-                            localUpdatedAt: timestamp,
-                            metadataSnapshot: { name: file.name, stack: file.stack, stackSequence: file.stackSequence }
-                        }, { debounce: !skipDebounce });
-                    }
                 } catch (error) {
                     Utils.showToast(`Failed to update metadata: ${error.message}`, 'error', true);
                 }
             },
-            async deleteFile(fileId, options = {}) {
-                const { source = 'ui', originStack = null, name = null } = options;
+            async deleteFile(fileId) {
                 const fileIndex = state.imageFiles.findIndex(f => f.id === fileId);
-                let file = null;
-                let stackRemoval = null;
                 if (fileIndex > -1) {
-                    const removed = state.imageFiles.splice(fileIndex, 1);
-                    file = removed && removed.length ? removed[0] : null;
-                    if (file && file.stack && state.stacks[file.stack]) {
-                        const stackArray = state.stacks[file.stack];
-                        const stackIndex = stackArray.findIndex(f => f.id === fileId);
-                        if (stackIndex > -1) {
-                            stackRemoval = { name: file.stack, index: stackIndex };
-                            stackArray.splice(stackIndex, 1);
-                        }
-                    }
+                    const [file] = state.imageFiles.splice(fileIndex, 1);
+                    const stackIndex = state.stacks[file.stack].findIndex(f => f.id === fileId);
+                    if (stackIndex > -1) { state.stacks[file.stack].splice(stackIndex, 1); }
                 }
-                const stackBefore = originStack || file?.stack || null;
-                const stackLabel = stackBefore ? (STACK_NAMES[stackBefore] || stackBefore) : null;
-                const fileName = name || file?.name || '';
-                const persistState = async () => {
-                    await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
-                };
-                const restoreState = async (reason) => {
-                    if (!file) { return false; }
-                    if (fileIndex > -1) {
-                        state.imageFiles.splice(fileIndex, 0, file);
-                    } else {
-                        state.imageFiles.push(file);
-                    }
-                    if (stackRemoval && state.stacks[stackRemoval.name]) {
-                        state.stacks[stackRemoval.name].splice(stackRemoval.index, 0, file);
-                    } else if (file.stack && state.stacks[file.stack] && !stackRemoval) {
-                        state.stacks[file.stack].push(file);
-                    }
-                    await persistState();
-                    state.syncLog?.log({
-                        event: 'provider:trash:rollback',
-                        level: 'warn',
-                        fileId,
-                        details: `Restored ${fileName || fileId} after ${reason}.`,
-                        data: { source, stack: stackBefore, stackLabel }
-                    });
-                    return true;
-                };
-                await persistState();
-
-                const provider = state.provider;
-                const providerName = state.providerType === 'onedrive' ? 'OneDrive' : state.providerType === 'googledrive' ? 'Google Drive' : 'provider';
-                if (!provider || typeof provider.deleteFile !== 'function') {
-                    state.syncLog?.log({
-                        event: 'provider:trash:error',
-                        level: 'error',
-                        fileId,
-                        details: `Provider recycle bin unavailable for ${fileName || fileId} (${providerName}).`,
-                        data: { source, stack: stackBefore }
-                    });
-                    await restoreState('missing provider recycle support');
-                    Utils.showToast('Provider recycle bin unavailable. Item restored locally.', 'error', true);
-                    return false;
-                }
-
-                state.syncLog?.log({
-                    event: 'provider:trash:request',
-                    level: 'warn',
-                    fileId,
-                    details: `Moving ${fileName || fileId} from ${stackLabel || 'unknown stack'} into the ${providerName} recycle bin (${source}).`,
-                    data: { source, stack: stackBefore, stackLabel }
-                });
-
+                await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
                 try {
-                    await provider.deleteFile(fileId);
-                    state.syncLog?.log({
-                        event: 'provider:trash:success',
-                        level: 'success',
-                        fileId,
-                        details: `${providerName} recycle bin accepted ${fileName || fileId} (from ${stackLabel || 'unknown stack'}). File is not permanently deleted.`,
-                        data: { source, stack: stackBefore, stackLabel }
-                    });
-                    return true;
+                    await state.provider.deleteFile(fileId);
                 } catch (e) {
-                    state.syncLog?.log({
-                        event: 'provider:trash:error',
-                        level: 'error',
-                        fileId,
-                        details: `Provider recycle move failed: ${e.message}`,
-                        data: { source, stack: stackBefore, stackLabel }
-                    });
-                    await restoreState('provider recycle failure');
-                    Utils.showToast(`Failed to move to recycle bin: ${e.message}`, 'error', true);
-                    return false;
+                    Utils.showToast(`Failed to delete from cloud: ${e.message}`, 'error', true);
                 }
             },
             async extractMetadataInBackground(pngFiles) {
                 const BATCH_SIZE = 5;
-                for (let i = 0; i < pngFiles.length; i = BATCH_SIZE) {
+                for (let i = 0; i < pngFiles.length; i += BATCH_SIZE) {
                     if (state.activeRequests.signal.aborted) return;
-                    const batch = pngFiles.slice(i, i  BATCH_SIZE);
+                    const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
                         if (file.metadataStatus === 'pending') {
                             return this.processFileMetadata(file);
@@ -3393,7 +2698,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
                     const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20)  '...' : folderName;
+                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
                     
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
@@ -3413,7 +2718,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             updateImageCounters() {
                 const stack = state.stacks[state.currentStack];
                 const total = stack ? stack.length : 0;
-                const current = total > 0 ? state.currentStackPosition  1 : 0;
+                const current = total > 0 ? state.currentStackPosition + 1 : 0;
                 const counterText = total > 0 ? `Item ${current} / ${total}` : 'No items';
                 if (Utils.elements.normalImageCount) {
                     Utils.elements.normalImageCount.textContent = counterText;
@@ -3431,6 +2736,9 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             },
 
             updateFavoriteButton() {
+                if (typeof UI !== 'undefined') {
+                    UI.favoriteToggleCooldownUntil = 0;
+                }
                 const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                 if (!currentFile) {
                     if (Utils.elements.focusFavoriteBtn) {
@@ -3463,49 +2771,26 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 if (currentPill) currentPill.classList.add('active');
             },
             
-            async moveToStack(targetStack, options = {}) {
-                const { source = 'ui:direct' } = options;
-                if (state.isImageTransitioning) return;
+            async moveToStack(targetStack) {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-
+                
                 const currentImage = currentStackArray[state.currentStackPosition];
                 if (!currentImage) return;
 
                 try {
-                    state.isImageTransitioning = true;
                     const originalStackName = state.currentStack;
-                    const movedFileId = currentImage.id;
-                    const stackLabel = STACK_NAMES[targetStack] || targetStack;
-                    const originalStackLabel = STACK_NAMES[originalStackName] || originalStackName;
                     if (targetStack === originalStackName) {
                         const otherImages = currentStackArray.filter(img => img.id !== currentImage.id);
                         const minSequence = otherImages.length > 0 ? Math.min(...otherImages.map(img => img.stackSequence || 0)) : Date.now();
                         const newSequence = minSequence - 1;
-                        state.syncLog?.log({
-                            event: 'ui:stack-resequence',
-                            level: 'info',
-                            fileId: movedFileId,
-                            details: `Re-sequencing ${currentImage.name || movedFileId} within ${originalStackLabel} (${source}).`,
-                            data: { stack: originalStackName, stackSequence: newSequence, source }
-                        });
-                        await App.updateUserMetadata(currentImage.id, { stackSequence: newSequence }, { skipDebounce: true, operationType: 'stack:resequence' });
+                        await App.updateUserMetadata(currentImage.id, { stackSequence: newSequence });
                         const [item] = currentStackArray.splice(state.currentStackPosition, 1);
                         item.stackSequence = newSequence;
                         currentStackArray.push(item);
                     } else {
                         const newSequence = Date.now();
-                        const isRecycleStackMove = targetStack === 'trash';
-                        state.syncLog?.log({
-                            event: isRecycleStackMove ? 'ui:stack-recycle' : 'ui:stack-move',
-                            level: 'info',
-                            fileId: movedFileId,
-                            details: isRecycleStackMove
-                                ? `Moved ${currentImage.name || movedFileId} from ${originalStackLabel} to ${stackLabel} (${source}). Metadata only—cloud file stays put until the recycle-bin action is used.`
-                                : `Moving ${currentImage.name || movedFileId} from ${originalStackLabel} to ${stackLabel} (${source}).`,
-                            data: { from: originalStackName, to: targetStack, stackSequence: newSequence, source, scope: isRecycleStackMove ? 'metadata-only' : 'stack-move' }
-                        });
-                        await App.updateUserMetadata(currentImage.id, { stack: targetStack, stackSequence: newSequence }, { skipDebounce: true, operationType: 'stack:move' });
+                        await App.updateUserMetadata(currentImage.id, { stack: targetStack, stackSequence: newSequence });
                         const [item] = currentStackArray.splice(state.currentStackPosition, 1);
                         item.stack = targetStack;
                         item.stackSequence = newSequence;
@@ -3516,73 +2801,11 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();
-                    if (targetStack === originalStackName) {
-                        Grid.syncWithStack(originalStackName, { preselectFirst: true });
-                    } else {
-                        Grid.syncWithStack(originalStackName, { removedIds: [movedFileId], preselectFirst: true });
-                        Grid.syncWithStack(targetStack, { preselectFirst: false });
-                    }
                 } catch (error) {
                     Utils.showToast(`Error moving image: ${error.message}`, 'error', true);
-                } finally {
-                    state.isImageTransitioning = false;
                 }
             },
-
-            async deleteCurrentImage(options = {}) {
-                const { exitFocusIfEmpty = true, source = 'ui:direct' } = options;
-                if (state.isImageTransitioning) return;
-                const currentStackName = state.currentStack;
-                const currentStackArray = state.stacks[currentStackName];
-                if (!currentStackArray || currentStackArray.length === 0) return;
-                const currentFile = currentStackArray[state.currentStackPosition];
-                if (!currentFile) return;
-
-                state.isImageTransitioning = true;
-                const fileId = currentFile.id;
-                const originalStack = currentFile.stack || currentStackName;
-
-                try {
-                    state.syncLog?.log({
-                        event: 'ui:provider-trash-request',
-                        level: 'warn',
-                        fileId,
-                        details: `User requested moving ${currentFile.name || fileId} from ${STACK_NAMES[originalStack] || originalStack} into the provider recycle bin (${source}). No permanent deletion occurs.`,
-                        data: { from: originalStack, source }
-                    });
-                    const movedToRecycle = await App.deleteFile(fileId, { source, originStack: originalStack, name: currentFile.name });
-                    if (!movedToRecycle) {
-                        state.syncLog?.log({
-                            event: 'ui:provider-trash-abort',
-                            level: 'error',
-                            fileId,
-                            details: `Provider recycle move failed for ${currentFile.name || fileId}; item restored in ${STACK_NAMES[originalStack] || originalStack}.`,
-                            data: { from: originalStack, source }
-                        });
-                        await this.displayCurrentImage();
-                        return;
-                    }
-                    this.updateStackCounts();
-                    const updatedStack = state.stacks[currentStackName] || [];
-                    if (updatedStack.length === 0) {
-                        state.currentStackPosition = 0;
-                        if (state.isFocusMode && exitFocusIfEmpty) {
-                            Gestures.toggleFocusMode();
-                        }
-                        this.showEmptyState();
-                    } else {
-                        state.currentStackPosition = 0;
-                        await this.displayCurrentImage();
-                    }
-                    Utils.showToast('Moved to provider recycle bin. Restore it from your cloud trash if needed.', 'info', true);
-                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: true });
-                } catch (error) {
-                    Utils.showToast(`Failed to delete ${currentFile.name}`, 'error', true);
-                } finally {
-                    state.isImageTransitioning = false;
-                }
-            },
-
+            
             showEmptyState() {
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
@@ -3598,6 +2821,8 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             }
         };
         const Grid = {
+            _dragMoveHandler: null,
+            _dragEndHandler: null,
             open(stack) {
                 Utils.showModal('grid-modal');
                 Utils.elements.gridTitle.textContent = STACK_NAMES[stack] || stack;
@@ -3607,13 +2832,15 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 Utils.elements.gridContainer.style.gridTemplateColumns = `repeat(${value}, 1fr)`;
                 state.grid.selected = []; state.grid.filtered = [];
                 Utils.elements.gridContainer.innerHTML = '';
+                this.clearDragState();
                 this.initializeLazyLoad(stack);
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
+                    this.clearDragState();
                     if (state.grid.isDirty) {
                         await this.reorderStackOnClose();
                     }
@@ -3647,7 +2874,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 Utils.elements.selectAllBtn.textContent = sourceFiles.length;
                 this.renderBatch();
                 if (lazyState.observer) lazyState.observer.disconnect();
-                lazyState.observer = new IntersectionObserver(this.handleIntersection.bind(this), {
+                lazyState.observer = new IntersectionObserver(this.handleIntersection.bind(this), { 
                     root: Utils.elements.gridContent, rootMargin: "400px"
                 });
                 const sentinel = document.getElementById('grid-sentinel');
@@ -3663,7 +2890,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             renderBatch() {
                 const lazyState = state.grid.lazyLoadState;
                 const container = Utils.elements.gridContainer;
-                const filesToRender = lazyState.allFiles.slice(lazyState.renderedCount, lazyState.renderedCount  lazyState.batchSize);
+                const filesToRender = lazyState.allFiles.slice(lazyState.renderedCount, lazyState.renderedCount + lazyState.batchSize);
 
                 const oldSentinel = document.getElementById('grid-sentinel');
                 if (oldSentinel && lazyState.observer) {
@@ -3679,7 +2906,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                     img.dataset.src = Utils.getPreferredImageUrl(file);
                     img.onload = () => img.classList.add('loaded');
                     img.onerror = () => {
-                        img.src = 'data:image/svgxml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'150\' height=\'150\' viewBox=\'0 0 150 150\' fill=\'none\'%3E%3Crect width=\'150\' height=\'150\' fill=\'%23E5E7EB\'/%3E%3Cpath d=\'M65 60H85V90H65V60Z\' fill=\'%239CA3AF\'/%3E%3Ccircle cx=\'75\' cy=\'45\' r=\'10\' fill=\'%239CA3AF\'/%3E%3C/svg%3E';
+                        img.src = 'data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'150\' height=\'150\' viewBox=\'0 0 150 150\' fill=\'none\'%3E%3Crect width=\'150\' height=\'150\' fill=\'%23E5E7EB\'/%3E%3Cpath d=\'M65 60H85V90H65V60Z\' fill=\'%239CA3AF\'/%3E%3Ccircle cx=\'75\' cy=\'45\' r=\'10\' fill=\'%239CA3AF\'/%3E%3C/svg%3E';
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
@@ -3688,10 +2915,11 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
+                    div.appendChild(this.createDragHandle(div, file.id));
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
-                lazyState.renderedCount = filesToRender.length;
+                lazyState.renderedCount += filesToRender.length;
 
                 if (lazyState.renderedCount < lazyState.allFiles.length) {
                     const sentinel = document.createElement('div');
@@ -3700,7 +2928,179 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
+            createDragHandle(gridItem, fileId) {
+                const handle = document.createElement('button');
+                handle.type = 'button';
+                handle.className = 'grid-drag-handle';
+                handle.textContent = '⠿';
+                handle.setAttribute('aria-label', 'Drag to reorder');
+                handle.addEventListener('pointerdown', event => {
+                    event.stopPropagation();
+                    this.startDrag(event, fileId, gridItem);
+                });
+                handle.addEventListener('click', event => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                });
+                return handle;
+            },
+
+            startDrag(event, fileId, gridItem) {
+                if (state.grid.isDragging) { return; }
+                if (!state.grid.stack) { return; }
+                if (event.pointerType === 'mouse' && event.button !== 0) { return; }
+
+                if (!state.grid.selected.includes(fileId)) {
+                    this.deselectAll();
+                    state.grid.selected = [fileId];
+                    gridItem.classList.add('selected');
+                    this.updateSelectionUI();
+                }
+
+                const selectedIds = state.grid.selected.length > 0 ? [...state.grid.selected] : [fileId];
+                const rect = gridItem.getBoundingClientRect();
+                const ghost = gridItem.cloneNode(true);
+                ghost.classList.add('grid-drag-ghost');
+                ghost.style.width = `${rect.width}px`;
+                ghost.style.height = `${rect.height}px`;
+                ghost.style.left = `${rect.left}px`;
+                ghost.style.top = `${rect.top}px`;
+                ghost.style.transform = `translate(${rect.left}px, ${rect.top}px)`;
+                document.body.appendChild(ghost);
+                document.body.style.userSelect = 'none';
+
+                state.grid.isDragging = true;
+                state.grid.dragSession = {
+                    ...createDefaultGridDragSession(),
+                    active: true,
+                    pointerId: event.pointerId ?? null,
+                    ghost,
+                    offsetX: event.clientX - rect.left,
+                    offsetY: event.clientY - rect.top,
+                    selectedIds
+                };
+
+                this._dragMoveHandler = this.handlePointerMove.bind(this);
+                this._dragEndHandler = this.handlePointerRelease.bind(this);
+                window.addEventListener('pointermove', this._dragMoveHandler, { passive: false });
+                window.addEventListener('pointerup', this._dragEndHandler);
+                window.addEventListener('pointercancel', this._dragEndHandler);
+
+                this.updateGhostPosition(event.clientX, event.clientY);
+                event.preventDefault();
+            },
+
+            handlePointerMove(event) {
+                const session = state.grid.dragSession;
+                if (!session.active) { return; }
+                if (session.pointerId !== null && event.pointerId !== session.pointerId) { return; }
+
+                if (event.cancelable) { event.preventDefault(); }
+                this.updateGhostPosition(event.clientX, event.clientY);
+
+                const element = document.elementFromPoint(event.clientX, event.clientY);
+                const tile = element ? element.closest('.grid-item') : null;
+                if (tile && tile.id === 'grid-sentinel') {
+                    this.setDropTarget(null);
+                } else {
+                    this.setDropTarget(tile);
+                }
+            },
+
+            async handlePointerRelease(event) {
+                const session = state.grid.dragSession;
+                if (!session.active) { return; }
+                if (session.pointerId !== null && event.pointerId !== session.pointerId) { return; }
+
+                this.detachDragListeners();
+
+                if (event.type === 'pointercancel') {
+                    this.clearDragState();
+                    return;
+                }
+
+                if (event.cancelable) { event.preventDefault(); }
+
+                if (!session.dropTarget) {
+                    this.clearDragState();
+                    return;
+                }
+
+                const dropTargetId = session.dropTarget.dataset.fileId;
+                if (!dropTargetId || session.selectedIds.includes(dropTargetId)) {
+                    this.clearDragState();
+                    return;
+                }
+
+                const allFiles = state.grid.lazyLoadState.allFiles || [];
+                let targetIndex = allFiles.findIndex(file => file.id === dropTargetId);
+                if (targetIndex === -1) { targetIndex = allFiles.length; }
+
+                try {
+                    await persistGroupDropOrder(session.selectedIds, targetIndex);
+                } catch (error) {
+                    console.error('Error reordering grid items:', error);
+                    Utils.showToast(`Error reordering items: ${error.message}`, 'error', true);
+                } finally {
+                    this.clearDragState();
+                }
+            },
+
+            detachDragListeners() {
+                if (this._dragMoveHandler) {
+                    window.removeEventListener('pointermove', this._dragMoveHandler);
+                    this._dragMoveHandler = null;
+                }
+                if (this._dragEndHandler) {
+                    window.removeEventListener('pointerup', this._dragEndHandler);
+                    window.removeEventListener('pointercancel', this._dragEndHandler);
+                    this._dragEndHandler = null;
+                }
+            },
+
+            updateGhostPosition(x, y) {
+                const session = state.grid.dragSession;
+                if (!session.ghost) { return; }
+                const left = x - session.offsetX;
+                const top = y - session.offsetY;
+                session.ghost.style.transform = `translate(${left}px, ${top}px)`;
+                session.ghost.style.left = `${left}px`;
+                session.ghost.style.top = `${top}px`;
+            },
+
+            setDropTarget(tile) {
+                const session = state.grid.dragSession;
+                if (session.dropTarget === tile) { return; }
+                if (session.dropTarget) {
+                    session.dropTarget.classList.remove('drop-target');
+                }
+                if (tile && tile !== session.ghost && tile.id !== 'grid-sentinel') {
+                    tile.classList.add('drop-target');
+                    session.dropTarget = tile;
+                } else {
+                    session.dropTarget = null;
+                }
+            },
+
+            clearDragState() {
+                const session = state.grid.dragSession;
+                if (session.dropTarget) {
+                    session.dropTarget.classList.remove('drop-target');
+                }
+                if (session.ghost && session.ghost.parentNode) {
+                    session.ghost.remove();
+                }
+                document.body.style.userSelect = '';
+                this.resetDragSession();
+            },
+
+            resetDragSession() {
+                this.detachDragListeners();
+                state.grid.dragSession = createDefaultGridDragSession();
+                state.grid.isDragging = false;
+            },
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -3735,23 +3135,22 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             },
             
             performSearch() {
-                const query = Utils.elements.omniSearch.value.trim();
+                const searchInput = Utils.elements.omniSearch;
+                const query = searchInput.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
+                state.grid.selected = [];
                 if (!query) { this.resetSearch(); return; }
 
                 const results = this.searchImages(query);
                 state.grid.filtered = results;
 
+                Utils.elements.gridContainer.innerHTML = '';
                 if (results.length === 0) {
-                    state.grid.selected = [];
                     Utils.elements.gridEmptyState.classList.remove('hidden');
-                    Utils.elements.selectAllBtn.textContent = '0';
                 } else {
-                    state.grid.selected = results.map(file => file.id);
                     Utils.elements.gridEmptyState.classList.add('hidden');
                 }
 
-                Utils.elements.gridContainer.innerHTML = '';
                 this.initializeLazyLoad(state.grid.stack, results);
                 this.updateSelectionUI();
                 state.grid.isDirty = true;
@@ -3768,40 +3167,48 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 this.deselectAll();
             },
 
-            syncWithStack(stackName, options = {}) {
-                if (!stackName) return;
-                const { removedIds = [], preselectFirst = true } = options;
-
-                if (removedIds.length > 0) {
-                    state.grid.selected = state.grid.selected.filter(id => !removedIds.includes(id));
-                    state.grid.filtered = state.grid.filtered.filter(file => !removedIds.includes(file.id));
-                }
-
-                if (state.grid.stack !== stackName) {
+            collectMetadataTokens(metadata, tokens) {
+                if (metadata === null || metadata === undefined) return;
+                if (typeof metadata === 'string' || typeof metadata === 'number' || typeof metadata === 'boolean') {
+                    const value = String(metadata).trim();
+                    if (value) tokens.push(value);
                     return;
                 }
-
-                const activeFiles = state.grid.filtered.length > 0
-                    ? state.grid.filtered
-                    : (state.stacks[stackName] || []);
-
-                if (preselectFirst) {
-                    if (activeFiles.length > 0) {
-                        state.grid.selected = [activeFiles[0].id];
-                    } else {
-                        state.grid.selected = [];
-                    }
+                if (Array.isArray(metadata)) {
+                    metadata.forEach(item => this.collectMetadataTokens(item, tokens));
+                    return;
                 }
+                if (typeof metadata === 'object') {
+                    Object.entries(metadata).forEach(([key, value]) => {
+                        const label = String(key).trim();
+                        if (label) tokens.push(label);
+                        this.collectMetadataTokens(value, tokens);
+                    });
+                }
+            },
 
-                Utils.elements.gridContainer.innerHTML = '';
-                this.initializeLazyLoad(stackName, activeFiles);
-                this.updateSelectionUI();
-                state.grid.isDirty = true;
+            buildSearchIndex(file) {
+                const tokens = [];
+                if (file.name) tokens.push(file.name);
+                if (Array.isArray(file.tags) && file.tags.length > 0) {
+                    tokens.push(...file.tags);
+                }
+                if (file.notes) tokens.push(file.notes);
+                this.collectMetadataTokens(file.extractedMetadata, tokens);
+
+                const normalized = tokens
+                    .map(token => typeof token === 'string' ? token : String(token))
+                    .join(' ')
+                    .replace(/\s+/g, ' ')
+                    .trim()
+                    .toLowerCase();
+
+                return normalized;
             },
 
             searchImages(query) {
                 const lowerCaseQuery = query.toLowerCase();
-                const terms = lowerCaseQuery.split(/\s/).filter(t => t);
+                const terms = lowerCaseQuery.split(/\s+/).filter(t => t);
 
                 const modifiers = terms.filter(t => t.startsWith('#'));
                 const exclusions = terms.filter(t => t.startsWith('-')).map(t => t.substring(1));
@@ -3809,8 +3216,15 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
 
                 let results = [...state.stacks[state.grid.stack]];
 
+                const searchIndexCache = new WeakMap();
+                const getSearchableText = (file) => {
+                    if (!searchIndexCache.has(file)) {
+                        searchIndexCache.set(file, this.buildSearchIndex(file));
+                    }
+                    return searchIndexCache.get(file);
+                };
+
                 // 1. Pass: Modifiers
-                const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
                         results = results.filter(file => file.favorite === true);
@@ -3824,46 +3238,17 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                         if (!isNaN(rating)) {
                             results = results.filter(file => file.contentRating === rating);
                         }
-                    } else if (mod.length > 1) {
-                        const normalizedTag = TagService.normalizeTagValue(mod);
-                        if (normalizedTag.length > 1) {
-                            tagFilters.push(normalizedTag.toLowerCase());
-                        }
                     }
                 });
-                if (tagFilters.length > 0) {
-                    results = results.filter(file => {
-                        const tags = TagService.normalizeTagList(file.tags || []).map(tag => tag.toLowerCase());
-                        return tagFilters.every(tag => tags.includes(tag));
-                    });
-                }
 
                 // 2. Pass: Inclusions
                 inclusions.forEach(term => {
-                    results = results.filter(file => {
-                        const searchableText = [
-                            file.name || '',
-                            file.tags?.join(' ') || '',
-                            file.notes || '',
-                            file.createdTime ? new Date(file.createdTime).toISOString().split('T')[0] : '',
-                            JSON.stringify(file.extractedMetadata || {})
-                        ].join(' ').toLowerCase();
-                        return searchableText.includes(term);
-                    });
+                    results = results.filter(file => getSearchableText(file).includes(term));
                 });
 
                 // 3. Pass: Exclusions
                 exclusions.forEach(term => {
-                    results = results.filter(file => {
-                        const searchableText = [
-                            file.name || '',
-                            file.tags?.join(' ') || '',
-                            file.notes || '',
-                            file.createdTime ? new Date(file.createdTime).toISOString().split('T')[0] : '',
-                            JSON.stringify(file.extractedMetadata || {})
-                        ].join(' ').toLowerCase();
-                        return !searchableText.includes(term);
-                    });
+                    results = results.filter(file => !getSearchableText(file).includes(term));
                 });
 
                 return results;
@@ -3900,6 +3285,85 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 Utils.showToast('Stack order updated', 'success');
             }
         };
+
+        async function persistGroupDropOrder(selectedIds, targetIndex) {
+            if (!Array.isArray(selectedIds) || selectedIds.length === 0) { return; }
+            const stackName = state.grid.stack;
+            if (!stackName) { return; }
+
+            const stackArray = state.stacks[stackName];
+            if (!Array.isArray(stackArray) || stackArray.length === 0) { return; }
+
+            const lazyState = state.grid.lazyLoadState || {};
+            const allFiles = Array.isArray(lazyState.allFiles) ? lazyState.allFiles : [];
+            const selectedSet = new Set(selectedIds);
+            const movingItems = [];
+            const remainingItems = [];
+
+            stackArray.forEach(file => {
+                if (selectedSet.has(file.id)) { movingItems.push(file); }
+                else { remainingItems.push(file); }
+            });
+
+            if (movingItems.length === 0) { return; }
+
+            const clampedIndex = Math.max(0, Math.min(Number.isFinite(targetIndex) ? targetIndex : 0, allFiles.length));
+            let insertionIndex = remainingItems.length;
+
+            if (clampedIndex < allFiles.length) {
+                let count = 0;
+                for (let i = 0; i < clampedIndex; i++) {
+                    const candidate = allFiles[i];
+                    if (candidate && !selectedSet.has(candidate.id)) { count += 1; }
+                }
+                insertionIndex = Math.min(count, remainingItems.length);
+            }
+
+            const newStackOrder = [
+                ...remainingItems.slice(0, insertionIndex),
+                ...movingItems,
+                ...remainingItems.slice(insertionIndex)
+            ];
+
+            const currentOrderIds = stackArray.map(file => file.id);
+            const newOrderIds = newStackOrder.map(file => file.id);
+            let hasChanges = currentOrderIds.length !== newOrderIds.length;
+            if (!hasChanges) {
+                for (let i = 0; i < currentOrderIds.length; i++) {
+                    if (currentOrderIds[i] !== newOrderIds[i]) { hasChanges = true; break; }
+                }
+            }
+            if (!hasChanges) { state.grid.isDirty = false; return; }
+
+            const timestamp = Date.now();
+            newStackOrder.forEach((file, idx) => {
+                file.stackSequence = timestamp - idx;
+            });
+
+            if (state.dbManager && typeof state.dbManager.saveMetadata === 'function') {
+                for (const file of newStackOrder) {
+                    await state.dbManager.saveMetadata(file.id, file);
+                }
+                if (state.currentFolder?.id && typeof state.dbManager.saveFolderCache === 'function') {
+                    await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
+                }
+            }
+
+            state.stacks[stackName] = newStackOrder;
+            if (state.grid.filtered.length > 0) {
+                const filteredIds = new Set(state.grid.filtered.map(file => file.id));
+                state.grid.filtered = newStackOrder.filter(file => filteredIds.has(file.id));
+            }
+
+            state.grid.lazyLoadState.allFiles = state.grid.filtered.length > 0 ? state.grid.filtered : newStackOrder;
+            state.grid.isDirty = false;
+
+            Utils.elements.gridContainer.innerHTML = '';
+            Grid.initializeLazyLoad(stackName);
+            Grid.updateSelectionUI();
+            Core.updateStackCounts();
+        }
+
         const Details = {
             tagEditor: null,
             notesEditor: null,
@@ -3956,47 +3420,26 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 const targetIds = this.getTargetFileIds(file?.id);
                 container.classList.add('tag-editor-container');
                 container.innerHTML = '';
-
-                const assignedSection = document.createElement('div');
-                assignedSection.className = 'tag-section';
-                const assignedTitle = document.createElement('div');
-                assignedTitle.className = 'tag-section-title';
-                assignedTitle.textContent = 'Assigned Tags';
-                const chipList = document.createElement('div');
-                chipList.className = 'tag-chip-list';
-                assignedSection.appendChild(assignedTitle);
-                assignedSection.appendChild(chipList);
-
-                const input = document.createElement('input');
-                input.type = 'text';
-                input.className = 'tag-input';
-                input.placeholder = 'Enter tags separated by commas - non-# tags are auto-prefixed when you press Enter';
-
-                const recentSection = document.createElement('div');
-                recentSection.className = 'tag-section';
-                const recentTitle = document.createElement('div');
-                recentTitle.className = 'tag-section-title';
-                recentTitle.textContent = 'Recently Used Tags';
-                const recentList = document.createElement('div');
-                recentList.className = 'tag-chip-list';
-                recentSection.appendChild(recentTitle);
-                recentSection.appendChild(recentList);
-
                 const message = document.createElement('div');
                 message.className = 'tag-editor-note';
                 message.textContent = targetIds.length > 1 ? `Changes apply to ${targetIds.length} selected images.` : 'Changes apply to this image.';
-
-                container.appendChild(assignedSection);
-                container.appendChild(input);
-                container.appendChild(recentSection);
                 container.appendChild(message);
-
+                const chipList = document.createElement('div');
+                chipList.className = 'tag-chip-list';
+                container.appendChild(chipList);
+                const input = document.createElement('input');
+                input.type = 'text';
+                input.className = 'tag-input';
+                input.placeholder = 'Add tag and press Enter';
+                container.appendChild(input);
+                const suggestions = document.createElement('div');
+                suggestions.className = 'tag-suggestions';
+                container.appendChild(suggestions);
                 this.tagEditor = TagEditor.create({
                     container: chipList,
                     input,
-                    recentContainer: recentList,
-                    targetIds,
-                    placeholder: input.placeholder
+                    suggestionContainer: suggestions,
+                    targetIds
                 });
                 input.focus();
             },
@@ -4063,8 +3506,8 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 const row = document.createElement('tr');
                 const formattedKey = key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
                 let formattedValue = String(value);
-                if (formattedValue.length > 200) { formattedValue = formattedValue.replace(/,\s/g, ',\n').replace(/\.\s/g, '.\n').replace(/;\s/g, ';\n').trim();
-                } else if (formattedValue.length > 100) { formattedValue = formattedValue.replace(/\s/g, ' ').trim(); }
+                if (formattedValue.length > 200) { formattedValue = formattedValue.replace(/,\s+/g, ',\n').replace(/\.\s+/g, '.\n').replace(/;\s+/g, ';\n').trim();
+                } else if (formattedValue.length > 100) { formattedValue = formattedValue.replace(/\s+/g, ' ').trim(); }
                 const keyCell = document.createElement('td');
                 keyCell.className = 'key-cell'; keyCell.textContent = formattedKey;
                 const valueCell = document.createElement('td');
@@ -4131,25 +3574,6 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                     option.addEventListener('click', () => { this.executeMove(option.dataset.stack); });
                 });
             },
-            setupFocusStackSwitch() {
-                const availableStacks = STACKS.filter(stack => stack !== state.currentStack && state.stacks[stack].length > 0);
-                let content = `<div style="display: flex; flex-direction: column; gap: 8px; margin-bottom: 16px;">`;
-                if (availableStacks.length > 0) {
-                    content = availableStacks.map(stack => `<button class="move-option" data-stack="${stack}" style="width: 100%; text-align: left; padding: 8px 16px; border-radius: 6px; border: none; background: transparent; cursor: pointer; transition: background-color 0.2s;">${STACK_NAMES[stack]} (${state.stacks[stack].length})</button>`).join('');
-                } else {
-                    content = `<p style="color: #4b5563; text-align: center;">No other stacks have images.</p>`;
-                }
-                content = `</div>`;
-                this.show('focus-stack-switch', { title: 'Switch Stack', content, confirmText: 'Cancel' });
-                document.querySelectorAll('.move-option').forEach(option => {
-                    option.addEventListener('click', () => {
-                        const targetStack = option.dataset.stack;
-                        UI.switchToStack(targetStack);
-                        Core.updateImageCounters();
-                        this.hide();
-                    });
-                });
-            },
             setupTagAction() {
                 const selectedIds = state.grid.selected.length > 0 ? [...state.grid.selected] : [];
                 const total = selectedIds.length;
@@ -4157,23 +3581,17 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 this.show('tag', {
                     title: 'Edit Tags',
                     content: `<div class="tag-editor-container">
-                                <div class="tag-section">
-                                    <div class="tag-section-title">Assigned Tags</div>
-                                    <div id="bulk-tag-chips" class="tag-chip-list"></div>
-                                </div>
-                                <input type="text" id="bulk-tag-input" class="tag-input" placeholder="Enter tags separated by commas - non-# tags are auto-prefixed when you press Enter">
-                                <div class="tag-section">
-                                    <div class="tag-section-title">Recently Used Tags</div>
-                                    <div id="bulk-tag-recents" class="tag-chip-list"></div>
-                                </div>
                                 <div class="tag-editor-note">${scopeText}</div>
+                                <div id="bulk-tag-chips" class="tag-chip-list"></div>
+                                <input type="text" id="bulk-tag-input" class="tag-input" placeholder="Add tag and press Enter">
+                                <div id="bulk-tag-suggestions" class="tag-suggestions"></div>
                              </div>`,
                     hideConfirm: true,
                     cancelText: 'Close'
                 });
                 const chipsContainer = document.getElementById('bulk-tag-chips');
                 const input = document.getElementById('bulk-tag-input');
-                const recents = document.getElementById('bulk-tag-recents');
+                const suggestions = document.getElementById('bulk-tag-suggestions');
                 if (this.tagEditor) {
                     this.tagEditor.destroy();
                     this.tagEditor = null;
@@ -4181,9 +3599,8 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 this.tagEditor = TagEditor.create({
                     container: chipsContainer,
                     input,
-                    recentContainer: recents,
-                    targetIds: selectedIds,
-                    placeholder: input ? input.placeholder : undefined
+                    suggestionContainer: suggestions,
+                    targetIds: selectedIds
                 });
                 if (input) input.focus();
             },
@@ -4255,22 +3672,18 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 confirmBtn.textContent = 'Processing...';
 
                 try {
-                    const affectedIds = [...state.grid.selected];
-                    const promises = affectedIds.map(fileId => action(fileId));
+                    const promises = state.grid.selected.map(fileId => action(fileId));
                     await Promise.all(promises);
 
                     Utils.showToast(successMessage.replace('{count}', promises.length), 'success', true);
                     this.hide();
                     Core.updateStackCounts();
-                    await Core.displayCurrentImage();
 
-                    if (updateGridOnSuccess && state.grid.stack) {
-                        Grid.syncWithStack(state.grid.stack, { removedIds: affectedIds, preselectFirst: true });
-                    } else if (updateGridOnSuccess) {
-                        Grid.deselectAll();
-                    } else {
-                        Grid.deselectAll();
+                    if (updateGridOnSuccess) {
+                        Utils.elements.gridContainer.innerHTML = '';
+                        Grid.initializeLazyLoad(state.grid.stack);
                     }
+                    Grid.deselectAll();
                     return true;
                 } catch (error) {
                     Utils.showToast(`Failed to process some images: ${error.message}`, 'error', true);
@@ -4287,16 +3700,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                         if (file) {
                             const currentStack = file.stack;
                             const newSequence = Date.now();
-                            const fromLabel = currentStack ? (STACK_NAMES[currentStack] || currentStack) : 'unknown';
-                            const toLabel = STACK_NAMES[targetStack] || targetStack;
-                            state.syncLog?.log({
-                                event: targetStack === 'trash' ? 'ui:stack-recycle' : 'ui:stack-move',
-                                level: targetStack === 'trash' ? 'warn' : 'info',
-                                fileId,
-                                details: `Bulk move ${file.name || fileId} from ${fromLabel} to ${toLabel} (grid selection).`,
-                                data: { from: currentStack, to: targetStack, stackSequence: newSequence, source: 'grid:bulk-move' }
-                            });
-                            await App.updateUserMetadata(fileId, { stack: targetStack, stackSequence: newSequence }, { skipDebounce: true, operationType: 'stack:move' });
+                            await App.updateUserMetadata(fileId, { stack: targetStack, stackSequence: newSequence });
                             const currentStackIndex = state.stacks[currentStack].findIndex(f => f.id === fileId);
                             if (currentStackIndex !== -1) {
                                 state.stacks[currentStack].splice(currentStackIndex, 1);
@@ -4345,14 +3749,9 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             async executeDelete() {
                 await this.executeBulkAction({
                     action: async (fileId) => {
-                        const file = state.imageFiles.find(f => f.id === fileId);
-                        await App.deleteFile(fileId, {
-                            source: 'grid:bulk-delete',
-                            originStack: file?.stack || null,
-                            name: file?.name || null
-                        });
+                        await App.deleteFile(fileId);
                     },
-                    successMessage: `Moved {count} images to provider recycle bin`
+                    successMessage: `Moved {count} images to provider trash`
                 });
             },
             async executeExport() {
@@ -4363,14 +3762,14 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 Utils.elements.actionContent.innerHTML = `<div style="background: #111; border: 1px solid #333; color: #eee; font-family: monospace; font-size: 12px; height: 250px; overflow-y: scroll; padding: 8px; white-space: pre-wrap;" id="export-log"></div>`;
                 const logEl = document.getElementById('export-log');
                 Utils.elements.actionConfirm.disabled = true; Utils.elements.actionCancel.textContent = "Close";
-                const log = (message) => { logEl.textContent = message  '\n'; logEl.scrollTop = logEl.scrollHeight; };
+                const log = (message) => { logEl.textContent += message + '\n'; logEl.scrollTop = logEl.scrollHeight; };
                 log(`Starting export for ${total} images...`);
-                for (let i = 0; i < filesToExport.length; i) {
+                for (let i = 0; i < filesToExport.length; i++) {
                     const file = filesToExport[i];
-                    Utils.elements.actionTitle.textContent = `Live Export: ${i  1} of ${total}`;
-                    log(`\n[${i1}/${total}] Processing: ${file.name}`);
+                    Utils.elements.actionTitle.textContent = `Live Export: ${i + 1} of ${total}`;
+                    log(`\n[${i+1}/${total}] Processing: ${file.name}`);
                     let extractedMetadata = {}; let success = false;
-                    for (let attempt = 1; attempt <= 3; attempt) {
+                    for (let attempt = 1; attempt <= 3; attempt++) {
                         try {
                             const metadata = await state.metadataExtractor.fetchMetadata(file, true);
                             if (metadata.error) throw new Error(metadata.error);
@@ -4378,7 +3777,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                         } catch (error) {
                             log(`  ⚠️ Attempt ${attempt} failed: ${error.message}`);
                             if (attempt < 3) { const delay = 1000 * attempt; log(`     Retrying in ${delay / 1000}s...`); await new Promise(res => setTimeout(res, delay));
-                            } else { log(`  ❌ FAILED permanently after 3 attempts.`); failures; }
+                            } else { log(`  ❌ FAILED permanently after 3 attempts.`); failures++; }
                         }
                     }
                     results.push({ ...file, extractedMetadata: extractedMetadata });
@@ -4405,11 +3804,13 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             hubPressActive: false,
             overlay: null,
             lastHubTap: { time: 0, x: 0, y: 0 },
-            tapHandled: false,
             DOUBLE_TAP_MAX_INTERVAL: 320,
             DOUBLE_TAP_MAX_DISTANCE: 28,
             TAP_DISTANCE_THRESHOLD: 26,
             TAP_DURATION_THRESHOLD: 260,
+            IGNORE_MOUSE_TIMEOUT: 450,
+            ignoreMouseEventsUntil: 0,
+            activePointerType: null,
             TRAIL_INTERVAL_MS: 12,
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
@@ -4514,8 +3915,8 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 if (!viewport) return false;
                 const rect = viewport.getBoundingClientRect();
                 if (!rect.width || !rect.height) return false;
-                const cx = rect.left  rect.width / 2;
-                const cy = rect.top  rect.height / 2;
+                const cx = rect.left + rect.width / 2;
+                const cy = rect.top + rect.height / 2;
                 const radius = Math.min(rect.width, rect.height) * 0.12;
                 return Math.hypot(clientX - cx, clientY - cy) <= radius;
             },
@@ -4523,15 +3924,15 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 const v0x = cx - ax, v0y = cy - ay;
                 const v1x = bx - ax, v1y = by - ay;
                 const v2x = px - ax, v2y = py - ay;
-                const dot00 = v0x * v0x  v0y * v0y;
-                const dot01 = v0x * v1x  v0y * v1y;
-                const dot02 = v0x * v2x  v0y * v2y;
-                const dot11 = v1x * v1x  v1y * v1y;
-                const dot12 = v1x * v2x  v1y * v2y;
+                const dot00 = v0x * v0x + v0y * v0y;
+                const dot01 = v0x * v1x + v0y * v1y;
+                const dot02 = v0x * v2x + v0y * v2y;
+                const dot11 = v1x * v1x + v1y * v1y;
+                const dot12 = v1x * v2x + v1y * v2y;
                 const invDen = 1 / (dot00 * dot11 - dot01 * dot01);
                 const u = (dot11 * dot02 - dot01 * dot12) * invDen;
                 const v = (dot00 * dot12 - dot01 * dot02) * invDen;
-                return (u >= 0) && (v >= 0) && (u  v <= 1);
+                return (u >= 0) && (v >= 0) && (u + v <= 1);
             },
             hitTriangle(clientX, clientY) {
                 const viewport = Utils.elements.imageViewport;
@@ -4582,8 +3983,8 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             },
             showEdgeGlow(direction) {
                 this.edgeElements.forEach(edge => edge.classList.remove('active'));
-                if (Utils.elements[`edge${direction.charAt(0).toUpperCase()  direction.slice(1)}`]) {
-                    Utils.elements[`edge${direction.charAt(0).toUpperCase()  direction.slice(1)}`].classList.add('active');
+                if (Utils.elements[`edge${direction.charAt(0).toUpperCase() + direction.slice(1)}`]) {
+                    Utils.elements[`edge${direction.charAt(0).toUpperCase() + direction.slice(1)}`].classList.add('active');
                 }
             },
             hideAllEdgeGlows() { this.edgeElements.forEach(edge => edge.classList.remove('active')); },
@@ -4599,19 +4000,26 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 try {
                     UI.acknowledgePillCounter(targetStack);
                     if (state.haptic) { state.haptic.triggerFeedback('swipe'); }
-                    await Core.moveToStack(targetStack, { source: 'gesture:flick' });
+                    await Core.moveToStack(targetStack);
                     this.hideAllEdgeGlows();
                 } catch(error) {
                     Utils.showToast(`Flick failed: ${error.message}`, 'error', true);
                 }
             },
             handleStart(e) {
-                this.tapHandled = false;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
+                const now = Date.now();
+                const isTouch = e.type && e.type.startsWith('touch');
+                if (!isTouch && now < this.ignoreMouseEventsUntil) { return; }
+                if (isTouch) {
+                    this.ignoreMouseEventsUntil = now + this.IGNORE_MOUSE_TIMEOUT;
+                }
                 const point = e.touches ? e.touches[0] : e;
+                if (!point) return;
                 const hubInteraction = this.isInHub(point.clientX, point.clientY);
                 if (!hubInteraction && state.stacks[state.currentStack].length === 0) return;
+                this.activePointerType = isTouch ? 'touch' : 'mouse';
                 this.startPos = { x: point.clientX, y: point.clientY };
                 this.currentPos = { x: point.clientX, y: point.clientY };
                 this.startTimestamp = performance.now();
@@ -4626,6 +4034,12 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             },
             handleMove(e) {
                 if (!state.isDragging) return;
+                const isTouch = e.type && e.type.startsWith('touch');
+                if (this.activePointerType === 'touch' && !isTouch) return;
+                if (this.activePointerType === 'mouse' && isTouch) return;
+                if (isTouch) {
+                    this.ignoreMouseEventsUntil = Date.now() + this.IGNORE_MOUSE_TIMEOUT;
+                }
                 if (e.touches && e.touches.length > 1) {
                     state.isDragging = false; Utils.elements.centerImage.classList.remove('dragging');
                     this.hideAllEdgeGlows(); return;
@@ -4638,7 +4052,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 if (state.imageFiles.length === 0) return;
                 const deltaX = this.currentPos.x - this.startPos.x;
                 const deltaY = this.currentPos.y - this.startPos.y;
-                const distance = Math.sqrt(deltaX * deltaX  deltaY * deltaY);
+                const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
                 if (distance > 30) {
                     this.gestureStarted = true;
                     if(!state.isFocusMode) {
@@ -4651,6 +4065,14 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             },
             handleEnd(e) {
                 if (!state.isDragging) return;
+                const coarseNow = Date.now();
+                const isTouch = e.type && e.type.startsWith('touch');
+                if (!isTouch && (this.activePointerType === 'touch' || coarseNow < this.ignoreMouseEventsUntil)) {
+                    return;
+                }
+                if (isTouch) {
+                    this.ignoreMouseEventsUntil = coarseNow + this.IGNORE_MOUSE_TIMEOUT;
+                }
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');
                 const point = e.changedTouches && e.changedTouches.length ? e.changedTouches[0] : e;
@@ -4658,7 +4080,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 this.spawnTrail(this.currentPos.x, this.currentPos.y);
                 const deltaX = this.currentPos.x - this.startPos.x;
                 const deltaY = this.currentPos.y - this.startPos.y;
-                const distance = Math.sqrt(deltaX * deltaX  deltaY * deltaY);
+                const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
                 const now = performance.now();
                 const duration = now - this.startTimestamp;
                 const isTap = distance < this.TAP_DISTANCE_THRESHOLD && duration < this.TAP_DURATION_THRESHOLD;
@@ -4703,18 +4125,16 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                         }
                     }
                 } else if (!this.gestureStarted && isTap) {
-                    if (!this.tapHandled) {
-                        this.tapHandled = true;
-                        this.spawnRipple(this.currentPos.x, this.currentPos.y);
-                        this.handleTap(this.currentPos.x, this.currentPos.y);
-                    }
+                    this.spawnRipple(this.currentPos.x, this.currentPos.y);
+                    this.handleTap(this.currentPos.x, this.currentPos.y);
                 }
                 this.hideAllEdgeGlows();
                 this.hubPressActive = false;
                 this.gestureStarted = false;
+                this.activePointerType = null;
             },
-            getDistance(touch1, touch2) { const dx = touch1.clientX - touch2.clientX; const dy = touch1.clientY - touch2.clientY; return Math.sqrt(dx * dx  dy * dy); },
-            getCenter(touch1, touch2) { return { x: (touch1.clientX  touch2.clientX) / 2, y: (touch1.clientY  touch2.clientY) / 2 }; },
+            getDistance(touch1, touch2) { const dx = touch1.clientX - touch2.clientX; const dy = touch1.clientY - touch2.clientY; return Math.sqrt(dx * dx + dy * dy); },
+            getCenter(touch1, touch2) { return { x: (touch1.clientX + touch2.clientX) / 2, y: (touch1.clientY + touch2.clientY) / 2 }; },
             handleTouchStart(e) {
                 if (e.touches.length === 2) {
                     e.preventDefault(); state.isPinching = true;
@@ -4734,8 +4154,8 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                     e.preventDefault();
                     const deltaX = e.touches[0].clientX - state.lastTouchPos.x;
                     const deltaY = e.touches[0].clientY - state.lastTouchPos.y;
-                    state.panOffset.x = deltaX / state.currentScale;
-                    state.panOffset.y = deltaY / state.currentScale;
+                    state.panOffset.x += deltaX / state.currentScale;
+                    state.panOffset.y += deltaY / state.currentScale;
                     state.lastTouchPos = { x: e.touches[0].clientX, y: e.touches[0].clientY }; Core.applyTransform();
                 }
             },
@@ -4762,17 +4182,35 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             async nextImage() {
                 const stack = state.stacks[state.currentStack];
                 if (stack.length === 0) return;
-                state.currentStackPosition = (state.currentStackPosition  1) % stack.length;
+                state.currentStackPosition = (state.currentStackPosition + 1) % stack.length;
                 await Core.displayCurrentImage();
             },
             async prevImage() {
                 const stack = state.stacks[state.currentStack];
                 if (stack.length === 0) return;
-                state.currentStackPosition = (state.currentStackPosition - 1  stack.length) % stack.length;
+                state.currentStackPosition = (state.currentStackPosition - 1 + stack.length) % stack.length;
                 await Core.displayCurrentImage();
             },
             async deleteCurrentImage() {
-                await Core.deleteCurrentImage({ exitFocusIfEmpty: true, source: 'gesture:shortcut' });
+                const currentStackArray = state.stacks[state.currentStack];
+                if (currentStackArray.length === 0) return;
+                const fileToDelete = currentStackArray[state.currentStackPosition];
+                try {
+                    await App.deleteFile(fileToDelete.id);
+                    Core.updateStackCounts();
+                    if (currentStackArray.length === 0) {
+                        this.toggleFocusMode();
+                        Core.showEmptyState();
+                    } else {
+                        if (state.currentStackPosition >= currentStackArray.length) {
+                            state.currentStackPosition = currentStackArray.length - 1;
+                        }
+                        if (state.currentStackPosition < 0) {
+                            state.currentStackPosition = 0;
+                        }
+                        await Core.displayCurrentImage();
+                    }
+                } catch (error) { Utils.showToast(`Failed to delete ${fileToDelete.name}`, 'error', true); }
             }
         };
         const Folders = {
@@ -4808,10 +4246,10 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
 
                     let dateInfo = new Date(folder.modifiedTime).toLocaleDateString();
                     if (folder.itemCount > 0) {
-                         dateInfo = ` • ${folder.itemCount} items`;
+                         dateInfo += ` • ${folder.itemCount} items`;
                     }
                     if (folder.hasChildren) {
-                        dateInfo = ` • Has subfolders`;
+                        dateInfo += ` • Has subfolders`;
                     }
 
                     const iconColor = folder.hasChildren ? 'var(--accent)' : 'rgba(255, 255, 255, 0.6)';
@@ -4880,7 +4318,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 const filesToMove = state.folderMoveMode.files;
                 Utils.showScreen('loading-screen'); Utils.updateLoadingProgress(0, filesToMove.length);
                 try {
-                    for(let i = 0; i < filesToMove.length; i) {
+                    for(let i = 0; i < filesToMove.length; i++) {
                         const fileId = filesToMove[i];
                         await state.provider.moveFileToFolder(fileId, folderId);
                         const fileIndex = state.imageFiles.findIndex(f => f.id === fileId);
@@ -4889,7 +4327,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                             const stackIndex = state.stacks[file.stack].findIndex(f => f.id === fileId);
                             if (stackIndex > -1) { state.stacks[file.stack].splice(stackIndex, 1); }
                         }
-                        Utils.updateLoadingProgress(i  1, filesToMove.length);
+                        Utils.updateLoadingProgress(i + 1, filesToMove.length);
                     }
                     Utils.showToast(`Moved ${filesToMove.length} images to ${folderName}`, 'success', true);
                     await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
@@ -4917,6 +4355,8 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             }
         };
         const UI = {
+            favoriteToggleCooldownUntil: 0,
+            FAVORITE_TOGGLE_DELAY: 400,
             updateEmptyStateButtons() {
                 const stacksWithImages = STACKS.filter(stack => state.stacks[stack].length > 0);
                 const hasOtherStacks = stacksWithImages.some(stack => stack !== state.currentStack);
@@ -4936,7 +4376,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             cycleThroughPills() {
                 const stackOrder = ['in', 'out', 'priority', 'trash'];
                 const currentIndex = stackOrder.indexOf(state.currentStack);
-                const nextIndex = (currentIndex  1) % stackOrder.length;
+                const nextIndex = (currentIndex + 1) % stackOrder.length;
                 const nextStack = stackOrder[nextIndex];
                 this.switchToStack(nextStack);
             }
@@ -4974,11 +4414,11 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                     const parent = modal.parentElement;
                     if (newTop < 0) newTop = 0;
                     if (newLeft < 0) newLeft = 0;
-                    if (newTop  modal.offsetHeight > parent.clientHeight) newTop = parent.clientHeight - modal.offsetHeight;
-                    if (newLeft  modal.offsetWidth > parent.clientWidth) newLeft = parent.clientWidth - modal.offsetWidth;
+                    if (newTop + modal.offsetHeight > parent.clientHeight) newTop = parent.clientHeight - modal.offsetHeight;
+                    if (newLeft + modal.offsetWidth > parent.clientWidth) newLeft = parent.clientWidth - modal.offsetWidth;
 
-                    modal.style.top = newTop  "px";
-                    modal.style.left = newLeft  "px";
+                    modal.style.top = newTop + "px";
+                    modal.style.left = newLeft + "px";
                 }
 
                 function closeDragElement() {
@@ -5078,20 +4518,44 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                 Utils.elements.detailsClose.addEventListener('click', () => Details.hide());
             },
             setupFocusMode() {
-                Utils.elements.centerTrashBtn.addEventListener('click', () => Core.deleteCurrentImage({ exitFocusIfEmpty: false, source: 'button:center-trash' }));
+                Utils.elements.centerTrashBtn.addEventListener('click', () => Core.moveToStack('trash'));
                 Utils.elements.focusStackName.addEventListener('click', () => Modal.setupFocusStackSwitch());
-                Utils.elements.focusDeleteBtn.addEventListener('click', () => Core.deleteCurrentImage({ exitFocusIfEmpty: true, source: 'button:focus-trash' }));
-                Utils.elements.focusFavoriteBtn.addEventListener('click', async () => {
-                    try {
-                        const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
-                        if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
-                        Core.updateFavoriteButton();
-                    } catch (error) {
-                         Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);
-                    }
-                });
+                Utils.elements.focusDeleteBtn.addEventListener('click', () => Gestures.deleteCurrentImage());
+                const { focusFavoriteBtn } = Utils.elements;
+                if (focusFavoriteBtn) {
+                    const toggleFavorite = async () => {
+                        try {
+                            const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
+                            if (!currentFile) return;
+                            const isFavorite = !currentFile.favorite;
+                            await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                            Core.updateFavoriteButton();
+                        } catch (error) {
+                            Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);
+                            UI.favoriteToggleCooldownUntil = Date.now();
+                        }
+                    };
+                    const readyForToggle = () => {
+                        const now = Date.now();
+                        if (now < UI.favoriteToggleCooldownUntil) { return false; }
+                        UI.favoriteToggleCooldownUntil = now + UI.FAVORITE_TOGGLE_DELAY;
+                        return true;
+                    };
+                    focusFavoriteBtn.addEventListener('pointerup', async (event) => {
+                        if (event.pointerType === 'mouse' && event.button !== 0) { return; }
+                        event.preventDefault();
+                        if (!readyForToggle()) { return; }
+                        await toggleFavorite();
+                    });
+                    focusFavoriteBtn.addEventListener('click', async (event) => {
+                        if (event.detail !== 0) {
+                            event.preventDefault();
+                            return;
+                        }
+                        if (!readyForToggle()) { return; }
+                        await toggleFavorite();
+                    });
+                }
             },
             setupTabs() { document.querySelectorAll('.tab-button').forEach(btn => { btn.addEventListener('click', () => Details.switchTab(btn.dataset.tab)); }); },
             setupCopyButtons() {
@@ -5137,6 +4601,7 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
             setupGridControls() {
                 Utils.elements.closeGrid.addEventListener('click', () => Grid.close());
                 Utils.elements.selectAllBtn.addEventListener('click', () => Grid.selectAll());
+                Utils.elements.deselectAllBtn.addEventListener('click', () => Grid.deselectAll());
                 Utils.elements.gridSize.addEventListener('input', () => {
                     const value = Utils.elements.gridSize.value;
                     Utils.elements.gridSizeValue.textContent = value;
@@ -5157,34 +4622,61 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                     searchHelper,
                     searchHelperIcon,
                     searchHelperPopup,
-                    searchHelperClose
+                    searchHelperClose,
+                    searchHelperRecent
                 } = Utils.elements;
 
                 const modifierLinks = document.querySelectorAll('.modifier-link');
                 const appendModifierToInput = (modifier) => {
                     if (!searchInput) return;
-                    const baseValue = searchInput.value.replace(/\s$/, '');
+                    const baseValue = searchInput.value.replace(/\s+$/, '');
                     const newValue = baseValue ? `${baseValue} ${modifier} ` : `${modifier} `;
                     searchInput.value = newValue;
                     searchInput.focus();
                     Grid.performSearch();
                 };
 
-                if (searchHelper && searchHelperIcon && searchHelperPopup) {
-                    const setHelperState = (isOpen) => {
-                        const open = Boolean(isOpen);
-                        searchHelper.classList.toggle('is-open', open);
-                        searchHelperPopup.setAttribute('aria-hidden', String(!open));
-                        searchHelperIcon.setAttribute('aria-expanded', String(open));
-                    };
-                    const closeHelper = (focusIcon = false) => {
-                        setHelperState(false);
-                        if (focusIcon) {
-                            searchHelperIcon.focus();
-                        }
-                    };
-                    const openHelper = () => setHelperState(true);
+                if (!searchHelper || !searchHelperIcon || !searchHelperPopup) {
+                    modifierLinks.forEach(link => {
+                        link.addEventListener('click', (event) => {
+                            event.preventDefault();
+                            const modifier = link.dataset.modifier;
+                            if (!modifier) return;
+                            appendModifierToInput(modifier);
+                        });
+                    });
+                    return;
+                }
 
+                const hoverMedia = window.matchMedia('(hover: hover)');
+                const setHelperState = (isOpen) => {
+                    const open = Boolean(isOpen);
+                    searchHelper.classList.toggle('is-open', open);
+                    searchHelperPopup.setAttribute('aria-hidden', String(!open));
+                    searchHelperIcon.setAttribute('aria-expanded', String(open));
+                };
+                const resetRecentModifier = () => {
+                    if (!searchHelperRecent) return;
+                    searchHelperRecent.innerHTML = '';
+                    searchHelperRecent.classList.add('hidden');
+                };
+                const closeHelper = (focusIcon = false) => {
+                    setHelperState(false);
+                    resetRecentModifier();
+                    if (focusIcon && searchHelperIcon) {
+                        searchHelperIcon.focus();
+                    }
+                };
+                const openHelper = () => setHelperState(true);
+
+                if (hoverMedia.matches) {
+                    searchHelper.addEventListener('mouseenter', openHelper);
+                    searchHelperIcon.addEventListener('focus', openHelper);
+                    searchHelperIcon.addEventListener('click', (event) => {
+                        event.preventDefault();
+                        openHelper();
+                    });
+                } else {
                     searchHelperIcon.addEventListener('click', (event) => {
                         event.preventDefault();
                         if (searchHelper.classList.contains('is-open')) {
@@ -5193,56 +4685,67 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                             openHelper();
                         }
                     });
+                }
 
-                    if (searchHelperClose) {
-                        searchHelperClose.addEventListener('click', (event) => {
-                            event.preventDefault();
-                            closeHelper(true);
-                        });
-                    }
-
-                    document.addEventListener('click', (event) => {
-                        if (!searchHelper.contains(event.target)) {
-                            closeHelper();
-                        }
-                    });
-
-                    const handleEscape = (event) => {
-                        if (event.key === 'Escape') {
-                            closeHelper(true);
-                        }
-                    };
-                    searchHelperIcon.addEventListener('keydown', handleEscape);
-                    searchHelperPopup.addEventListener('keydown', handleEscape);
-
-                    modifierLinks.forEach(link => {
-                        link.addEventListener('click', (event) => {
-                            event.preventDefault();
-                            const modifier = link.dataset.modifier;
-                            if (!modifier) return;
-                            appendModifierToInput(modifier);
-                            closeHelper();
-                        });
-                    });
-                } else {
-                    modifierLinks.forEach(link => {
-                        link.addEventListener('click', (event) => {
-                            event.preventDefault();
-                            const modifier = link.dataset.modifier;
-                            if (!modifier) return;
-                            appendModifierToInput(modifier);
-                        });
+                if (searchHelperClose) {
+                    searchHelperClose.addEventListener('click', (event) => {
+                        event.preventDefault();
+                        closeHelper(true);
                     });
                 }
 
-                if (Utils.elements.deselectAllBtn) {
-                    Utils.elements.deselectAllBtn.addEventListener('click', () => {
-                        if (Utils.elements.omniSearch.value.trim() || state.grid.filtered.length > 0) {
-                            Grid.resetSearch();
-                        } else {
-                            Grid.deselectAll();
-                        }
+                const showRecentModifier = (modifier) => {
+                    if (!searchHelperRecent) return;
+                    const pill = document.createElement('button');
+                    pill.type = 'button';
+                    pill.className = 'modifier-pill';
+                    pill.textContent = modifier;
+                    pill.addEventListener('click', () => {
+                        closeHelper(true);
                     });
+                    searchHelperRecent.innerHTML = '';
+                    searchHelperRecent.appendChild(pill);
+                    searchHelperRecent.classList.remove('hidden');
+                };
+
+                const handleModifierSelection = (modifier) => {
+                    appendModifierToInput(modifier);
+                    if (hoverMedia.matches) {
+                        showRecentModifier(modifier);
+                        openHelper();
+                    } else {
+                        closeHelper();
+                    }
+                };
+
+                modifierLinks.forEach(link => {
+                    link.addEventListener('click', (event) => {
+                        event.preventDefault();
+                        const modifier = link.dataset.modifier;
+                        if (!modifier) return;
+                        handleModifierSelection(modifier);
+                    });
+                });
+
+                document.addEventListener('click', (event) => {
+                    if (!searchHelper.contains(event.target)) {
+                        closeHelper();
+                    }
+                });
+
+                const handleEscape = (event) => {
+                    if (event.key === 'Escape') {
+                        closeHelper(true);
+                    }
+                };
+                searchHelperIcon.addEventListener('keydown', handleEscape);
+                searchHelperPopup.addEventListener('keydown', handleEscape);
+
+                const handleMediaChange = () => closeHelper();
+                if (typeof hoverMedia.addEventListener === 'function') {
+                    hoverMedia.addEventListener('change', handleMediaChange);
+                } else if (typeof hoverMedia.addListener === 'function') {
+                    hoverMedia.addListener(handleMediaChange);
                 }
             },
             setupActionButtons() {
@@ -5283,9 +4786,9 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
                         if (keyMap[e.key]) {
                             e.preventDefault();
                             const targetStack = keyMap[e.key];
-                            if (state.stacks[state.currentStack].length > 0) {
-                                UI.acknowledgePillCounter(targetStack);
-                                await Core.moveToStack(targetStack, { source: `keyboard:${e.key}` });
+                            if (state.stacks[state.currentStack].length > 0) { 
+                                UI.acknowledgePillCounter(targetStack); 
+                                await Core.moveToStack(targetStack); 
                             }
                             return;
                         }
@@ -5302,15 +4805,12 @@ index 0000000000000000000000000000000000000000..7d5b412630a3a5acf38e1da0f00280b5
         async function initApp() {
             try {
                 Utils.init();
-                state.syncLog = new SyncActivityLogger();
-                state.syncLog.init();
                 state.visualCues = new VisualCueManager();
                 state.haptic = new HapticFeedbackManager();
                 state.export = new ExportSystem();
                 state.dbManager = new DBManager();
                 await state.dbManager.init();
-                state.syncManager = new SyncManager({ dbManager: state.dbManager, logger: state.syncLog });
-                state.syncManager.start();
+                state.syncManager = new SyncManager();
                 state.metadataExtractor = new MetadataExtractor();
                 Utils.showScreen('provider-screen');
                 Events.init();


### PR DESCRIPTION
## Summary
- rebuild ui-v2 from the ui-v1 baseline while switching Google Drive image URLs to permanent shareable links
- filter synthetic mouse events in the gesture handlers so taps only advance a single image and stack pills remain responsive
- keep focus mode on the next image after deletions and add pointer-aware favorite toggling that updates immediately

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7e5727080832da7ededb032963711