### PR TITLE
Add unified checklist console with shared storage

### DIFF
--- a/checklist.html
+++ b/checklist.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Codex Checklist Console</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f6f7fb;
+      --bg-dark: #131722;
+      --panel: rgba(255, 255, 255, 0.92);
+      --panel-dark: rgba(28, 32, 44, 0.9);
+      --border: #d7d9e6;
+      --border-dark: #2f3342;
+      --muted: #5c6375;
+      --muted-dark: #a0a7bb;
+      --accent: #4361ee;
+      --accent-soft: rgba(67, 97, 238, 0.18);
+      --text: #1f2430;
+      --text-dark: #f7f9ff;
+      font-family: "Inter", "Segoe UI", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif;
+      line-height: 1.6;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: linear-gradient(180deg, rgba(67, 97, 238, 0.12), transparent 340px) var(--bg);
+      color: var(--text);
+      display: flex;
+      flex-direction: column;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background: linear-gradient(180deg, rgba(122, 162, 255, 0.22), transparent 340px) var(--bg-dark);
+        color: var(--text-dark);
+      }
+    }
+
+    header {
+      padding: 32px clamp(20px, 5vw, 56px) 16px;
+    }
+
+    header h1 {
+      margin: 0 0 8px;
+      font-size: clamp(1.6rem, 4vw, 2.5rem);
+      letter-spacing: -0.02em;
+    }
+
+    header p {
+      margin: 0;
+      max-width: 720px;
+      color: var(--muted);
+      font-size: 1rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      header p {
+        color: var(--muted-dark);
+      }
+    }
+
+    main {
+      flex: 1;
+      padding: 0 clamp(20px, 5vw, 56px) 48px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .tab-bar {
+      display: flex;
+      gap: 10px;
+      border-bottom: 1px solid rgba(67, 97, 238, 0.15);
+      flex-wrap: wrap;
+    }
+
+    .tab-button {
+      position: relative;
+      appearance: none;
+      border: none;
+      background: none;
+      padding: 12px 20px;
+      font: inherit;
+      font-weight: 600;
+      color: var(--muted);
+      border-radius: 14px 14px 0 0;
+      cursor: pointer;
+      transition: color 0.18s ease, background 0.18s ease;
+    }
+
+    .tab-button.active {
+      color: var(--accent);
+      background: var(--panel);
+      box-shadow: 0 -10px 30px rgba(19, 29, 60, 0.08);
+    }
+
+    .tab-panel {
+      display: none;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 0 18px 18px 18px;
+      box-shadow: 0 28px 48px rgba(19, 29, 60, 0.08);
+      padding: 0;
+      overflow: hidden;
+    }
+
+    .tab-panel.active {
+      display: block;
+    }
+
+    .tab-panel iframe {
+      display: block;
+      width: 100%;
+      height: min(78vh, 960px);
+      min-height: 520px;
+      border: none;
+      background: transparent;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .tab-button.active {
+        background: var(--panel-dark);
+        color: #c8d1ff;
+        box-shadow: 0 -10px 30px rgba(0, 0, 0, 0.35);
+      }
+
+      .tab-panel {
+        background: var(--panel-dark);
+        border-color: var(--border-dark);
+        box-shadow: 0 28px 48px rgba(0, 0, 0, 0.4);
+      }
+    }
+
+    @media (max-width: 960px) {
+      .tab-panel iframe {
+        height: 70vh;
+        min-height: 440px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Codex Checklist Console</h1>
+    <p>Collect merged pull requests, curate review notes, and consume the same checklist from a unified viewer. Use the tabs below to switch between entry management and the presentation experience.</p>
+  </header>
+  <main>
+    <nav class="tab-bar" role="tablist">
+      <button id="tab-checklist" class="tab-button active" data-tab="checklist" role="tab" aria-selected="true" aria-controls="panel-checklist">Checklist Builder</button>
+      <button id="tab-viewer" class="tab-button" data-tab="viewer" role="tab" aria-selected="false" aria-controls="panel-viewer">Reviewer View</button>
+    </nav>
+    <section class="tab-panel active" id="panel-checklist" role="tabpanel" aria-labelledby="tab-checklist">
+      <iframe id="checklist-frame" src="view.html" title="Checklist builder"></iframe>
+    </section>
+    <section class="tab-panel" id="panel-viewer" role="tabpanel" aria-labelledby="tab-viewer">
+      <iframe id="viewer-frame" src="viewer.html" title="Checklist viewer"></iframe>
+    </section>
+  </main>
+  <script src="codex-checklist-shared.js"></script>
+  <script>
+    const tabButtons = Array.from(document.querySelectorAll('.tab-button'));
+    const panels = {
+      checklist: document.getElementById('panel-checklist'),
+      viewer: document.getElementById('panel-viewer')
+    };
+
+    tabButtons.forEach(button => {
+      button.addEventListener('click', () => {
+        const tab = button.dataset.tab;
+        if (!tab || !panels[tab]) return;
+        tabButtons.forEach(btn => {
+          const isActive = btn === button;
+          btn.classList.toggle('active', isActive);
+          btn.setAttribute('aria-selected', String(isActive));
+        });
+        Object.entries(panels).forEach(([key, panel]) => {
+          panel.classList.toggle('active', key === tab);
+        });
+      });
+    });
+
+    const viewFrame = document.getElementById('checklist-frame');
+    const viewerFrame = document.getElementById('viewer-frame');
+
+    const readyState = {
+      checklist: false,
+      viewer: false,
+      bootstrapped: false
+    };
+
+    function postToFrame(frame, detail) {
+      if (!frame || !frame.contentWindow || !detail) return;
+      try {
+        frame.contentWindow.postMessage({
+          type: 'codexrecall-checklist-updated',
+          owner: detail.owner,
+          repo: detail.repo,
+          payload: detail.payload
+        }, '*');
+      } catch (error) {
+        console.warn('Codex Checklist Console: unable to post update to frame', error);
+      }
+    }
+
+    function hydrateFramesFromCurrent() {
+      if (!window.CodexChecklist) return;
+      const current = window.CodexChecklist.current || window.CodexChecklist.loadLatest();
+      if (!current) return;
+      window.CodexChecklist.setCurrent(current, { dispatchEvent: false, bubble: false });
+      postToFrame(viewFrame, current);
+      postToFrame(viewerFrame, current);
+    }
+
+    function tryBootstrap() {
+      if (readyState.bootstrapped) return;
+      if (readyState.checklist && readyState.viewer) {
+        readyState.bootstrapped = true;
+        hydrateFramesFromCurrent();
+      }
+    }
+
+    viewFrame.addEventListener('load', () => {
+      readyState.checklist = true;
+      tryBootstrap();
+    });
+
+    viewerFrame.addEventListener('load', () => {
+      readyState.viewer = true;
+      tryBootstrap();
+    });
+
+    window.addEventListener('message', event => {
+      const data = event && event.data;
+      if (!data || data.type !== 'codexrecall-checklist-updated') return;
+      if (!data.owner || !data.repo || !data.payload) return;
+      const sourceWindow = event.source;
+      const source = sourceWindow === viewFrame.contentWindow ? 'view' : sourceWindow === viewerFrame.contentWindow ? 'viewer' : 'external';
+      if (window.CodexChecklist) {
+        window.CodexChecklist.setCurrent({ owner: data.owner, repo: data.repo, payload: data.payload, source }, { dispatchEvent: false, bubble: false });
+      }
+      if (source !== 'view') {
+        postToFrame(viewFrame, data);
+      }
+      if (source !== 'viewer') {
+        postToFrame(viewerFrame, data);
+      }
+    });
+
+    window.addEventListener('codexrecall:checklist-updated', event => {
+      const detail = event.detail;
+      if (!detail || !detail.payload) return;
+      if (detail.source === 'view' || detail.source === 'viewer' || detail.source === 'message') return;
+      postToFrame(viewFrame, detail);
+      postToFrame(viewerFrame, detail);
+    });
+  </script>
+</body>
+</html>

--- a/codex-checklist-shared.js
+++ b/codex-checklist-shared.js
@@ -1,0 +1,198 @@
+(function () {
+  const STORAGE_PREFIX = 'codexrecall.checklist.';
+  const LEGACY_KEY = 'viewer_entries_state_v1';
+  const MIGRATION_MARKER = 'codexrecall.viewer.migrated';
+  const CodexChecklist = { current: null };
+
+  function deepClone(value) {
+    try {
+      return JSON.parse(JSON.stringify(value));
+    } catch (error) {
+      console.warn('CodexChecklist: failed to clone value', error);
+      return value;
+    }
+  }
+
+  function keyFor(owner, repo) {
+    return `${STORAGE_PREFIX}${owner}.${repo}`;
+  }
+
+  function parseKey(key) {
+    if (!key || !key.startsWith(STORAGE_PREFIX)) return null;
+    const remainder = key.slice(STORAGE_PREFIX.length);
+    if (!remainder) return null;
+    const parts = remainder.split('.');
+    if (parts.length < 2) return null;
+    const [owner, ...repoParts] = parts;
+    const repo = repoParts.join('.') || null;
+    if (!owner || !repo) return null;
+    return { owner, repo };
+  }
+
+  function readPayload(key) {
+    try {
+      const raw = localStorage.getItem(key);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (!parsed || !Array.isArray(parsed.entries)) {
+        return null;
+      }
+      return {
+        savedAt: parsed.savedAt || null,
+        entries: parsed.entries
+      };
+    } catch (error) {
+      console.warn('CodexChecklist: failed to read payload for', key, error);
+      return null;
+    }
+  }
+
+  function createSnapshot({ owner, repo, payload, source = null }) {
+    const normalizedPayload = {
+      savedAt: payload && payload.savedAt ? payload.savedAt : new Date().toISOString(),
+      entries: Array.isArray(payload && payload.entries) ? payload.entries : []
+    };
+    return {
+      owner,
+      repo,
+      key: keyFor(owner, repo),
+      source,
+      payload: deepClone(normalizedPayload)
+    };
+  }
+
+  function listAll() {
+    const snapshots = [];
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i);
+      if (!key || !key.startsWith(STORAGE_PREFIX)) continue;
+      const info = parseKey(key);
+      if (!info) continue;
+      const payload = readPayload(key);
+      if (!payload) continue;
+      snapshots.push(createSnapshot({ ...info, payload, source: 'storage' }));
+    }
+    snapshots.sort((a, b) => {
+      const aTime = Date.parse(a.payload.savedAt || '') || 0;
+      const bTime = Date.parse(b.payload.savedAt || '') || 0;
+      return bTime - aTime;
+    });
+    return snapshots;
+  }
+
+  function loadChecklist(owner, repo) {
+    if (!owner || !repo) return null;
+    const payload = readPayload(keyFor(owner, repo));
+    if (!payload) return null;
+    return createSnapshot({ owner, repo, payload, source: 'storage' });
+  }
+
+  function loadLatest() {
+    const all = listAll();
+    return all.length ? all[0] : null;
+  }
+
+  function setCurrent(detail, { dispatchEvent = true, bubble = true } = {}) {
+    if (!detail || !detail.owner || !detail.repo) return null;
+    const snapshot = createSnapshot({ owner: detail.owner, repo: detail.repo, payload: detail.payload || {}, source: detail.source || null });
+    CodexChecklist.current = snapshot;
+    if (dispatchEvent) {
+      window.dispatchEvent(new CustomEvent('codexrecall:checklist-updated', { detail: snapshot }));
+    }
+    if (bubble && window.parent && window.parent !== window) {
+      try {
+        window.parent.postMessage({
+          type: 'codexrecall-checklist-updated',
+          owner: snapshot.owner,
+          repo: snapshot.repo,
+          payload: snapshot.payload
+        }, '*');
+      } catch (error) {
+        console.warn('CodexChecklist: unable to post message to parent', error);
+      }
+    }
+    return snapshot;
+  }
+
+  function broadcastUpdate(detail) {
+    return setCurrent(detail);
+  }
+
+  function migrateLegacy() {
+    if (localStorage.getItem(MIGRATION_MARKER)) {
+      return null;
+    }
+    let migrated = null;
+    try {
+      const raw = localStorage.getItem(LEGACY_KEY);
+      if (!raw) {
+        localStorage.setItem(MIGRATION_MARKER, 'true');
+        return null;
+      }
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed) || !parsed.length) {
+        localStorage.removeItem(LEGACY_KEY);
+        localStorage.setItem(MIGRATION_MARKER, 'true');
+        return null;
+      }
+      const owner = 'legacy';
+      const repo = 'viewer';
+      const key = keyFor(owner, repo);
+      if (!localStorage.getItem(key)) {
+        const payload = { savedAt: new Date().toISOString(), entries: parsed };
+        localStorage.setItem(key, JSON.stringify(payload));
+        migrated = setCurrent({ owner, repo, payload, source: 'migration' });
+      }
+      localStorage.removeItem(LEGACY_KEY);
+      localStorage.setItem(MIGRATION_MARKER, 'true');
+    } catch (error) {
+      console.warn('CodexChecklist: failed to migrate legacy viewer state', error);
+    }
+    return migrated;
+  }
+
+  function handleStorage(event) {
+    if (!event.key) return;
+    if (event.key === LEGACY_KEY) {
+      migrateLegacy();
+      return;
+    }
+    if (!event.key.startsWith(STORAGE_PREFIX)) return;
+    const info = parseKey(event.key);
+    if (!info) return;
+    const payload = readPayload(event.key);
+    if (!payload) return;
+    setCurrent({ ...info, payload, source: 'storage' }, { bubble: false });
+  }
+
+  window.addEventListener('storage', handleStorage);
+  window.addEventListener('message', event => {
+    const data = event && event.data;
+    if (!data || data.type !== 'codexrecall-checklist-updated') return;
+    if (!data.owner || !data.repo || !data.payload) return;
+    setCurrent({ owner: data.owner, repo: data.repo, payload: data.payload, source: 'message' }, { bubble: false });
+  });
+
+  Object.assign(CodexChecklist, {
+    STORAGE_PREFIX,
+    LEGACY_KEY,
+    keyFor,
+    parseKey,
+    listAll,
+    loadChecklist,
+    loadLatest,
+    setCurrent,
+    broadcastUpdate,
+    migrateLegacy
+  });
+
+  window.CodexChecklist = CodexChecklist;
+
+  migrateLegacy();
+  if (!CodexChecklist.current) {
+    const initial = loadLatest();
+    if (initial) {
+      setCurrent(initial, { dispatchEvent: false, bubble: false });
+    }
+  }
+})();

--- a/view.html
+++ b/view.html
@@ -486,6 +486,7 @@
     </form>
   </dialog>
 
+  <script src="codex-checklist-shared.js"></script>
   <script>
     const TOKEN_KEY = 'codexrecall.pat';
     const SETTINGS_KEY = 'codexrecall.settings';
@@ -636,6 +637,16 @@
       if (confirm('Clear the locally cached checklist for this repository?')) {
         localStorage.removeItem(checklistKey());
         state.entries = [];
+        const payload = {
+          savedAt: new Date().toISOString(),
+          entries: []
+        };
+        window.CodexChecklist?.broadcastUpdate({
+          owner: state.owner,
+          repo: state.repo,
+          payload,
+          source: 'view-clear'
+        });
         applyFilters();
         render();
       }
@@ -682,6 +693,12 @@
         state.entries = cachedChecklist.entries;
         applyFilters();
         render();
+        window.CodexChecklist?.setCurrent({
+          owner: state.owner,
+          repo: state.repo,
+          payload: cachedChecklist,
+          source: 'view-cache'
+        });
       }
       try {
         state.isLoading = true;
@@ -739,6 +756,12 @@
         entries: state.entries
       };
       localStorage.setItem(checklistKey(), JSON.stringify(payload));
+      window.CodexChecklist?.broadcastUpdate({
+        owner: state.owner,
+        repo: state.repo,
+        payload,
+        source: 'view'
+      });
     }
 
     function mergeWithCached(newEntries) {

--- a/viewer.html
+++ b/viewer.html
@@ -488,8 +488,8 @@
       <div class="entries" id="entry-list"></div>
     </section>
   </div>
+  <script src="codex-checklist-shared.js"></script>
   <script>
-    const STORAGE_KEY = 'viewer_entries_state_v1';
 
     const defaultEntries = [
       {
@@ -530,6 +530,8 @@
       }
     ];
 
+    const codex = window.CodexChecklist;
+
     const dom = {
       entryList: document.getElementById('entry-list'),
       refreshButton: document.getElementById('refresh-button'),
@@ -539,31 +541,97 @@
       statusBar: document.getElementById('status-bar')
     };
 
-    let entries = loadState();
     const openEntries = new Set();
 
-    function loadState() {
-      try {
-        const stored = localStorage.getItem(STORAGE_KEY);
-        if (stored) {
-          const parsed = JSON.parse(stored);
-          if (Array.isArray(parsed)) {
-            return parsed;
-          }
-        }
-      } catch (error) {
-        console.warn('Failed to load saved state', error);
+    let currentChecklist = initializeCurrentChecklist();
+    let entries = cloneEntries(currentChecklist?.payload?.entries || defaultEntries);
+    if (!entries.length) {
+      entries = cloneEntries(defaultEntries);
+    }
+
+    let pendingSaveKey = null;
+
+    function initializeCurrentChecklist() {
+      if (!codex) return null;
+      if (codex.current) return codex.current;
+      const latest = codex.loadLatest();
+      if (latest) {
+        codex.setCurrent(latest, { dispatchEvent: false, bubble: false });
+        return codex.current;
       }
-      return JSON.parse(JSON.stringify(defaultEntries));
+      return null;
+    }
+
+    function formatLabel(info) {
+      if (!info) return 'unknown repository';
+      return `${info.owner}/${info.repo}`;
+    }
+
+    function cloneEntries(data) {
+      try {
+        return JSON.parse(JSON.stringify(Array.isArray(data) ? data : []));
+      } catch (error) {
+        console.warn('Failed to clone entries', error);
+        return Array.isArray(data) ? data.slice() : [];
+      }
+    }
+
+    function adoptChecklist(update) {
+      if (!update || !update.payload || !Array.isArray(update.payload.entries)) {
+        return false;
+      }
+      const key = codex?.keyFor ? codex.keyFor(update.owner, update.repo) : update.key;
+      currentChecklist = {
+        owner: update.owner,
+        repo: update.repo,
+        key: key || update.key,
+        payload: {
+          savedAt: update.payload.savedAt,
+          entries: cloneEntries(update.payload.entries)
+        },
+        source: update.source || null
+      };
+      entries = cloneEntries(update.payload.entries);
+      openEntries.clear();
+      renderEntries();
+      return true;
     }
 
     function saveState() {
+      if (!codex) {
+        setStatus('Shared checklist utilities unavailable. Cannot save.', true);
+        return;
+      }
+      if (!currentChecklist) {
+        setStatus('No checklist selected. Load data in the checklist view first.', true);
+        return;
+      }
+      const key = codex.keyFor(currentChecklist.owner, currentChecklist.repo);
+      const payload = {
+        savedAt: new Date().toISOString(),
+        entries: cloneEntries(entries)
+      };
       try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
-        setStatus('Saved current entries to local storage.');
+        localStorage.setItem(key, JSON.stringify(payload));
+        currentChecklist = {
+          owner: currentChecklist.owner,
+          repo: currentChecklist.repo,
+          key,
+          payload
+        };
+        pendingSaveKey = key;
+        codex.broadcastUpdate({
+          owner: currentChecklist.owner,
+          repo: currentChecklist.repo,
+          payload,
+          source: 'viewer'
+        });
+        setStatus(`Saved checklist for ${formatLabel(currentChecklist)}.`);
       } catch (error) {
         console.error('Unable to save state', error);
         setStatus('Unable to save state. Check storage availability.', true);
+      } finally {
+        pendingSaveKey = null;
       }
     }
 
@@ -985,24 +1053,37 @@
     }
 
     function handleRefresh() {
-      entries = loadState();
-      openEntries.clear();
-      renderEntries();
-      setStatus('Reloaded entries from saved state.');
+      if (!codex || !currentChecklist) {
+        setStatus('No saved checklist available. Load data in the checklist view first.', true);
+        return;
+      }
+      const reloaded = codex.loadChecklist(currentChecklist.owner, currentChecklist.repo);
+      if (reloaded && adoptChecklist(reloaded)) {
+        setStatus(`Reloaded ${entries.length} entr${entries.length === 1 ? 'y' : 'ies'} from ${formatLabel(reloaded)}.`);
+      } else {
+        setStatus('No saved data found for the current repository.', true);
+      }
     }
 
     function handleExport() {
-      const blob = new Blob([JSON.stringify(entries, null, 2)], { type: 'application/json' });
+      const payload = currentChecklist ? {
+        owner: currentChecklist.owner,
+        repo: currentChecklist.repo,
+        savedAt: currentChecklist.payload?.savedAt || new Date().toISOString(),
+        entries
+      } : { entries };
+      const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-      link.download = `viewer-entries-${timestamp}.json`;
+      const label = currentChecklist ? `${currentChecklist.owner}-${currentChecklist.repo}` : 'viewer-entries';
+      link.download = `checklist-${label}-${timestamp}.json`;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
       URL.revokeObjectURL(url);
-      setStatus('Exported entries as JSON.');
+      setStatus('Exported checklist as JSON.');
     }
 
     function handleImport(event) {
@@ -1012,13 +1093,40 @@
       reader.onload = e => {
         try {
           const parsed = JSON.parse(e.target.result);
-          if (!Array.isArray(parsed)) {
-            throw new Error('JSON must be an array of entries.');
+          let importedEntries;
+          let importedChecklist = null;
+          if (Array.isArray(parsed)) {
+            importedEntries = parsed;
+          } else if (parsed && Array.isArray(parsed.entries)) {
+            importedEntries = parsed.entries;
+            if (parsed.owner && parsed.repo) {
+              importedChecklist = {
+                owner: parsed.owner,
+                repo: parsed.repo,
+                payload: {
+                  savedAt: parsed.savedAt || new Date().toISOString(),
+                  entries: cloneEntries(parsed.entries)
+                },
+                source: 'import'
+              };
+            }
+          } else {
+            throw new Error('JSON must be an array or object containing an entries array.');
           }
-          entries = parsed;
+          entries = cloneEntries(importedEntries);
           openEntries.clear();
           renderEntries();
-          setStatus(`Imported ${parsed.length} entr${parsed.length === 1 ? 'y' : 'ies'} from JSON.`);
+          if (importedChecklist) {
+            currentChecklist = {
+              owner: importedChecklist.owner,
+              repo: importedChecklist.repo,
+              key: codex ? codex.keyFor(importedChecklist.owner, importedChecklist.repo) : null,
+              payload: importedChecklist.payload
+            };
+            setStatus(`Imported ${entries.length} entr${entries.length === 1 ? 'y' : 'ies'} for ${formatLabel(importedChecklist)}. Save to persist.`, false);
+          } else {
+            setStatus(`Imported ${entries.length} entr${entries.length === 1 ? 'y' : 'ies'} from JSON. Save to persist changes.`, false);
+          }
         } catch (error) {
           console.error('Import failed', error);
           setStatus('Import failed: ' + error.message, true);
@@ -1026,6 +1134,28 @@
       };
       reader.readAsText(file);
       event.target.value = '';
+    }
+
+    if (codex) {
+      window.addEventListener('codexrecall:checklist-updated', event => {
+        const update = event.detail;
+        if (!update || !update.payload || !Array.isArray(update.payload.entries)) return;
+        if (pendingSaveKey && update.key === pendingSaveKey) return;
+        const wasAdopted = adoptChecklist(update);
+        if (!wasAdopted) return;
+        const isSameRepo = currentChecklist && update.owner === currentChecklist.owner && update.repo === currentChecklist.repo;
+        if (isSameRepo) {
+          setStatus(`Checklist refreshed with ${entries.length} entr${entries.length === 1 ? 'y' : 'ies'}.`);
+        } else {
+          setStatus(`Switched to ${formatLabel(update)} (${entries.length} entr${entries.length === 1 ? 'y' : 'ies'}).`);
+        }
+      });
+    }
+
+    if (currentChecklist && entries.length) {
+      setStatus(`Loaded ${entries.length} entr${entries.length === 1 ? 'y' : 'ies'} from ${formatLabel(currentChecklist)}.`);
+    } else {
+      setStatus('No checklist loaded yet. Use the Codex checklist view or import JSON to begin.');
     }
 
     dom.entryList.addEventListener('click', handleEntryClick);


### PR DESCRIPTION
## Summary
- add a Codex checklist console shell that embeds the builder and viewer behind coordinated tabs
- share checklist data through a new checklist bus with legacy viewer migration and two-way broadcast helpers
- update the checklist builder and viewer to hydrate from the shared storage/events and keep both panes in sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da26b5738c832d85c348e2fd22775a