### PR TITLE
Add Codex merge request catalog app

### DIFF
--- a/codexrecall.html
+++ b/codexrecall.html
@@ -1,0 +1,1011 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Codex Recall</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f7f7fb;
+      --bg-dark: #1a1d24;
+      --panel: #ffffff;
+      --panel-dark: #232734;
+      --border: #d7d7e5;
+      --border-dark: #34384a;
+      --accent: #4361ee;
+      --accent-dark: #7aa2ff;
+      --danger: #d64550;
+      --text: #1f2430;
+      --text-muted: #596174;
+      --text-invert: #f9fbff;
+      font-family: "Inter", "Segoe UI", Helvetica, Arial, sans-serif;
+      line-height: 1.5;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      min-height: 100vh;
+      background: linear-gradient(180deg, rgba(67,97,238,0.08), transparent 320px) var(--bg);
+      color: var(--text);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background: linear-gradient(180deg, rgba(122,162,255,0.16), transparent 320px) var(--bg-dark);
+        color: var(--text-invert);
+      }
+    }
+
+    header {
+      padding: 24px clamp(20px, 4vw, 48px) 12px;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      align-items: center;
+      gap: 16px;
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: clamp(1.4rem, 4vw, 2.1rem);
+      letter-spacing: -0.03em;
+    }
+
+    header p {
+      margin: 0;
+      max-width: 520px;
+      color: var(--text-muted);
+      font-size: 0.95rem;
+    }
+
+    .container {
+      display: grid;
+      grid-template-columns: minmax(260px, 320px) 1fr;
+      gap: 20px;
+      padding: 0 clamp(20px, 4vw, 48px) 32px;
+    }
+
+    @media (max-width: 960px) {
+      .container {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 20px;
+      box-shadow: 0 12px 32px rgba(20, 30, 60, 0.06);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .panel {
+        background: var(--panel-dark);
+        border-color: var(--border-dark);
+        box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+      }
+    }
+
+    .panel h2 {
+      margin: 0 0 12px;
+      font-size: 1.1rem;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      margin-bottom: 14px;
+    }
+
+    label {
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+    }
+
+    input[type="text"],
+    input[type="search"],
+    textarea,
+    select {
+      background: rgba(255, 255, 255, 0.9);
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      padding: 10px 12px;
+      font-size: 0.95rem;
+      font-family: inherit;
+      color: inherit;
+      transition: border 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      input[type="text"],
+      input[type="search"],
+      textarea,
+      select {
+        background: rgba(35, 39, 52, 0.95);
+        border-color: var(--border-dark);
+      }
+    }
+
+    input[type="text"]:focus,
+    input[type="search"]:focus,
+    textarea:focus,
+    select:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(67, 97, 238, 0.22);
+    }
+
+    button {
+      background: var(--accent);
+      border: none;
+      border-radius: 999px;
+      padding: 10px 18px;
+      font-size: 0.95rem;
+      color: white;
+      cursor: pointer;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
+      font-weight: 600;
+    }
+
+    button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 22px rgba(67, 97, 238, 0.25);
+    }
+
+    button:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      transform: none;
+      box-shadow: none;
+    }
+
+    .button-secondary {
+      background: rgba(95, 107, 130, 0.16);
+      color: inherit;
+      border: 1px solid transparent;
+    }
+
+    .button-danger {
+      background: var(--danger);
+    }
+
+    .token-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: center;
+      margin-bottom: 18px;
+    }
+
+    .token-row span {
+      font-size: 0.9rem;
+      color: var(--text-muted);
+    }
+
+    .status-bar {
+      padding: 10px 16px;
+      border-radius: 12px;
+      border: 1px solid rgba(67, 97, 238, 0.25);
+      background: rgba(67, 97, 238, 0.08);
+      margin-bottom: 18px;
+      font-size: 0.9rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .status-bar {
+        background: rgba(122, 162, 255, 0.14);
+        border-color: rgba(122, 162, 255, 0.25);
+      }
+    }
+
+    .results-toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 16px;
+    }
+
+    .results-toolbar .filters {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: center;
+    }
+
+    .request-list {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .request-card {
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 16px;
+      background: rgba(255, 255, 255, 0.92);
+      display: grid;
+      gap: 12px;
+    }
+
+    .request-header {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      justify-content: space-between;
+      align-items: baseline;
+    }
+
+    .request-header h3 {
+      margin: 0;
+      font-size: 1.05rem;
+    }
+
+    .request-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      font-size: 0.85rem;
+      color: var(--text-muted);
+    }
+
+    .request-body {
+      white-space: pre-wrap;
+      background: rgba(67, 97, 238, 0.06);
+      border-radius: 10px;
+      padding: 12px;
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+      font-size: 0.85rem;
+      overflow-x: auto;
+    }
+
+    .file-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .file-chip {
+      background: rgba(95, 107, 130, 0.16);
+      border-radius: 999px;
+      padding: 6px 12px;
+      font-size: 0.8rem;
+    }
+
+    .notes-area textarea {
+      min-height: 80px;
+      resize: vertical;
+    }
+
+    .tag-editor {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .tag-editor input {
+      flex: 1;
+      min-width: 160px;
+    }
+
+    .tag-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      background: rgba(67, 97, 238, 0.12);
+      color: inherit;
+      padding: 4px 10px;
+      border-radius: 999px;
+      font-size: 0.75rem;
+    }
+
+    .tag-pill button {
+      background: transparent;
+      border: none;
+      color: inherit;
+      padding: 0;
+      font-size: 1rem;
+      cursor: pointer;
+    }
+
+    .status-toggle {
+      display: inline-flex;
+      gap: 6px;
+      align-items: center;
+    }
+
+    .status-toggle button {
+      padding: 6px 14px;
+      font-size: 0.8rem;
+    }
+
+    .request-card[data-status="exclude"] {
+      border-color: rgba(214, 69, 80, 0.5);
+      background: rgba(214, 69, 80, 0.08);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      input[type="text"], input[type="search"], textarea, select, .request-card {
+        background: rgba(35, 39, 52, 0.85);
+      }
+
+      .file-chip {
+        background: rgba(122, 162, 255, 0.16);
+      }
+    }
+
+    dialog {
+      border: none;
+      border-radius: 16px;
+      padding: 0;
+      width: min(420px, 92vw);
+    }
+
+    dialog::backdrop {
+      background: rgba(15, 18, 28, 0.55);
+    }
+
+    .modal-shell {
+      padding: 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+      background: var(--panel);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .modal-shell {
+        background: var(--panel-dark);
+      }
+    }
+
+    .modal-shell h2 {
+      margin: 0;
+      font-size: 1.2rem;
+    }
+
+    .modal-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 10px;
+    }
+
+    .empty-state {
+      padding: 40px;
+      border: 2px dashed rgba(95, 107, 130, 0.25);
+      border-radius: 16px;
+      text-align: center;
+      color: var(--text-muted);
+    }
+
+    .loader {
+      display: inline-block;
+      width: 18px;
+      height: 18px;
+      border: 3px solid rgba(255, 255, 255, 0.6);
+      border-top-color: rgba(255, 255, 255, 1);
+      border-radius: 50%;
+      animation: spin 0.75s linear infinite;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div>
+      <h1>Codex Recall</h1>
+      <p>Inventory merged Codex requests for any repository, inspect their prompts, map the files they touched, and curate a living checklist you can annotate or export.</p>
+    </div>
+    <div class="token-row">
+      <span id="tokenStatus">Token: not set</span>
+      <button id="setTokenBtn" class="button-secondary">Set token</button>
+      <button id="forgetTokenBtn" class="button-secondary">Forget token</button>
+    </div>
+  </header>
+
+  <div class="container">
+    <section class="panel" id="controlPanel">
+      <h2>Repository</h2>
+      <div class="field">
+        <label for="ownerInput">Owner</label>
+        <input id="ownerInput" type="text" placeholder="e.g. openai" />
+      </div>
+      <div class="field">
+        <label for="repoInput">Repository</label>
+        <input id="repoInput" type="text" placeholder="e.g. codex-recall" />
+      </div>
+      <div class="field">
+        <label for="branchFilterInput">Head branch filter (regex)</label>
+        <input id="branchFilterInput" type="text" placeholder="Default: codex/" />
+      </div>
+      <div class="field">
+        <label for="maxPrsInput">Maximum PRs to fetch</label>
+        <input id="maxPrsInput" type="text" value="100" />
+      </div>
+      <div class="field">
+        <label for="sinceInput">Only merged after (ISO date, optional)</label>
+        <input id="sinceInput" type="text" placeholder="2024-01-01" />
+      </div>
+      <button id="loadBtn">Load merged requests</button>
+      <div class="status-bar" id="statusBar" hidden></div>
+      <div class="field">
+        <label for="searchInput">Filter checklist</label>
+        <input id="searchInput" type="search" placeholder="Search title, prompt, files" />
+      </div>
+      <div class="field">
+        <label for="statusFilter">Status</label>
+        <select id="statusFilter">
+          <option value="all">All</option>
+          <option value="include">Included</option>
+          <option value="exclude">Excluded</option>
+        </select>
+      </div>
+      <button id="exportBtn" class="button-secondary">Export checklist JSON</button>
+      <button id="clearChecklistBtn" class="button-secondary">Clear local checklist copy</button>
+    </section>
+
+    <section class="panel" id="resultsPanel">
+      <div class="results-toolbar">
+        <div class="filters">
+          <strong id="resultsCount">0 requests</strong>
+          <span id="lastFetched"></span>
+        </div>
+        <div>
+          <button id="refreshBtn" class="button-secondary">Refresh</button>
+        </div>
+      </div>
+      <div id="results" class="request-list"></div>
+      <div id="emptyState" class="empty-state">
+        <p>Load a repository to see Codex merge requests. They will appear here with prompt text, affected files, and annotation controls.</p>
+      </div>
+    </section>
+  </div>
+
+  <dialog id="tokenDialog">
+    <form method="dialog" class="modal-shell">
+      <h2>Personal Access Token</h2>
+      <p>Paste a GitHub token with <strong>repo</strong> scope. It stays in your browser’s localStorage and is only used for direct GitHub API calls from this page.</p>
+      <div class="field">
+        <label for="tokenInput">Token</label>
+        <input id="tokenInput" type="text" autocomplete="off" required />
+      </div>
+      <div class="modal-actions">
+        <button value="cancel" type="button" class="button-secondary">Cancel</button>
+        <button value="confirm" type="submit">Save token</button>
+      </div>
+    </form>
+  </dialog>
+
+  <script>
+    const TOKEN_KEY = 'codexrecall.pat';
+    const SETTINGS_KEY = 'codexrecall.settings';
+
+    const ownerInput = document.getElementById('ownerInput');
+    const repoInput = document.getElementById('repoInput');
+    const branchFilterInput = document.getElementById('branchFilterInput');
+    const sinceInput = document.getElementById('sinceInput');
+    const maxPrsInput = document.getElementById('maxPrsInput');
+    const loadBtn = document.getElementById('loadBtn');
+    const refreshBtn = document.getElementById('refreshBtn');
+    const exportBtn = document.getElementById('exportBtn');
+    const clearChecklistBtn = document.getElementById('clearChecklistBtn');
+    const statusBar = document.getElementById('statusBar');
+    const resultsEl = document.getElementById('results');
+    const emptyStateEl = document.getElementById('emptyState');
+    const resultsCountEl = document.getElementById('resultsCount');
+    const lastFetchedEl = document.getElementById('lastFetched');
+    const searchInput = document.getElementById('searchInput');
+    const statusFilter = document.getElementById('statusFilter');
+    const tokenStatus = document.getElementById('tokenStatus');
+    const setTokenBtn = document.getElementById('setTokenBtn');
+    const forgetTokenBtn = document.getElementById('forgetTokenBtn');
+    const tokenDialog = document.getElementById('tokenDialog');
+    const tokenInput = document.getElementById('tokenInput');
+
+    const state = {
+      entries: [],
+      filteredEntries: [],
+      owner: '',
+      repo: '',
+      isLoading: false,
+      token: null
+    };
+
+    function loadSettings() {
+      const storedSettings = localStorage.getItem(SETTINGS_KEY);
+      if (storedSettings) {
+        try {
+          const parsed = JSON.parse(storedSettings);
+          ownerInput.value = parsed.owner || '';
+          repoInput.value = parsed.repo || '';
+          branchFilterInput.value = parsed.branchFilter || '';
+          sinceInput.value = parsed.since || '';
+          maxPrsInput.value = parsed.maxPrs || '100';
+        } catch (err) {
+          console.warn('Failed to parse settings', err);
+        }
+      }
+      const storedToken = localStorage.getItem(TOKEN_KEY);
+      if (storedToken) {
+        state.token = storedToken;
+      }
+      updateTokenStatus();
+    }
+
+    function persistSettings() {
+      const payload = {
+        owner: ownerInput.value.trim(),
+        repo: repoInput.value.trim(),
+        branchFilter: branchFilterInput.value.trim(),
+        since: sinceInput.value.trim(),
+        maxPrs: maxPrsInput.value.trim()
+      };
+      localStorage.setItem(SETTINGS_KEY, JSON.stringify(payload));
+    }
+
+    function updateTokenStatus() {
+      if (state.token) {
+        tokenStatus.textContent = 'Token: saved locally';
+        forgetTokenBtn.disabled = false;
+      } else {
+        tokenStatus.textContent = 'Token: not set';
+        forgetTokenBtn.disabled = true;
+      }
+    }
+
+    setTokenBtn.addEventListener('click', () => {
+      tokenInput.value = '';
+      tokenDialog.showModal();
+      setTimeout(() => tokenInput.focus(), 10);
+    });
+
+    tokenDialog.addEventListener('close', () => {
+      if (tokenDialog.returnValue === 'confirm' && tokenInput.value.trim()) {
+        const token = tokenInput.value.trim();
+        localStorage.setItem(TOKEN_KEY, token);
+        state.token = token;
+        updateTokenStatus();
+      }
+    });
+
+    forgetTokenBtn.addEventListener('click', () => {
+      if (!state.token) return;
+      if (confirm('Remove the stored token?')) {
+        localStorage.removeItem(TOKEN_KEY);
+        state.token = null;
+        updateTokenStatus();
+      }
+    });
+
+    loadBtn.addEventListener('click', () => {
+      persistSettings();
+      loadRequests();
+    });
+
+    refreshBtn.addEventListener('click', () => {
+      loadRequests({force: true});
+    });
+
+    searchInput.addEventListener('input', () => {
+      applyFilters();
+      render();
+    });
+
+    statusFilter.addEventListener('change', () => {
+      applyFilters();
+      render();
+    });
+
+    exportBtn.addEventListener('click', () => {
+      if (!state.entries.length) {
+        alert('No checklist entries to export yet.');
+        return;
+      }
+      const payload = {
+        owner: state.owner,
+        repo: state.repo,
+        exportedAt: new Date().toISOString(),
+        entries: state.entries
+      };
+      const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `codexrecall-${state.owner}-${state.repo}.json`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    });
+
+    clearChecklistBtn.addEventListener('click', () => {
+      if (!state.owner || !state.repo) {
+        alert('Load a repository first.');
+        return;
+      }
+      if (confirm('Clear the locally cached checklist for this repository?')) {
+        localStorage.removeItem(checklistKey());
+        state.entries = [];
+        applyFilters();
+        render();
+      }
+    });
+
+    function checklistKey() {
+      return `codexrecall.checklist.${state.owner}.${state.repo}`;
+    }
+
+    function setStatus(message, { tone = 'info', spinner = false } = {}) {
+      if (!message) {
+        statusBar.hidden = true;
+        statusBar.textContent = '';
+        return;
+      }
+      statusBar.hidden = false;
+      statusBar.textContent = message;
+      statusBar.dataset.tone = tone;
+      if (spinner) {
+        statusBar.innerHTML = `<span class="loader"></span> <span>${message}</span>`;
+      }
+    }
+
+    function setButtonsDisabled(disabled) {
+      loadBtn.disabled = disabled;
+      refreshBtn.disabled = disabled;
+    }
+
+    async function loadRequests({ force = false } = {}) {
+      if (!state.token) {
+        alert('Save a GitHub token first.');
+        return;
+      }
+      const owner = ownerInput.value.trim();
+      const repo = repoInput.value.trim();
+      if (!owner || !repo) {
+        alert('Enter both owner and repository.');
+        return;
+      }
+      state.owner = owner;
+      state.repo = repo;
+      const cachedChecklist = !force ? loadCachedChecklist() : null;
+      if (cachedChecklist && cachedChecklist.entries) {
+        state.entries = cachedChecklist.entries;
+        applyFilters();
+        render();
+      }
+      try {
+        state.isLoading = true;
+        setButtonsDisabled(true);
+        setStatus('Fetching merged pull requests…', { spinner: true });
+        const filterText = branchFilterInput.value.trim();
+        let branchRegex;
+        if (filterText) {
+          try {
+            branchRegex = new RegExp(filterText, 'i');
+          } catch (err) {
+            throw new Error(`Invalid branch regex: ${err.message}`);
+          }
+        } else {
+          branchRegex = /codex\//i;
+        }
+        const maxPrs = parseInt(maxPrsInput.value.trim(), 10) || 100;
+        const since = sinceInput.value.trim();
+        const mergedAfter = since ? Date.parse(since) : null;
+        const prs = await fetchMergedPullRequests({ owner, repo, maxPrs });
+        const filteredPrs = prs.filter(pr => branchRegex.test(pr.headRefName));
+        const finalPrs = mergedAfter ? filteredPrs.filter(pr => Date.parse(pr.mergedAt) >= mergedAfter) : filteredPrs;
+        setStatus(`Found ${finalPrs.length} merged PRs. Fetching file changes…`, { spinner: true });
+        const entries = await enrichPullRequests(finalPrs, { owner, repo });
+        mergeWithCached(entries);
+        state.isLoading = false;
+        setStatus(`Loaded ${entries.length} request${entries.length === 1 ? '' : 's'}.`);
+        lastFetchedEl.textContent = `Last fetched ${new Date().toLocaleString()}`;
+        saveChecklist();
+        applyFilters();
+        render();
+      } catch (error) {
+        console.error(error);
+        state.isLoading = false;
+        setStatus(`Error: ${error.message}`, { tone: 'error' });
+      } finally {
+        setButtonsDisabled(false);
+      }
+    }
+
+    function loadCachedChecklist() {
+      try {
+        const raw = localStorage.getItem(checklistKey());
+        if (!raw) return null;
+        return JSON.parse(raw);
+      } catch (err) {
+        console.warn('Failed to parse cached checklist', err);
+        return null;
+      }
+    }
+
+    function saveChecklist() {
+      const payload = {
+        savedAt: new Date().toISOString(),
+        entries: state.entries
+      };
+      localStorage.setItem(checklistKey(), JSON.stringify(payload));
+    }
+
+    function mergeWithCached(newEntries) {
+      const cache = loadCachedChecklist();
+      if (!cache || !cache.entries) {
+        state.entries = newEntries;
+        return;
+      }
+      const map = new Map(cache.entries.map(entry => [entry.id, entry]));
+      const merged = newEntries.map(entry => {
+        const cached = map.get(entry.id);
+        if (!cached) return entry;
+        return {
+          ...entry,
+          status: cached.status || 'include',
+          notes: cached.notes || '',
+          tags: cached.tags || []
+        };
+      });
+      state.entries = merged;
+    }
+
+    async function fetchMergedPullRequests({ owner, repo, maxPrs }) {
+      const perPage = 50;
+      const collected = [];
+      let cursor = null;
+      while (collected.length < maxPrs) {
+        const remaining = maxPrs - collected.length;
+        const batchSize = Math.min(perPage, remaining);
+        const result = await githubGraphQL({
+          query: `query($owner:String!, $repo:String!, $cursor:String, $pageSize:Int!){
+            repository(owner:$owner, name:$repo){
+              pullRequests(first:$pageSize, after:$cursor, states:MERGED, orderBy:{field:UPDATED_AT, direction:DESC}){
+                pageInfo{ hasNextPage endCursor }
+                nodes{
+                  number
+                  title
+                  mergedAt
+                  createdAt
+                  headRefName
+                  url
+                  author{ login }
+                  body
+                }
+              }
+            }
+          }`,
+          variables: { owner, repo, cursor, pageSize: batchSize }
+        });
+        const nodes = result?.repository?.pullRequests?.nodes || [];
+        collected.push(...nodes);
+        const pageInfo = result?.repository?.pullRequests?.pageInfo;
+        if (!pageInfo?.hasNextPage) break;
+        cursor = pageInfo.endCursor;
+      }
+      return collected;
+    }
+
+    async function enrichPullRequests(prs, { owner, repo }) {
+      const entries = [];
+      for (const pr of prs) {
+        const files = await fetchPullRequestFiles(owner, repo, pr.number);
+        entries.push({
+          id: `pr-${pr.number}`,
+          type: 'PR',
+          number: pr.number,
+          title: pr.title,
+          mergedAt: pr.mergedAt,
+          createdAt: pr.createdAt,
+          headRefName: pr.headRefName,
+          url: pr.url,
+          author: pr.author?.login || 'unknown',
+          prompt: pr.body || '',
+          files: files.map(file => ({
+            filename: file.filename,
+            status: file.status,
+            additions: file.additions,
+            deletions: file.deletions,
+            changes: file.changes,
+            blobUrl: file.blob_url,
+            rawUrl: file.raw_url
+          })),
+          status: 'include',
+          notes: '',
+          tags: []
+        });
+      }
+      return entries;
+    }
+
+    async function fetchPullRequestFiles(owner, repo, number) {
+      const results = [];
+      let page = 1;
+      while (true) {
+        const response = await githubRest(`/repos/${owner}/${repo}/pulls/${number}/files?per_page=100&page=${page}`);
+        if (!Array.isArray(response) || !response.length) break;
+        results.push(...response);
+        if (response.length < 100) break;
+        page += 1;
+      }
+      return results;
+    }
+
+    async function githubGraphQL({ query, variables }) {
+      const res = await fetch('https://api.github.com/graphql', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${state.token}`
+        },
+        body: JSON.stringify({ query, variables })
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`GraphQL error ${res.status}: ${text}`);
+      }
+      const json = await res.json();
+      if (json.errors) {
+        throw new Error(json.errors.map(e => e.message).join('\n'));
+      }
+      return json.data;
+    }
+
+    async function githubRest(path) {
+      const res = await fetch(`https://api.github.com${path}`, {
+        headers: {
+          'Authorization': `Bearer ${state.token}`,
+          'Accept': 'application/vnd.github+json'
+        }
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`GitHub API error ${res.status}: ${text}`);
+      }
+      return res.json();
+    }
+
+    function applyFilters() {
+      const query = searchInput.value.trim().toLowerCase();
+      const statusValue = statusFilter.value;
+      const filtered = state.entries.filter(entry => {
+        if (statusValue !== 'all' && entry.status !== statusValue) return false;
+        if (!query) return true;
+        const haystack = [
+          entry.title,
+          entry.prompt,
+          entry.headRefName,
+          entry.files.map(f => f.filename).join(' '),
+          entry.tags?.join(' ')
+        ].join(' ').toLowerCase();
+        return haystack.includes(query);
+      });
+      state.filteredEntries = filtered;
+    }
+
+    function render() {
+      resultsEl.innerHTML = '';
+      if (!state.filteredEntries.length) {
+        resultsCountEl.textContent = '0 requests';
+        emptyStateEl.style.display = 'block';
+        return;
+      }
+      emptyStateEl.style.display = 'none';
+      resultsCountEl.textContent = `${state.filteredEntries.length} request${state.filteredEntries.length === 1 ? '' : 's'}`;
+      for (const entry of state.filteredEntries) {
+        const card = document.createElement('article');
+        card.className = 'request-card';
+        card.dataset.status = entry.status;
+        card.innerHTML = `
+          <div class="request-header">
+            <h3>#${entry.number} · ${escapeHtml(entry.title)}</h3>
+            <div class="request-meta">
+              <span>${new Date(entry.mergedAt).toLocaleString()}</span>
+              <span>${escapeHtml(entry.headRefName)}</span>
+              <a href="${entry.url}" target="_blank" rel="noopener">View PR ↗</a>
+            </div>
+          </div>
+          <div class="request-body">${escapeHtml(entry.prompt || '(no prompt provided)')}</div>
+          <div class="file-list">${entry.files.map(file => `<span class="file-chip" title="Δ ${file.changes} (${file.status})">${escapeHtml(file.filename)}</span>`).join('')}</div>
+          <div class="status-toggle">
+            <span>Status:</span>
+            <button data-action="set-status" data-value="include" ${entry.status === 'include' ? 'disabled' : ''}>Include</button>
+            <button data-action="set-status" data-value="exclude" class="button-secondary" ${entry.status === 'exclude' ? 'disabled' : ''}>Exclude</button>
+          </div>
+          <div class="tag-editor">
+            <div class="existing-tags">${renderTags(entry)}</div>
+            <input type="text" placeholder="Add tag and press Enter" data-action="add-tag" />
+          </div>
+          <div class="notes-area">
+            <label>Notes</label>
+            <textarea data-action="update-notes" placeholder="Add checklist notes…">${escapeHtml(entry.notes || '')}</textarea>
+          </div>
+        `;
+        card.querySelectorAll('button[data-action="set-status"]').forEach(btn => {
+          btn.addEventListener('click', () => {
+            const value = btn.dataset.value;
+            updateEntry(entry.id, { status: value });
+            applyFilters();
+            render();
+          });
+        });
+        const tagInput = card.querySelector('input[data-action="add-tag"]');
+        tagInput.addEventListener('keydown', event => {
+          if (event.key === 'Enter' && tagInput.value.trim()) {
+            event.preventDefault();
+            const tag = tagInput.value.trim();
+            addTag(entry.id, tag);
+            tagInput.value = '';
+            applyFilters();
+            render();
+          }
+        });
+        card.querySelectorAll('.tag-pill button').forEach(btn => {
+          btn.addEventListener('click', () => {
+            const tag = btn.dataset.tag;
+            removeTag(entry.id, tag);
+            applyFilters();
+            render();
+          });
+        });
+        const notesArea = card.querySelector('textarea[data-action="update-notes"]');
+        notesArea.addEventListener('change', () => {
+          updateEntry(entry.id, { notes: notesArea.value });
+        });
+        resultsEl.appendChild(card);
+      }
+    }
+
+    function renderTags(entry) {
+      if (!entry.tags || !entry.tags.length) return '<span class="tag-pill" style="opacity:0.6;">No tags</span>';
+      return entry.tags.map(tag => `<span class="tag-pill">${escapeHtml(tag)} <button data-tag="${escapeHtml(tag)}" title="Remove">×</button></span>`).join('');
+    }
+
+    function updateEntry(id, patch) {
+      const index = state.entries.findIndex(entry => entry.id === id);
+      if (index === -1) return;
+      state.entries[index] = { ...state.entries[index], ...patch };
+      saveChecklist();
+    }
+
+    function addTag(id, tag) {
+      const entry = state.entries.find(e => e.id === id);
+      if (!entry) return;
+      entry.tags = Array.from(new Set([...(entry.tags || []), tag]));
+      saveChecklist();
+    }
+
+    function removeTag(id, tag) {
+      const entry = state.entries.find(e => e.id === id);
+      if (!entry) return;
+      entry.tags = (entry.tags || []).filter(t => t !== tag);
+      saveChecklist();
+    }
+
+    function escapeHtml(str) {
+      return (str || '').replace(/[&<>"']/g, ch => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+      }[ch]));
+    }
+
+    loadSettings();
+    applyFilters();
+    render();
+  </script>
+</body>
+</html>

--- a/standalone-app.html
+++ b/standalone-app.html
@@ -1,0 +1,626 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GitHub Standalone Editor</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #0f172a;
+      --surface: rgba(15, 23, 42, 0.88);
+      --text: #e2e8f0;
+      --accent: #38bdf8;
+      --danger: #f87171;
+      --success: #34d399;
+      --border: rgba(148, 163, 184, 0.4);
+      --radius: 16px;
+      --gap: 12px;
+      --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: radial-gradient(circle at top, #1e293b, #020617);
+      min-height: 100vh;
+      color: var(--text);
+      display: flex;
+      justify-content: center;
+      padding: 32px 16px 64px;
+    }
+
+    main {
+      width: min(1100px, 100%);
+      display: grid;
+      gap: var(--gap);
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+
+    section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 20px;
+      backdrop-filter: blur(12px);
+      box-shadow: 0 20px 45px rgba(2, 6, 23, 0.45);
+    }
+
+    h1 {
+      grid-column: 1 / -1;
+      font-size: clamp(1.8rem, 3vw, 2.4rem);
+      margin: 0;
+      text-align: center;
+      letter-spacing: 0.01em;
+      font-weight: 600;
+    }
+
+    p.lead {
+      grid-column: 1 / -1;
+      margin: 0;
+      text-align: center;
+      opacity: 0.75;
+      font-size: 0.95rem;
+    }
+
+    label {
+      display: block;
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      opacity: 0.8;
+      margin-bottom: 6px;
+    }
+
+    input, select, textarea {
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: rgba(15, 23, 42, 0.7);
+      color: inherit;
+      padding: 12px 14px;
+      font-size: 0.95rem;
+      font-family: inherit;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    input:focus, select:focus, textarea:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+    }
+
+    textarea {
+      min-height: 420px;
+      resize: vertical;
+      font-family: var(--mono);
+      line-height: 1.45;
+      letter-spacing: 0.01em;
+      background: rgba(15, 23, 42, 0.9);
+    }
+
+    .row {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: var(--gap);
+    }
+
+    button {
+      border: none;
+      border-radius: 12px;
+      padding: 12px 16px;
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.15s ease, box-shadow 0.2s ease;
+      background: rgba(56, 189, 248, 0.12);
+      color: var(--accent);
+    }
+
+    button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 30px rgba(56, 189, 248, 0.28);
+    }
+
+    button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      box-shadow: none;
+      transform: none;
+    }
+
+    button.primary {
+      background: linear-gradient(135deg, #38bdf8, #0ea5e9);
+      color: #0f172a;
+    }
+
+    button.danger {
+      background: rgba(248, 113, 113, 0.16);
+      color: var(--danger);
+    }
+
+    button.secondary {
+      background: rgba(148, 163, 184, 0.12);
+      color: #cbd5f5;
+    }
+
+    ul.file-list {
+      list-style: none;
+      padding: 0;
+      margin: 16px 0 0;
+      max-height: 360px;
+      overflow-y: auto;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: rgba(15, 23, 42, 0.6);
+    }
+
+    ul.file-list li {
+      padding: 10px 14px;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 8px;
+      font-family: var(--mono);
+      font-size: 0.85rem;
+      cursor: pointer;
+    }
+
+    ul.file-list li:last-child {
+      border-bottom: none;
+    }
+
+    ul.file-list li.active {
+      background: rgba(56, 189, 248, 0.16);
+      color: var(--accent);
+    }
+
+    ul.file-list li:hover {
+      background: rgba(56, 189, 248, 0.1);
+    }
+
+    .status-bar {
+      margin-top: 18px;
+      font-size: 0.9rem;
+      padding: 10px 12px;
+      border-radius: 10px;
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      background: rgba(15, 23, 42, 0.65);
+      min-height: 42px;
+    }
+
+    .status-bar.success { border-color: rgba(52, 211, 153, 0.35); color: var(--success); }
+    .status-bar.error { border-color: rgba(248, 113, 113, 0.35); color: var(--danger); }
+
+    .toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 16px;
+      justify-content: flex-end;
+    }
+
+    .tag-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: rgba(56, 189, 248, 0.15);
+      color: var(--accent);
+      font-size: 0.75rem;
+      letter-spacing: 0.03em;
+      margin-right: 6px;
+    }
+
+    dialog {
+      border: none;
+      border-radius: 20px;
+      padding: 24px;
+      max-width: 360px;
+      width: calc(100% - 40px);
+      background: rgba(15, 23, 42, 0.95);
+      color: var(--text);
+      box-shadow: 0 24px 60px rgba(2, 6, 23, 0.6);
+    }
+
+    dialog::backdrop {
+      background: rgba(2, 6, 23, 0.75);
+      backdrop-filter: blur(6px);
+    }
+
+    .pat-actions {
+      display: flex;
+      gap: 12px;
+      margin-top: 18px;
+      justify-content: flex-end;
+    }
+
+    @media (max-width: 720px) {
+      body { padding: 24px 12px 48px; }
+      textarea { min-height: 320px; }
+      main { grid-template-columns: 1fr; }
+      section { padding: 16px; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Standalone GitHub Editor</h1>
+    <p class="lead">Works from any static host. Provide a Personal Access Token once, then browse, edit, and commit files directly from your browser.</p>
+
+    <section aria-labelledby="connection-heading">
+      <h2 id="connection-heading" style="margin-top:0;font-size:1.1rem;">Repository Connection</h2>
+      <div class="row">
+        <div>
+          <label for="ownerInput">Owner</label>
+          <input id="ownerInput" autocomplete="off" placeholder="github-user" spellcheck="false">
+        </div>
+        <div>
+          <label for="repoInput">Repository</label>
+          <input id="repoInput" autocomplete="off" placeholder="repo-name" spellcheck="false">
+        </div>
+      </div>
+      <div class="row" style="margin-top: var(--gap);">
+        <div>
+          <label for="branchInput">Branch</label>
+          <input id="branchInput" autocomplete="off" placeholder="main">
+        </div>
+        <div>
+          <label for="pathFilterInput">Path Filter (optional)</label>
+          <input id="pathFilterInput" autocomplete="off" placeholder="e.g. src/">
+        </div>
+      </div>
+      <div class="toolbar">
+        <button id="loadBtn" class="primary" type="button">Load Repository</button>
+        <button id="changePatBtn" type="button">Update Token</button>
+        <button id="signOutBtn" class="danger" type="button">Forget Token</button>
+      </div>
+      <div class="status-bar" id="connectionStatus" role="status" aria-live="polite"></div>
+      <ul class="file-list" id="fileList" aria-label="Repository files"></ul>
+    </section>
+
+    <section aria-labelledby="editor-heading">
+      <h2 id="editor-heading" style="margin-top:0;font-size:1.1rem;">Editor</h2>
+      <div>
+        <label for="filePathDisplay">Selected File</label>
+        <input id="filePathDisplay" readonly>
+      </div>
+      <div style="margin-top: var(--gap);">
+        <label for="editorArea">File Contents</label>
+        <textarea id="editorArea" placeholder="Select a file to load its contents" spellcheck="false"></textarea>
+      </div>
+      <div class="row" style="margin-top: var(--gap);">
+        <div>
+          <label for="commitMessageInput">Commit Message</label>
+          <input id="commitMessageInput" placeholder="Describe your change">
+        </div>
+        <div>
+          <label for="commitBranchInput">Commit Branch</label>
+          <input id="commitBranchInput" placeholder="same as base by default">
+        </div>
+      </div>
+      <div class="toolbar">
+        <button id="refreshFileBtn" type="button">Reload File</button>
+        <button id="saveBtn" class="primary" type="button">Commit Changes</button>
+      </div>
+      <div class="status-bar" id="editorStatus" role="status" aria-live="polite"></div>
+    </section>
+  </main>
+
+  <dialog id="tokenDialog">
+    <form method="dialog">
+      <h3 style="margin:0 0 12px;font-size:1.15rem;">GitHub Personal Access Token</h3>
+      <p style="margin:0 0 16px;font-size:0.9rem;opacity:0.75;">Generate a fine-grained token with <strong>repo</strong> scope. The token is stored in <code>localStorage</code> on this device only.</p>
+      <label for="tokenInput">Token</label>
+      <input id="tokenInput" type="password" autocomplete="off" spellcheck="false" placeholder="ghp_...">
+      <div class="pat-actions">
+        <button value="cancel" type="submit" class="secondary">Cancel</button>
+        <button id="storePatBtn" value="confirm" type="submit" class="primary">Save Token</button>
+      </div>
+    </form>
+  </dialog>
+
+  <template id="fileListItemTemplate">
+    <li>
+      <span class="file-name"></span>
+      <span class="tag-pill file-size"></span>
+    </li>
+  </template>
+
+  <script>
+    (() => {
+      const STORAGE_TOKEN_KEY = 'standalone_github_pat_v1';
+      const STORAGE_OWNER_KEY = 'standalone_github_owner';
+      const STORAGE_REPO_KEY = 'standalone_github_repo';
+      const STORAGE_BRANCH_KEY = 'standalone_github_branch';
+      const STORAGE_FILTER_KEY = 'standalone_github_filter';
+      const STORAGE_COMMIT_BRANCH_KEY = 'standalone_github_commit_branch';
+
+      const elements = {
+        ownerInput: document.getElementById('ownerInput'),
+        repoInput: document.getElementById('repoInput'),
+        branchInput: document.getElementById('branchInput'),
+        pathFilterInput: document.getElementById('pathFilterInput'),
+        commitBranchInput: document.getElementById('commitBranchInput'),
+        commitMessageInput: document.getElementById('commitMessageInput'),
+        fileList: document.getElementById('fileList'),
+        loadBtn: document.getElementById('loadBtn'),
+        refreshFileBtn: document.getElementById('refreshFileBtn'),
+        saveBtn: document.getElementById('saveBtn'),
+        changePatBtn: document.getElementById('changePatBtn'),
+        signOutBtn: document.getElementById('signOutBtn'),
+        editorArea: document.getElementById('editorArea'),
+        connectionStatus: document.getElementById('connectionStatus'),
+        editorStatus: document.getElementById('editorStatus'),
+        filePathDisplay: document.getElementById('filePathDisplay'),
+        tokenDialog: document.getElementById('tokenDialog'),
+        tokenInput: document.getElementById('tokenInput'),
+        storePatBtn: document.getElementById('storePatBtn'),
+        fileTemplate: document.getElementById('fileListItemTemplate'),
+      };
+
+      let token = localStorage.getItem(STORAGE_TOKEN_KEY) || '';
+      let currentSha = null;
+      let currentPath = '';
+      let treeCache = [];
+
+      // Restore prior session state
+      elements.ownerInput.value = localStorage.getItem(STORAGE_OWNER_KEY) || '';
+      elements.repoInput.value = localStorage.getItem(STORAGE_REPO_KEY) || '';
+      const branch = localStorage.getItem(STORAGE_BRANCH_KEY) || 'main';
+      elements.branchInput.value = branch;
+      const commitBranch = localStorage.getItem(STORAGE_COMMIT_BRANCH_KEY) || '';
+      elements.commitBranchInput.value = commitBranch;
+      elements.pathFilterInput.value = localStorage.getItem(STORAGE_FILTER_KEY) || '';
+
+      function ensureToken(promptIfMissing = true) {
+        if (token) return true;
+        if (!promptIfMissing) return false;
+        showTokenDialog();
+        return false;
+      }
+
+      function showTokenDialog(initial = '') {
+        elements.tokenInput.value = initial || token || '';
+        if (typeof elements.tokenDialog.showModal === 'function') {
+          elements.tokenDialog.showModal();
+        } else {
+          alert('Your browser does not support the token dialog. Please use a modern browser.');
+        }
+      }
+
+      function updateStatus(target, message, cls) {
+        target.className = 'status-bar' + (cls ? ' ' + cls : '');
+        target.textContent = message;
+      }
+
+      async function githubRequest(path, options = {}) {
+        if (!ensureToken()) throw new Error('Token required');
+        const url = new URL(path, 'https://api.github.com');
+        const headers = {
+          'Accept': 'application/vnd.github.v3+json',
+          'Authorization': `token ${token}`,
+        };
+        if (options.headers) Object.assign(headers, options.headers);
+        const response = await fetch(url.toString(), { ...options, headers });
+        if (!response.ok) {
+          const detail = await response.text().catch(() => '');
+          throw new Error(`GitHub ${response.status}: ${detail || response.statusText}`);
+        }
+        if (response.status === 204) return null;
+        const text = await response.text();
+        return text ? JSON.parse(text) : null;
+      }
+
+      function decodeContent(base64) {
+        try {
+          return decodeURIComponent(escape(atob(base64)));
+        } catch (error) {
+          console.warn('Falling back to plain atob for content decode', error);
+          return atob(base64);
+        }
+      }
+
+      function encodeContent(text) {
+        const normalized = text.replace(/\r\n?/g, '\n');
+        return btoa(unescape(encodeURIComponent(normalized)));
+      }
+
+      async function loadRepository() {
+        if (!ensureToken()) return;
+        const owner = elements.ownerInput.value.trim();
+        const repo = elements.repoInput.value.trim();
+        const branchName = elements.branchInput.value.trim() || 'main';
+        if (!owner || !repo) {
+          updateStatus(elements.connectionStatus, 'Owner and repository are required.', 'error');
+          return;
+        }
+
+        updateStatus(elements.connectionStatus, 'Loading repository tree…', '');
+        elements.fileList.innerHTML = '';
+        treeCache = [];
+        try {
+          const ref = await githubRequest(`/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`);
+          const defaultBranch = ref.default_branch || branchName;
+          if (!elements.branchInput.value.trim()) {
+            elements.branchInput.value = defaultBranch;
+          }
+          const tree = await githubRequest(`/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/git/trees/${encodeURIComponent(branchName)}?recursive=1`);
+          if (!tree || !Array.isArray(tree.tree)) throw new Error('Unexpected tree response');
+          treeCache = tree.tree.filter(entry => entry.type === 'blob');
+          const filter = elements.pathFilterInput.value.trim();
+          renderFileList(filter);
+          persistConnectionState();
+          updateStatus(elements.connectionStatus, `Loaded ${treeCache.length} blobs from ${branchName}.`, 'success');
+        } catch (error) {
+          console.error(error);
+          updateStatus(elements.connectionStatus, error.message, 'error');
+        }
+      }
+
+      function renderFileList(filter = '') {
+        elements.fileList.innerHTML = '';
+        const matcher = filter ? new RegExp(filter.split('*').map(s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('.*'), 'i') : null;
+        const items = matcher ? treeCache.filter(item => matcher.test(item.path)) : treeCache;
+        const template = elements.fileTemplate.content.firstElementChild;
+        items.slice(0, 2000).forEach(item => {
+          const clone = template.cloneNode(true);
+          const nameSpan = clone.querySelector('.file-name');
+          const sizeSpan = clone.querySelector('.file-size');
+          nameSpan.textContent = item.path;
+          sizeSpan.textContent = item.size ? `${item.size.toLocaleString()} B` : 'blob';
+          clone.dataset.path = item.path;
+          clone.addEventListener('click', () => selectFile(item.path));
+          elements.fileList.appendChild(clone);
+        });
+      }
+
+      async function selectFile(path) {
+        if (!ensureToken()) return;
+        const owner = elements.ownerInput.value.trim();
+        const repo = elements.repoInput.value.trim();
+        const branchName = elements.branchInput.value.trim() || 'main';
+        if (!owner || !repo) {
+          updateStatus(elements.editorStatus, 'Owner and repository are required.', 'error');
+          return;
+        }
+        updateStatus(elements.editorStatus, `Loading ${path}…`, '');
+        elements.saveBtn.disabled = true;
+        try {
+          const data = await githubRequest(`/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${encodeURIComponent(path)}?ref=${encodeURIComponent(branchName)}`);
+          currentSha = data.sha;
+          currentPath = data.path;
+          const content = decodeContent(data.content);
+          elements.editorArea.value = content;
+          elements.filePathDisplay.value = currentPath;
+          elements.commitMessageInput.value = elements.commitMessageInput.value || `Update ${currentPath}`;
+          markActiveFile(path);
+          updateStatus(elements.editorStatus, `Loaded ${currentPath}`, 'success');
+          elements.saveBtn.disabled = false;
+        } catch (error) {
+          console.error(error);
+          updateStatus(elements.editorStatus, error.message, 'error');
+        }
+      }
+
+      function markActiveFile(path) {
+        for (const li of elements.fileList.children) {
+          li.classList.toggle('active', li.dataset.path === path);
+        }
+      }
+
+      async function refreshFile() {
+        if (!currentPath) {
+          updateStatus(elements.editorStatus, 'Select a file to refresh.', '');
+          return;
+        }
+        await selectFile(currentPath);
+      }
+
+      async function saveFile() {
+        if (!ensureToken()) return;
+        const owner = elements.ownerInput.value.trim();
+        const repo = elements.repoInput.value.trim();
+        const baseBranch = elements.branchInput.value.trim() || 'main';
+        const commitBranch = elements.commitBranchInput.value.trim() || baseBranch;
+        const message = elements.commitMessageInput.value.trim() || `Update ${currentPath}`;
+        if (!currentPath) {
+          updateStatus(elements.editorStatus, 'Select a file before committing.', 'error');
+          return;
+        }
+        const encoded = encodeContent(elements.editorArea.value);
+        updateStatus(elements.editorStatus, 'Saving changes…', '');
+        elements.saveBtn.disabled = true;
+        try {
+          const payload = {
+            message,
+            content: encoded,
+            branch: commitBranch,
+            sha: currentSha,
+          };
+          const res = await githubRequest(`/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${encodeURIComponent(currentPath)}`, {
+            method: 'PUT',
+            body: JSON.stringify(payload),
+          });
+          currentSha = res.content && res.content.sha ? res.content.sha : currentSha;
+          updateStatus(elements.editorStatus, `Committed to ${commitBranch} at ${res.commit && res.commit.sha ? res.commit.sha.slice(0, 7) : 'latest'}.`, 'success');
+          persistConnectionState();
+          elements.saveBtn.disabled = false;
+        } catch (error) {
+          console.error(error);
+          updateStatus(elements.editorStatus, error.message, 'error');
+          elements.saveBtn.disabled = false;
+        }
+      }
+
+      function persistConnectionState() {
+        localStorage.setItem(STORAGE_OWNER_KEY, elements.ownerInput.value.trim());
+        localStorage.setItem(STORAGE_REPO_KEY, elements.repoInput.value.trim());
+        localStorage.setItem(STORAGE_BRANCH_KEY, elements.branchInput.value.trim() || 'main');
+        localStorage.setItem(STORAGE_FILTER_KEY, elements.pathFilterInput.value.trim());
+        localStorage.setItem(STORAGE_COMMIT_BRANCH_KEY, elements.commitBranchInput.value.trim());
+      }
+
+      function clearSelection() {
+        currentPath = '';
+        currentSha = null;
+        elements.filePathDisplay.value = '';
+        elements.editorArea.value = '';
+        elements.commitMessageInput.value = '';
+        markActiveFile('');
+      }
+
+      function forgetToken() {
+        localStorage.removeItem(STORAGE_TOKEN_KEY);
+        token = '';
+        clearSelection();
+        updateStatus(elements.connectionStatus, 'Token removed. Provide a new token to continue.', '');
+        ensureToken();
+      }
+
+      elements.storePatBtn.addEventListener('click', (event) => {
+        event.preventDefault();
+        const value = elements.tokenInput.value.trim();
+        if (!value) {
+          updateStatus(elements.connectionStatus, 'Token cannot be empty.', 'error');
+          return;
+        }
+        localStorage.setItem(STORAGE_TOKEN_KEY, value);
+        token = value;
+        elements.tokenDialog.close('confirm');
+        updateStatus(elements.connectionStatus, 'Token stored locally.', 'success');
+      });
+
+      elements.tokenDialog.addEventListener('close', () => {
+        elements.tokenInput.value = '';
+        if (!token) {
+          updateStatus(elements.connectionStatus, 'Token required to access repository data.', 'error');
+        }
+      });
+
+      elements.loadBtn.addEventListener('click', loadRepository);
+      elements.refreshFileBtn.addEventListener('click', refreshFile);
+      elements.saveBtn.addEventListener('click', saveFile);
+      elements.changePatBtn.addEventListener('click', () => showTokenDialog());
+      elements.signOutBtn.addEventListener('click', () => {
+        if (confirm('Remove the stored Personal Access Token?')) forgetToken();
+      });
+      elements.pathFilterInput.addEventListener('input', (event) => {
+        renderFileList(event.target.value.trim());
+        localStorage.setItem(STORAGE_FILTER_KEY, event.target.value.trim());
+      });
+
+      ensureToken();
+      if (token && elements.ownerInput.value && elements.repoInput.value) {
+        loadRepository();
+      }
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `codexrecall.html`, a standalone Codex request inventory tool with inline styling and script
- integrate PAT storage, repository controls, and GitHub API fetching for merged PRs filtered by branch patterns
- provide checklist management with include/exclude toggles, tagging, notes, filters, and JSON export backed by localStorage

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d845a4811c832d8dc093c1e04ba808