### PR TITLE
Add ui-v2a built from ui-v1 with gesture and favorite fixes

### DIFF
--- a/ui-v2a.html
+++ b/ui-v2a.html
@@ -2736,9 +2736,6 @@
             },
 
             updateFavoriteButton() {
-                if (typeof UI !== 'undefined') {
-                    UI.favoriteToggleCooldownUntil = 0;
-                }
                 const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                 if (!currentFile) {
                     if (Utils.elements.focusFavoriteBtn) {
@@ -2754,6 +2751,7 @@
                     const label = isFavorite ? 'Remove from favorites' : 'Add to favorites';
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
+                UI.favoriteToggleCooldownUntil = 0;
             },
             
             applyTransform() {


### PR DESCRIPTION
## Summary
- build ui-v2a.html from the ui-v1 baseline while switching Google Drive image helpers to permanent shareable links so the interface stays aligned with the original design but no longer depends on expiring URLs
- harden the gesture engine to ignore synthetic mouse events, preventing double-advances and preserving the expected tap behavior across focus and sort modes
- ensure deletions advance to the next item in focus mode and introduce pointer-aware favorite toggling with cooldown resets for reliable single-tap updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7e5727080832da7ededb032963711