### PR TITLE
Enhance checklist console with exports and link detection

### DIFF
--- a/checklist.html
+++ b/checklist.html
@@ -70,6 +70,42 @@
       gap: 16px;
     }
 
+    .console-toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+    }
+
+    .console-toolbar button {
+      appearance: none;
+      border: 1px solid var(--border);
+      background: var(--accent-soft);
+      color: var(--accent);
+      padding: 10px 16px;
+      border-radius: 12px;
+      font: inherit;
+      font-weight: 600;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      transition: background 0.18s ease, color 0.18s ease, transform 0.18s ease;
+    }
+
+    .console-toolbar button:hover,
+    .console-toolbar button:focus-visible {
+      background: rgba(67, 97, 238, 0.22);
+      transform: translateY(-1px);
+      outline: none;
+    }
+
+    #status-bar {
+      min-height: 24px;
+      font-size: 0.95rem;
+      color: var(--muted);
+    }
+
     .tab-bar {
       display: flex;
       gap: 10px;
@@ -120,6 +156,79 @@
       background: transparent;
     }
 
+    .reference-panel {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      padding: 20px 24px;
+      box-shadow: 0 18px 36px rgba(19, 29, 60, 0.08);
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .reference-panel h2 {
+      margin: 0;
+      font-size: 1.2rem;
+    }
+
+    .reference-summary {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .reference-list {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .reference-item {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 12px;
+      border-radius: 12px;
+      background: rgba(67, 97, 238, 0.08);
+    }
+
+    .reference-path {
+      font-family: "Fira Code", "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      font-size: 0.95rem;
+      background: rgba(17, 24, 39, 0.08);
+      padding: 4px 8px;
+      border-radius: 8px;
+    }
+
+    .reference-links {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .reference-links a {
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 600;
+      padding: 4px 8px;
+      border-radius: 8px;
+      background: rgba(67, 97, 238, 0.16);
+    }
+
+    .reference-links a:hover,
+    .reference-links a:focus-visible {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .reference-count {
+      margin-left: auto;
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+
     @media (prefers-color-scheme: dark) {
       .tab-button.active {
         background: var(--panel-dark);
@@ -131,6 +240,40 @@
         background: var(--panel-dark);
         border-color: var(--border-dark);
         box-shadow: 0 28px 48px rgba(0, 0, 0, 0.4);
+      }
+
+      .console-toolbar button {
+        border-color: var(--border-dark);
+        background: rgba(122, 162, 255, 0.18);
+        color: #d9ddff;
+      }
+
+      .console-toolbar button:hover,
+      .console-toolbar button:focus-visible {
+        background: rgba(122, 162, 255, 0.32);
+      }
+
+      .reference-panel {
+        background: var(--panel-dark);
+        border-color: var(--border-dark);
+        box-shadow: 0 18px 36px rgba(0, 0, 0, 0.4);
+      }
+
+      .reference-item {
+        background: rgba(99, 102, 241, 0.24);
+      }
+
+      .reference-path {
+        background: rgba(12, 16, 32, 0.6);
+      }
+
+      .reference-links a {
+        background: rgba(99, 102, 241, 0.24);
+        color: #d9ddff;
+      }
+
+      .reference-count {
+        color: var(--muted-dark);
       }
     }
 
@@ -148,6 +291,15 @@
     <p>Collect merged pull requests, curate review notes, and consume the same checklist from a unified viewer. Use the tabs below to switch between entry management and the presentation experience.</p>
   </header>
   <main>
+    <div class="console-toolbar" role="toolbar" aria-label="Checklist actions">
+      <button id="refresh-button" type="button">Refresh</button>
+      <button id="export-json-button" type="button">Export JSON</button>
+      <button id="export-text-button" type="button">Export Text</button>
+      <button id="export-markdown-button" type="button">Export Markdown</button>
+      <button id="export-csv-button" type="button">Export CSV</button>
+      <button id="export-pdf-button" type="button">Export PDF</button>
+    </div>
+    <div id="status-bar" role="status" aria-live="polite"></div>
     <nav class="tab-bar" role="tablist">
       <button id="tab-checklist" class="tab-button active" data-tab="checklist" role="tab" aria-selected="true" aria-controls="panel-checklist">Checklist Builder</button>
       <button id="tab-viewer" class="tab-button" data-tab="viewer" role="tab" aria-selected="false" aria-controls="panel-viewer">Reviewer View</button>
@@ -158,6 +310,11 @@
     <section class="tab-panel" id="panel-viewer" role="tabpanel" aria-labelledby="tab-viewer">
       <iframe id="viewer-frame" src="viewer.html" title="Checklist viewer"></iframe>
     </section>
+    <aside class="reference-panel" id="reference-panel" aria-live="polite">
+      <h2>Detected File References</h2>
+      <p class="reference-summary" id="reference-summary">File references will appear here once a checklist loads.</p>
+      <div class="reference-list" id="reference-list" role="list"></div>
+    </aside>
   </main>
   <script src="codex-checklist-shared.js"></script>
   <script>
@@ -166,6 +323,54 @@
       checklist: document.getElementById('panel-checklist'),
       viewer: document.getElementById('panel-viewer')
     };
+
+    const dom = {
+      refreshButton: document.getElementById('refresh-button'),
+      exportJsonButton: document.getElementById('export-json-button'),
+      exportTextButton: document.getElementById('export-text-button'),
+      exportMarkdownButton: document.getElementById('export-markdown-button'),
+      exportCsvButton: document.getElementById('export-csv-button'),
+      exportPdfButton: document.getElementById('export-pdf-button'),
+      statusBar: document.getElementById('status-bar'),
+      referencePanel: document.getElementById('reference-panel'),
+      referenceSummary: document.getElementById('reference-summary'),
+      referenceList: document.getElementById('reference-list')
+    };
+
+    const readyState = {
+      checklist: false,
+      viewer: false,
+      bootstrapped: false
+    };
+
+    const derivedState = {
+      normalizedEntries: [],
+      repoContext: null,
+      jsonPayload: { entries: [] },
+      textContent: '',
+      markdownContent: '',
+      csvContent: '',
+      pdfBlob: null,
+      fileReferences: []
+    };
+
+    let currentSnapshot = null;
+
+    function setStatus(message, isError = false) {
+      if (!dom.statusBar) return;
+      dom.statusBar.textContent = message || '';
+      dom.statusBar.style.color = isError ? '#d14343' : 'var(--muted)';
+      if (setStatus.timeoutId) {
+        clearTimeout(setStatus.timeoutId);
+      }
+      if (message) {
+        setStatus.timeoutId = setTimeout(() => {
+          dom.statusBar.textContent = '';
+        }, 4000);
+      }
+    }
+
+    setStatus('Waiting for checklist data…');
 
     tabButtons.forEach(button => {
       button.addEventListener('click', () => {
@@ -185,11 +390,473 @@
     const viewFrame = document.getElementById('checklist-frame');
     const viewerFrame = document.getElementById('viewer-frame');
 
-    const readyState = {
-      checklist: false,
-      viewer: false,
-      bootstrapped: false
-    };
+    function cloneEntries(data) {
+      try {
+        return JSON.parse(JSON.stringify(Array.isArray(data) ? data : []));
+      } catch (error) {
+        console.warn('Codex Checklist Console: failed to clone entries', error);
+        return Array.isArray(data) ? data.slice() : [];
+      }
+    }
+
+    function normalizeEntriesForExport(data) {
+      return cloneEntries(data).map(entry => {
+        const normalized = {
+          id: entry?.id ?? '',
+          title: entry?.title ?? '',
+          summary: entry?.summary ?? '',
+          timestamp: entry?.timestamp ?? '',
+          docRef: entry?.docRef ?? '',
+          include: entry?.include !== false,
+          pr: {
+            label: entry?.pr?.label ?? '',
+            url: entry?.pr?.url ?? ''
+          },
+          sections: []
+        };
+        if (Array.isArray(entry?.sections)) {
+          normalized.sections = entry.sections.map(section => ({
+            title: section?.title ?? '',
+            lines: Array.isArray(section?.lines) ? section.lines.map(line => line ?? '') : []
+          }));
+        }
+        return normalized;
+      });
+    }
+
+    function deriveRepoContext(normalizedEntries) {
+      let owner = currentSnapshot?.owner || null;
+      let repo = currentSnapshot?.repo || null;
+      let branch = currentSnapshot?.payload?.branch
+        || currentSnapshot?.payload?.defaultBranch
+        || currentSnapshot?.payload?.branchName
+        || currentSnapshot?.payload?.currentBranch
+        || null;
+
+      if ((!owner || !repo) && Array.isArray(normalizedEntries)) {
+        for (const entry of normalizedEntries) {
+          const prUrl = entry?.pr?.url;
+          if (!prUrl) continue;
+          try {
+            const parsed = new URL(prUrl);
+            const parts = parsed.pathname.split('/').filter(Boolean);
+            if (parts.length >= 2) {
+              owner = owner || parts[0];
+              repo = repo || parts[1];
+            }
+            if (owner && repo) break;
+          } catch (error) {
+            console.warn('Codex Checklist Console: unable to parse PR URL', prUrl, error);
+          }
+        }
+      }
+
+      if (!branch) {
+        branch = 'main';
+      }
+
+      if (!owner || !repo) {
+        return null;
+      }
+
+      const pagesHost = `${owner}.github.io`;
+      return { owner, repo, branch, pagesHost };
+    }
+
+    function buildTextExport(normalizedEntries, repoContext) {
+      const lines = [];
+      if (repoContext) {
+        lines.push(`Repository: ${repoContext.owner}/${repoContext.repo}`);
+        lines.push(`Branch: ${repoContext.branch}`);
+        lines.push('');
+      }
+      normalizedEntries.forEach(entry => {
+        lines.push(`#${entry.id || 'N/A'} ${entry.title || ''}`.trim());
+        lines.push(`Include: ${entry.include ? 'Yes' : 'No'}`);
+        if (entry.summary) {
+          lines.push(`Summary: ${entry.summary}`);
+        }
+        if (entry.timestamp) {
+          lines.push(`Timestamp: ${entry.timestamp}`);
+        }
+        if (entry.docRef) {
+          lines.push(`Doc: ${entry.docRef}`);
+        }
+        if (entry.pr?.url || entry.pr?.label) {
+          const label = entry.pr.label || entry.pr.url;
+          lines.push(`PR: ${label}${entry.pr.url ? ` (${entry.pr.url})` : ''}`);
+        }
+        if (entry.sections.length) {
+          entry.sections.forEach(section => {
+            if (section.title) {
+              lines.push('');
+              lines.push(section.title);
+            }
+            section.lines.forEach(line => {
+              lines.push(`- ${line || ''}`);
+            });
+          });
+        }
+        lines.push('');
+      });
+      return lines.join('\n').replace(/\n{3,}/g, '\n\n');
+    }
+
+    function buildMarkdownExport(normalizedEntries, repoContext) {
+      const lines = [];
+      if (repoContext) {
+        lines.push(`# Checklist for ${repoContext.owner}/${repoContext.repo}`);
+        lines.push(`*Branch:* \`${repoContext.branch}\``);
+        lines.push('');
+      }
+      normalizedEntries.forEach(entry => {
+        lines.push(`## #${entry.id || 'N/A'} ${entry.title || ''}`.trim());
+        lines.push(`- **Include:** ${entry.include ? 'Yes' : 'No'}`);
+        if (entry.summary) {
+          lines.push(`- **Summary:** ${entry.summary}`);
+        }
+        if (entry.timestamp) {
+          lines.push(`- **Timestamp:** ${entry.timestamp}`);
+        }
+        if (entry.docRef) {
+          lines.push(`- **Doc:** ${entry.docRef}`);
+        }
+        if (entry.pr?.url || entry.pr?.label) {
+          const label = entry.pr.label || entry.pr.url;
+          const url = entry.pr.url || '';
+          if (url) {
+            lines.push(`- **PR:** [${label}](${url})`);
+          } else if (label) {
+            lines.push(`- **PR:** ${label}`);
+          }
+        }
+        if (entry.sections.length) {
+          lines.push('');
+          entry.sections.forEach(section => {
+            if (section.title) {
+              lines.push(`### ${section.title}`);
+            }
+            section.lines.forEach(line => {
+              lines.push(`- ${line || ''}`);
+            });
+            lines.push('');
+          });
+        }
+        lines.push('');
+      });
+      return lines.join('\n').replace(/\n{3,}/g, '\n\n');
+    }
+
+    function csvEscape(value) {
+      const stringValue = String(value ?? '');
+      if (/[",\n]/.test(stringValue)) {
+        return '"' + stringValue.replace(/"/g, '""') + '"';
+      }
+      return stringValue;
+    }
+
+    function buildCsvExport(normalizedEntries) {
+      const headers = ['Entry ID', 'Include', 'Title', 'Summary', 'Timestamp', 'Doc Ref', 'PR Label', 'PR URL', 'Section', 'Line Index', 'Line'];
+      const rows = [headers.join(',')];
+      normalizedEntries.forEach(entry => {
+        if (!entry.sections.length) {
+          rows.push([
+            csvEscape(entry.id),
+            csvEscape(entry.include ? 'Yes' : 'No'),
+            csvEscape(entry.title),
+            csvEscape(entry.summary),
+            csvEscape(entry.timestamp),
+            csvEscape(entry.docRef),
+            csvEscape(entry.pr?.label || ''),
+            csvEscape(entry.pr?.url || ''),
+            csvEscape(''),
+            csvEscape(''),
+            csvEscape('')
+          ].join(','));
+          return;
+        }
+        entry.sections.forEach(section => {
+          const sectionTitle = section.title || '';
+          if (!section.lines.length) {
+            rows.push([
+              csvEscape(entry.id),
+              csvEscape(entry.include ? 'Yes' : 'No'),
+              csvEscape(entry.title),
+              csvEscape(entry.summary),
+              csvEscape(entry.timestamp),
+              csvEscape(entry.docRef),
+              csvEscape(entry.pr?.label || ''),
+              csvEscape(entry.pr?.url || ''),
+              csvEscape(sectionTitle),
+              csvEscape(''),
+              csvEscape('')
+            ].join(','));
+            return;
+          }
+          section.lines.forEach((line, index) => {
+            rows.push([
+              csvEscape(entry.id),
+              csvEscape(entry.include ? 'Yes' : 'No'),
+              csvEscape(entry.title),
+              csvEscape(entry.summary),
+              csvEscape(entry.timestamp),
+              csvEscape(entry.docRef),
+              csvEscape(entry.pr?.label || ''),
+              csvEscape(entry.pr?.url || ''),
+              csvEscape(sectionTitle),
+              csvEscape(index + 1),
+              csvEscape(line || '')
+            ].join(','));
+          });
+        });
+      });
+      return rows.join('\n');
+    }
+
+    function escapePdfText(value) {
+      return String(value ?? '').replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+    }
+
+    function createPdfBlob(textContent) {
+      const sanitized = String(textContent || '').replace(/\r\n?/g, '\n');
+      const lines = sanitized.split('\n');
+      const contentParts = ['BT', '/F1 10 Tf', '50 780 Td'];
+      lines.forEach((line, index) => {
+        if (index === 0) {
+          contentParts.push(`(${escapePdfText(line)}) Tj`);
+        } else {
+          contentParts.push('0 -14 Td');
+          contentParts.push(`(${escapePdfText(line)}) Tj`);
+        }
+      });
+      contentParts.push('ET');
+      const contentStream = contentParts.join('\n');
+      const encoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
+      const contentLength = encoder ? encoder.encode(contentStream).length : contentStream.length;
+      const objects = [
+        '1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n',
+        '2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n',
+        '3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n',
+        `4 0 obj\n<< /Length ${contentLength} >>\nstream\n${contentStream}\nendstream\nendobj\n`,
+        '5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n'
+      ];
+      const pdfParts = ['%PDF-1.4\n'];
+      const offsets = [];
+      const measure = value => encoder ? encoder.encode(value).length : value.length;
+      let byteLength = measure(pdfParts[0]);
+      objects.forEach(obj => {
+        offsets.push(byteLength);
+        pdfParts.push(obj);
+        byteLength += measure(obj);
+      });
+      const xrefPosition = byteLength;
+      let xref = `xref\n0 ${objects.length + 1}\n`;
+      xref += '0000000000 65535 f \n';
+      offsets.forEach(offset => {
+        xref += offset.toString().padStart(10, '0') + ' 00000 n \n';
+      });
+      pdfParts.push(xref);
+      byteLength += measure(xref);
+      const trailer = `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefPosition}\n%%EOF`;
+      pdfParts.push(trailer);
+      return new Blob(pdfParts, { type: 'application/pdf' });
+    }
+
+    function encodePathSegments(path) {
+      return path.split('/').map(segment => encodeURIComponent(segment)).join('/');
+    }
+
+    function isValidFileReference(candidate) {
+      if (!candidate) return false;
+      if (candidate.includes('://')) return false;
+      if (candidate.includes('<') || candidate.includes('>')) return false;
+      if (!/\./.test(candidate)) return false;
+      return /^[A-Za-z0-9_.\/\-]+$/.test(candidate);
+    }
+
+    function extractFileReferences(text) {
+      if (!text) return [];
+      const found = new Set();
+      const matches = text.matchAll(/(?:File(?:name)?|Path|Page|Asset)[:\s]+([^|\n]+)/gi);
+      for (const match of matches) {
+        const candidate = match[1].trim();
+        if (candidate) {
+          candidate.split(/[,\s]+/).forEach(item => {
+            const cleaned = item.replace(/^[`'"(\[]+/, '').replace(/[`'"),\]]+$/, '');
+            if (isValidFileReference(cleaned)) {
+              found.add(cleaned);
+            }
+          });
+        }
+      }
+      text.split(/\s+/).forEach(token => {
+        const cleaned = token.replace(/^[`'"(\[]+/, '').replace(/[`'"),.;:>\]]+$/, '');
+        if (isValidFileReference(cleaned)) {
+          found.add(cleaned);
+        }
+      });
+      return Array.from(found);
+    }
+
+    function createFileLinks(path, repoContext) {
+      if (!repoContext) return [];
+      const normalizedPath = path.replace(/^[./]+/, '');
+      if (!normalizedPath) return [];
+      const encodedPath = encodePathSegments(normalizedPath);
+      const githubUrl = `https://github.com/${repoContext.owner}/${repoContext.repo}/blob/${encodeURIComponent(repoContext.branch)}/${encodedPath}`;
+      const pagesUrl = `https://${repoContext.pagesHost}/${repoContext.repo}/${encodedPath}`;
+      const githubLink = document.createElement('a');
+      githubLink.href = githubUrl;
+      githubLink.target = '_blank';
+      githubLink.rel = 'noopener noreferrer';
+      githubLink.textContent = 'GitHub';
+      githubLink.title = `Open ${normalizedPath} on GitHub (${repoContext.branch})`;
+      const pagesLink = document.createElement('a');
+      pagesLink.href = pagesUrl;
+      pagesLink.target = '_blank';
+      pagesLink.rel = 'noopener noreferrer';
+      pagesLink.textContent = 'Pages';
+      pagesLink.title = `Open ${normalizedPath} on GitHub Pages`;
+      return [githubLink, pagesLink];
+    }
+
+    function collectFileReferences(normalizedEntries) {
+      const map = new Map();
+      normalizedEntries.forEach(entry => {
+        entry.sections.forEach(section => {
+          const seenInSection = new Set();
+          section.lines.forEach(line => {
+            extractFileReferences(line).forEach(path => {
+              const normalized = path.replace(/^[./]+/, '');
+              if (!normalized) return;
+              if (!seenInSection.has(normalized)) {
+                seenInSection.add(normalized);
+                if (!map.has(normalized)) {
+                  map.set(normalized, { path: normalized, count: 0 });
+                }
+                map.get(normalized).count += 1;
+              }
+            });
+          });
+        });
+      });
+      return Array.from(map.values()).sort((a, b) => a.path.localeCompare(b.path));
+    }
+
+    function renderFileReferences() {
+      if (!dom.referenceSummary || !dom.referenceList) return;
+      const repoContext = derivedState.repoContext;
+      const references = Array.isArray(derivedState.fileReferences) ? derivedState.fileReferences : [];
+      dom.referenceList.innerHTML = '';
+      if (!references.length) {
+        dom.referenceSummary.textContent = repoContext
+          ? 'No file references detected in the current checklist.'
+          : 'File references will appear here once a checklist with repository details loads.';
+        return;
+      }
+      const entryCount = derivedState.normalizedEntries.length;
+      const summaryParts = [`${references.length} unique file reference${references.length === 1 ? '' : 's'}`];
+      if (repoContext) {
+        summaryParts.push(`for ${repoContext.owner}/${repoContext.repo} (${repoContext.branch})`);
+      }
+      if (entryCount) {
+        summaryParts.push(`across ${entryCount} entr${entryCount === 1 ? 'y' : 'ies'}`);
+      }
+      dom.referenceSummary.textContent = summaryParts.join(' ') + '.';
+      references.forEach(ref => {
+        const item = document.createElement('div');
+        item.className = 'reference-item';
+        item.setAttribute('role', 'listitem');
+        const pathEl = document.createElement('span');
+        pathEl.className = 'reference-path';
+        pathEl.textContent = ref.path;
+        item.appendChild(pathEl);
+        const linksWrap = document.createElement('span');
+        linksWrap.className = 'reference-links';
+        if (repoContext) {
+          createFileLinks(ref.path, repoContext).forEach(link => {
+            linksWrap.appendChild(link);
+          });
+        } else {
+          const missing = document.createElement('span');
+          missing.textContent = 'No repo context';
+          missing.style.color = 'var(--muted)';
+          linksWrap.appendChild(missing);
+        }
+        item.appendChild(linksWrap);
+        const countEl = document.createElement('span');
+        countEl.className = 'reference-count';
+        countEl.textContent = `${ref.count}×`;
+        item.appendChild(countEl);
+        dom.referenceList.appendChild(item);
+      });
+    }
+
+    function clearDerivedState() {
+      derivedState.normalizedEntries = [];
+      derivedState.repoContext = null;
+      derivedState.jsonPayload = { entries: [] };
+      derivedState.textContent = '';
+      derivedState.markdownContent = '';
+      derivedState.csvContent = '';
+      derivedState.pdfBlob = createPdfBlob('');
+      derivedState.fileReferences = [];
+      renderFileReferences();
+    }
+
+    function updateDerivedState() {
+      const sourceEntries = Array.isArray(currentSnapshot?.payload?.entries)
+        ? currentSnapshot.payload.entries
+        : [];
+      const normalizedEntries = normalizeEntriesForExport(sourceEntries);
+      derivedState.normalizedEntries = normalizedEntries;
+      derivedState.repoContext = deriveRepoContext(normalizedEntries);
+      const repoContext = derivedState.repoContext;
+      const normalizedClone = cloneEntries(normalizedEntries);
+      derivedState.jsonPayload = currentSnapshot ? {
+        owner: currentSnapshot.owner,
+        repo: currentSnapshot.repo,
+        branch: repoContext?.branch || currentSnapshot.payload?.branch || null,
+        savedAt: currentSnapshot.payload?.savedAt || new Date().toISOString(),
+        entries: normalizedClone
+      } : { entries: normalizedClone };
+      derivedState.textContent = buildTextExport(normalizedEntries, repoContext);
+      derivedState.markdownContent = buildMarkdownExport(normalizedEntries, repoContext);
+      derivedState.csvContent = buildCsvExport(normalizedEntries);
+      derivedState.pdfBlob = createPdfBlob(derivedState.textContent);
+      derivedState.fileReferences = collectFileReferences(normalizedEntries);
+      renderFileReferences();
+    }
+
+    function adoptSnapshot(detail, { announce = false } = {}) {
+      if (!detail || !detail.payload || !Array.isArray(detail.payload.entries)) {
+        currentSnapshot = null;
+        clearDerivedState();
+        if (announce) {
+          setStatus('No checklist entries available.', true);
+        }
+        return false;
+      }
+      currentSnapshot = {
+        owner: detail.owner || null,
+        repo: detail.repo || null,
+        payload: {
+          savedAt: detail.payload.savedAt || null,
+          branch: detail.payload.branch || detail.payload.branchName || detail.payload.currentBranch || detail.payload.defaultBranch || null,
+          defaultBranch: detail.payload.defaultBranch || null,
+          entries: cloneEntries(detail.payload.entries)
+        },
+        source: detail.source || null
+      };
+      updateDerivedState();
+      if (announce) {
+        const entryCount = derivedState.normalizedEntries.length;
+        const repoContext = derivedState.repoContext;
+        const repoLabel = repoContext ? `${repoContext.owner}/${repoContext.repo}@${repoContext.branch}` : 'unbound checklist';
+        setStatus(`Synchronized ${entryCount} entr${entryCount === 1 ? 'y' : 'ies'} from ${repoLabel}.`);
+      }
+      return true;
+    }
 
     function postToFrame(frame, detail) {
       if (!frame || !frame.contentWindow || !detail) return;
@@ -205,14 +872,105 @@
       }
     }
 
-    function hydrateFramesFromCurrent() {
-      if (!window.CodexChecklist) return;
+    function hydrateFramesFromCurrent({ announce = false } = {}) {
+      if (!window.CodexChecklist) {
+        clearDerivedState();
+        return;
+      }
       const current = window.CodexChecklist.current || window.CodexChecklist.loadLatest();
-      if (!current) return;
-      window.CodexChecklist.setCurrent(current, { dispatchEvent: false, bubble: false });
-      postToFrame(viewFrame, current);
-      postToFrame(viewerFrame, current);
+      if (!current) {
+        clearDerivedState();
+        if (announce) {
+          setStatus('No saved checklist found.', true);
+        }
+        return;
+      }
+      const snapshot = window.CodexChecklist.setCurrent(current, { dispatchEvent: false, bubble: false }) || current;
+      adoptSnapshot(snapshot, { announce });
+      postToFrame(viewFrame, snapshot);
+      postToFrame(viewerFrame, snapshot);
     }
+
+    function getDownloadLabel() {
+      if (currentSnapshot) {
+        const sanitize = value => String(value ?? '').replace(/[^A-Za-z0-9._-]+/g, '-');
+        const owner = sanitize(currentSnapshot.owner);
+        const repo = sanitize(currentSnapshot.repo);
+        const branchValue = derivedState.repoContext?.branch ? `-${sanitize(derivedState.repoContext.branch)}` : '';
+        return `${owner}-${repo}${branchValue}`;
+      }
+      return 'checklist';
+    }
+
+    function downloadFile(content, { type, extension }) {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const label = getDownloadLabel();
+      const blob = content instanceof Blob ? content : new Blob([content], { type });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `checklist-${label}-${timestamp}.${extension}`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    }
+
+    function handleRefresh() {
+      hydrateFramesFromCurrent({ announce: true });
+    }
+
+    function ensureEntriesBeforeExport(formatLabel) {
+      const count = derivedState.normalizedEntries.length;
+      if (!count) {
+        setStatus(`Exported ${formatLabel} with no entries.`);
+      } else {
+        setStatus(`Exported ${formatLabel} for ${count} entr${count === 1 ? 'y' : 'ies'}.`);
+      }
+    }
+
+    function handleExportJson() {
+      updateDerivedState();
+      const payload = derivedState.jsonPayload;
+      if (!payload) {
+        setStatus('Unable to build JSON export.', true);
+        return;
+      }
+      downloadFile(JSON.stringify(payload, null, 2), { type: 'application/json', extension: 'json' });
+      ensureEntriesBeforeExport('JSON');
+    }
+
+    function handleExportText() {
+      updateDerivedState();
+      downloadFile(derivedState.textContent, { type: 'text/plain', extension: 'txt' });
+      ensureEntriesBeforeExport('text');
+    }
+
+    function handleExportMarkdown() {
+      updateDerivedState();
+      downloadFile(derivedState.markdownContent, { type: 'text/markdown', extension: 'md' });
+      ensureEntriesBeforeExport('Markdown');
+    }
+
+    function handleExportCsv() {
+      updateDerivedState();
+      downloadFile(derivedState.csvContent, { type: 'text/csv', extension: 'csv' });
+      ensureEntriesBeforeExport('CSV');
+    }
+
+    function handleExportPdf() {
+      updateDerivedState();
+      const blob = derivedState.pdfBlob || createPdfBlob(derivedState.textContent);
+      downloadFile(blob, { type: 'application/pdf', extension: 'pdf' });
+      ensureEntriesBeforeExport('PDF');
+    }
+
+    dom.refreshButton?.addEventListener('click', handleRefresh);
+    dom.exportJsonButton?.addEventListener('click', handleExportJson);
+    dom.exportTextButton?.addEventListener('click', handleExportText);
+    dom.exportMarkdownButton?.addEventListener('click', handleExportMarkdown);
+    dom.exportCsvButton?.addEventListener('click', handleExportCsv);
+    dom.exportPdfButton?.addEventListener('click', handleExportPdf);
 
     function tryBootstrap() {
       if (readyState.bootstrapped) return;
@@ -237,25 +995,36 @@
       if (!data || data.type !== 'codexrecall-checklist-updated') return;
       if (!data.owner || !data.repo || !data.payload) return;
       const sourceWindow = event.source;
-      const source = sourceWindow === viewFrame.contentWindow ? 'view' : sourceWindow === viewerFrame.contentWindow ? 'viewer' : 'external';
+      const source = sourceWindow === viewFrame.contentWindow ? 'view'
+        : sourceWindow === viewerFrame.contentWindow ? 'viewer'
+        : 'external';
+      let snapshot = data;
       if (window.CodexChecklist) {
-        window.CodexChecklist.setCurrent({ owner: data.owner, repo: data.repo, payload: data.payload, source }, { dispatchEvent: false, bubble: false });
+        snapshot = window.CodexChecklist.setCurrent({ owner: data.owner, repo: data.repo, payload: data.payload, source }, { dispatchEvent: false, bubble: false }) || data;
       }
+      adoptSnapshot(snapshot);
       if (source !== 'view') {
-        postToFrame(viewFrame, data);
+        postToFrame(viewFrame, snapshot);
       }
       if (source !== 'viewer') {
-        postToFrame(viewerFrame, data);
+        postToFrame(viewerFrame, snapshot);
       }
     });
 
     window.addEventListener('codexrecall:checklist-updated', event => {
       const detail = event.detail;
       if (!detail || !detail.payload) return;
-      if (detail.source === 'view' || detail.source === 'viewer' || detail.source === 'message') return;
+      adoptSnapshot(detail);
+      if (detail.source === 'view' || detail.source === 'viewer' || detail.source === 'message') {
+        return;
+      }
       postToFrame(viewFrame, detail);
       postToFrame(viewerFrame, detail);
     });
+
+    if (window.CodexChecklist && window.CodexChecklist.current) {
+      adoptSnapshot(window.CodexChecklist.current);
+    }
   </script>
 </body>
 </html>

--- a/viewer.html
+++ b/viewer.html
@@ -382,6 +382,32 @@
       transform: translateY(-1px);
     }
 
+    .file-links {
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-left: 8px;
+      font-size: 0.82rem;
+    }
+
+    .file-links a {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 2px 6px;
+      border-radius: 6px;
+      border: 1px solid rgba(79, 70, 229, 0.18);
+      background: rgba(79, 70, 229, 0.1);
+      color: var(--accent);
+      text-decoration: none;
+      transition: background 0.2s ease, transform 0.2s ease;
+    }
+
+    .file-links a:hover {
+      background: var(--accent-soft);
+      transform: translateY(-1px);
+    }
+
     .inline-editor,
     .inline-editor-area {
       width: 100%;
@@ -482,6 +508,10 @@
         <button type="button" id="refresh-button">↻ Refresh</button>
         <label for="import-input">⬆ Import JSON<input id="import-input" type="file" accept="application/json" /></label>
         <button type="button" id="export-button">⬇ Export JSON</button>
+        <button type="button" id="export-text-button">⬇ Export TXT</button>
+        <button type="button" id="export-markdown-button">⬇ Export Markdown</button>
+        <button type="button" id="export-csv-button">⬇ Export CSV</button>
+        <button type="button" id="export-pdf-button">⬇ Export PDF</button>
         <button type="button" id="save-button">💾 Save JSON</button>
       </div>
       <div id="status-bar" role="status" aria-live="polite"></div>
@@ -536,12 +566,26 @@
       entryList: document.getElementById('entry-list'),
       refreshButton: document.getElementById('refresh-button'),
       exportButton: document.getElementById('export-button'),
+      exportTextButton: document.getElementById('export-text-button'),
+      exportMarkdownButton: document.getElementById('export-markdown-button'),
+      exportCsvButton: document.getElementById('export-csv-button'),
+      exportPdfButton: document.getElementById('export-pdf-button'),
       saveButton: document.getElementById('save-button'),
       importInput: document.getElementById('import-input'),
       statusBar: document.getElementById('status-bar')
     };
 
     const openEntries = new Set();
+
+    const derivedState = {
+      repoContext: null,
+      normalizedEntries: [],
+      jsonPayload: null,
+      textContent: '',
+      markdownContent: '',
+      csvContent: '',
+      pdfBlob: null
+    };
 
     let currentChecklist = initializeCurrentChecklist();
     let entries = cloneEntries(currentChecklist?.payload?.entries || defaultEntries);
@@ -574,6 +618,369 @@
         console.warn('Failed to clone entries', error);
         return Array.isArray(data) ? data.slice() : [];
       }
+    }
+
+    function normalizeEntriesForExport(data) {
+      return cloneEntries(data).map(entry => {
+        const normalized = {
+          id: entry?.id ?? '',
+          title: entry?.title ?? '',
+          summary: entry?.summary ?? '',
+          timestamp: entry?.timestamp ?? '',
+          docRef: entry?.docRef ?? '',
+          include: entry?.include !== false,
+          pr: {
+            label: entry?.pr?.label ?? '',
+            url: entry?.pr?.url ?? ''
+          },
+          sections: []
+        };
+        if (Array.isArray(entry?.sections)) {
+          normalized.sections = entry.sections.map(section => ({
+            title: section?.title ?? '',
+            lines: Array.isArray(section?.lines) ? section.lines.map(line => line ?? '') : []
+          }));
+        }
+        return normalized;
+      });
+    }
+
+    function deriveRepoContext(normalizedEntries) {
+      let owner = currentChecklist?.owner || null;
+      let repo = currentChecklist?.repo || null;
+      let branch = currentChecklist?.payload?.branch
+        || currentChecklist?.payload?.defaultBranch
+        || currentChecklist?.payload?.branchName
+        || currentChecklist?.payload?.currentBranch
+        || null;
+
+      if ((!owner || !repo) && Array.isArray(normalizedEntries)) {
+        for (const entry of normalizedEntries) {
+          const prUrl = entry?.pr?.url;
+          if (!prUrl) continue;
+          try {
+            const parsed = new URL(prUrl);
+            const parts = parsed.pathname.split('/').filter(Boolean);
+            if (parts.length >= 2) {
+              owner = owner || parts[0];
+              repo = repo || parts[1];
+            }
+            if (owner && repo) break;
+          } catch (error) {
+            console.warn('Unable to parse PR URL for repo context', prUrl, error);
+          }
+        }
+      }
+
+      if (!branch) {
+        branch = 'main';
+      }
+
+      if (!owner || !repo) {
+        return null;
+      }
+
+      return {
+        owner,
+        repo,
+        branch,
+        pagesHost: `${owner.toLowerCase()}.github.io`
+      };
+    }
+
+    function buildTextExport(normalizedEntries, repoContext) {
+      const lines = [];
+      if (repoContext) {
+        lines.push(`Repository: ${repoContext.owner}/${repoContext.repo}`);
+        lines.push(`Branch: ${repoContext.branch}`);
+        lines.push('');
+      }
+      normalizedEntries.forEach(entry => {
+        lines.push(`#${entry.id || 'N/A'} ${entry.title || ''}`.trim());
+        lines.push(`Summary: ${entry.summary || ''}`);
+        lines.push(`Timestamp: ${entry.timestamp || ''}`);
+        lines.push(`Doc: ${entry.docRef || ''}`);
+        lines.push(`Include: ${entry.include ? 'Yes' : 'No'}`);
+        if (entry.pr?.url || entry.pr?.label) {
+          const label = entry.pr.label ? `${entry.pr.label}: ` : '';
+          lines.push(`PR: ${label}${entry.pr.url || ''}`.trim());
+        }
+        entry.sections.forEach(section => {
+          if (!section.title && !section.lines.length) return;
+          lines.push(`  ${section.title || 'Section'}`.trim());
+          section.lines.forEach(line => {
+            lines.push('    - ' + (line || ''));
+          });
+        });
+        lines.push('');
+      });
+      return lines.join('\n');
+    }
+
+    function buildMarkdownExport(normalizedEntries, repoContext) {
+      const lines = [];
+      if (repoContext) {
+        lines.push(`# Checklist for ${repoContext.owner}/${repoContext.repo}`);
+        lines.push(`*Branch:* \`${repoContext.branch}\``);
+        lines.push('');
+      }
+      normalizedEntries.forEach(entry => {
+        lines.push(`## #${entry.id || 'N/A'} ${entry.title || ''}`.trim());
+        lines.push(`- **Include:** ${entry.include ? 'Yes' : 'No'}`);
+        if (entry.summary) {
+          lines.push(`- **Summary:** ${entry.summary}`);
+        }
+        if (entry.timestamp) {
+          lines.push(`- **Timestamp:** ${entry.timestamp}`);
+        }
+        if (entry.docRef) {
+          lines.push(`- **Doc:** ${entry.docRef}`);
+        }
+        if (entry.pr?.url || entry.pr?.label) {
+          const label = entry.pr.label || entry.pr.url;
+          const url = entry.pr.url || '';
+          if (url) {
+            lines.push(`- **PR:** [${label}](${url})`);
+          } else if (label) {
+            lines.push(`- **PR:** ${label}`);
+          }
+        }
+        if (entry.sections.length) {
+          lines.push('');
+          entry.sections.forEach(section => {
+            if (section.title) {
+              lines.push(`### ${section.title}`);
+            }
+            section.lines.forEach(line => {
+              lines.push(`- ${line || ''}`);
+            });
+            lines.push('');
+          });
+        }
+        lines.push('');
+      });
+      return lines.join('\n').replace(/\n{3,}/g, '\n\n');
+    }
+
+    function csvEscape(value) {
+      const stringValue = String(value ?? '');
+      if (/[",\n]/.test(stringValue)) {
+        return '"' + stringValue.replace(/"/g, '""') + '"';
+      }
+      return stringValue;
+    }
+
+    function buildCsvExport(normalizedEntries) {
+      const headers = ['Entry ID', 'Include', 'Title', 'Summary', 'Timestamp', 'Doc Ref', 'PR Label', 'PR URL', 'Section', 'Line Index', 'Line'];
+      const rows = [headers.join(',')];
+      normalizedEntries.forEach(entry => {
+        if (!entry.sections.length) {
+          rows.push([
+            csvEscape(entry.id),
+            csvEscape(entry.include ? 'Yes' : 'No'),
+            csvEscape(entry.title),
+            csvEscape(entry.summary),
+            csvEscape(entry.timestamp),
+            csvEscape(entry.docRef),
+            csvEscape(entry.pr?.label || ''),
+            csvEscape(entry.pr?.url || ''),
+            csvEscape(''),
+            csvEscape(''),
+            csvEscape('')
+          ].join(','));
+          return;
+        }
+        entry.sections.forEach(section => {
+          const sectionTitle = section.title || '';
+          if (!section.lines.length) {
+            rows.push([
+              csvEscape(entry.id),
+              csvEscape(entry.include ? 'Yes' : 'No'),
+              csvEscape(entry.title),
+              csvEscape(entry.summary),
+              csvEscape(entry.timestamp),
+              csvEscape(entry.docRef),
+              csvEscape(entry.pr?.label || ''),
+              csvEscape(entry.pr?.url || ''),
+              csvEscape(sectionTitle),
+              csvEscape(''),
+              csvEscape('')
+            ].join(','));
+            return;
+          }
+          section.lines.forEach((line, index) => {
+            rows.push([
+              csvEscape(entry.id),
+              csvEscape(entry.include ? 'Yes' : 'No'),
+              csvEscape(entry.title),
+              csvEscape(entry.summary),
+              csvEscape(entry.timestamp),
+              csvEscape(entry.docRef),
+              csvEscape(entry.pr?.label || ''),
+              csvEscape(entry.pr?.url || ''),
+              csvEscape(sectionTitle),
+              csvEscape(index + 1),
+              csvEscape(line || '')
+            ].join(','));
+          });
+        });
+      });
+      return rows.join('\n');
+    }
+
+    function escapePdfText(value) {
+      return String(value ?? '').replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+    }
+
+    function createPdfBlob(textContent) {
+      const sanitized = String(textContent || '').replace(/\r\n?/g, '\n');
+      const lines = sanitized.split('\n');
+      const contentParts = ['BT', '/F1 10 Tf', '50 780 Td'];
+      lines.forEach((line, index) => {
+        if (index === 0) {
+          contentParts.push(`(${escapePdfText(line)}) Tj`);
+        } else {
+          contentParts.push('0 -14 Td');
+          contentParts.push(`(${escapePdfText(line)}) Tj`);
+        }
+      });
+      contentParts.push('ET');
+      const contentStream = contentParts.join('\n');
+      const encoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
+      const contentLength = encoder ? encoder.encode(contentStream).length : contentStream.length;
+      const objects = [
+        '1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n',
+        '2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n',
+        '3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n',
+        `4 0 obj\n<< /Length ${contentLength} >>\nstream\n${contentStream}\nendstream\nendobj\n`,
+        '5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n'
+      ];
+      const pdfParts = ['%PDF-1.4\n'];
+      const offsets = [];
+      const measure = value => encoder ? encoder.encode(value).length : value.length;
+      let byteLength = measure(pdfParts[0]);
+      objects.forEach(obj => {
+        offsets.push(byteLength);
+        pdfParts.push(obj);
+        byteLength += measure(obj);
+      });
+      const xrefPosition = byteLength;
+      let xref = `xref\n0 ${objects.length + 1}\n`;
+      xref += '0000000000 65535 f \n';
+      offsets.forEach(offset => {
+        xref += offset.toString().padStart(10, '0') + ' 00000 n \n';
+      });
+      pdfParts.push(xref);
+      byteLength += measure(xref);
+      const trailer = `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefPosition}\n%%EOF`;
+      pdfParts.push(trailer);
+      return new Blob(pdfParts, { type: 'application/pdf' });
+    }
+
+    function sanitizeForFilename(value) {
+      return String(value ?? '').replace(/[^A-Za-z0-9._-]+/g, '-');
+    }
+
+    function getDownloadLabel() {
+      if (currentChecklist) {
+        const owner = sanitizeForFilename(currentChecklist.owner);
+        const repo = sanitizeForFilename(currentChecklist.repo);
+        const branchValue = derivedState.repoContext?.branch ? `-${sanitizeForFilename(derivedState.repoContext.branch)}` : '';
+        return `${owner}-${repo}${branchValue}`;
+      }
+      return 'viewer-entries';
+    }
+
+    function downloadFile(content, { type, extension }) {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const label = getDownloadLabel();
+      const blob = content instanceof Blob ? content : new Blob([content], { type });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `checklist-${label}-${timestamp}.${extension}`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    }
+
+    function encodePathSegments(path) {
+      return path.split('/').map(segment => encodeURIComponent(segment)).join('/');
+    }
+
+    function extractFileReferences(text) {
+      if (!text) return [];
+      const found = new Set();
+      const matches = text.matchAll(/(?:File(?:name)?|Path|Page|Asset)[:\s]+([^|\n]+)/gi);
+      for (const match of matches) {
+        const candidate = match[1].trim();
+        if (candidate) {
+          candidate.split(/[,\s]+/).forEach(item => {
+            const cleaned = item.replace(/^[`'"(\[]+/, '').replace(/[`'"),\]]+$/, '');
+            if (isValidFileReference(cleaned)) {
+              found.add(cleaned);
+            }
+          });
+        }
+      }
+      text.split(/\s+/).forEach(token => {
+        const cleaned = token.replace(/^[`'"(\[]+/, '').replace(/[`'"),.;:>\]]+$/, '');
+        if (isValidFileReference(cleaned)) {
+          found.add(cleaned);
+        }
+      });
+      return Array.from(found);
+    }
+
+    function isValidFileReference(candidate) {
+      if (!candidate) return false;
+      if (candidate.includes('://')) return false;
+      if (candidate.includes('<') || candidate.includes('>')) return false;
+      if (!/\./.test(candidate)) return false;
+      return /^[A-Za-z0-9_.\/\-]+$/.test(candidate);
+    }
+
+    function createFileLinks(path, repoContext) {
+      if (!repoContext) return [];
+      const normalizedPath = path.replace(/^[./]+/, '');
+      if (!normalizedPath) return [];
+      const encodedPath = encodePathSegments(normalizedPath);
+      const githubUrl = `https://github.com/${repoContext.owner}/${repoContext.repo}/blob/${encodeURIComponent(repoContext.branch)}/${encodedPath}`;
+      const pagesUrl = `https://${repoContext.pagesHost}/${repoContext.repo}/${encodedPath}`;
+      const githubLink = document.createElement('a');
+      githubLink.href = githubUrl;
+      githubLink.target = '_blank';
+      githubLink.rel = 'noopener noreferrer';
+      githubLink.textContent = 'GitHub';
+      githubLink.title = `Open ${normalizedPath} on GitHub (${repoContext.branch})`;
+
+      const pagesLink = document.createElement('a');
+      pagesLink.href = pagesUrl;
+      pagesLink.target = '_blank';
+      pagesLink.rel = 'noopener noreferrer';
+      pagesLink.textContent = 'Pages';
+      pagesLink.title = `Open ${normalizedPath} on GitHub Pages`;
+      return [githubLink, pagesLink];
+    }
+
+    function updateDerivedState() {
+      derivedState.normalizedEntries = normalizeEntriesForExport(entries);
+      derivedState.repoContext = deriveRepoContext(derivedState.normalizedEntries);
+      const repoContext = derivedState.repoContext;
+      const normalizedEntries = derivedState.normalizedEntries;
+      const payload = currentChecklist ? {
+        owner: currentChecklist.owner,
+        repo: currentChecklist.repo,
+        branch: repoContext?.branch,
+        savedAt: currentChecklist.payload?.savedAt || new Date().toISOString(),
+        entries: cloneEntries(normalizedEntries)
+      } : { entries: cloneEntries(normalizedEntries) };
+      derivedState.jsonPayload = payload;
+      derivedState.textContent = buildTextExport(normalizedEntries, repoContext);
+      derivedState.markdownContent = buildMarkdownExport(normalizedEntries, repoContext);
+      derivedState.csvContent = buildCsvExport(normalizedEntries);
+      derivedState.pdfBlob = createPdfBlob(derivedState.textContent);
     }
 
     function adoptChecklist(update) {
@@ -647,6 +1054,8 @@
     }
 
     function renderEntries() {
+      updateDerivedState();
+      const repoContext = derivedState.repoContext;
       dom.entryList.innerHTML = '';
       if (!entries.length) {
         const emptyState = document.createElement('div');
@@ -779,6 +1188,22 @@
               openButton.title = 'Open link in new tab';
               lineEl.appendChild(openButton);
             });
+
+            if (repoContext) {
+              const fileRefs = extractFileReferences(line);
+              if (fileRefs.length) {
+                const linksWrapper = document.createElement('span');
+                linksWrapper.className = 'file-links';
+                fileRefs.forEach(path => {
+                  createFileLinks(path, repoContext).forEach(link => {
+                    linksWrapper.appendChild(link);
+                  });
+                });
+                if (linksWrapper.childNodes.length) {
+                  lineEl.appendChild(linksWrapper);
+                }
+              }
+            }
 
             sectionBody.appendChild(lineEl);
           });
@@ -1065,25 +1490,35 @@
       }
     }
 
-    function handleExport() {
-      const payload = currentChecklist ? {
-        owner: currentChecklist.owner,
-        repo: currentChecklist.repo,
-        savedAt: currentChecklist.payload?.savedAt || new Date().toISOString(),
-        entries
-      } : { entries };
-      const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-      const label = currentChecklist ? `${currentChecklist.owner}-${currentChecklist.repo}` : 'viewer-entries';
-      link.download = `checklist-${label}-${timestamp}.json`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(url);
+    function handleExportJson() {
+      updateDerivedState();
+      const payload = derivedState.jsonPayload;
+      downloadFile(JSON.stringify(payload, null, 2), { type: 'application/json', extension: 'json' });
       setStatus('Exported checklist as JSON.');
+    }
+
+    function handleExportText() {
+      updateDerivedState();
+      downloadFile(derivedState.textContent, { type: 'text/plain', extension: 'txt' });
+      setStatus('Exported checklist as plain text.');
+    }
+
+    function handleExportMarkdown() {
+      updateDerivedState();
+      downloadFile(derivedState.markdownContent, { type: 'text/markdown', extension: 'md' });
+      setStatus('Exported checklist as Markdown.');
+    }
+
+    function handleExportCsv() {
+      updateDerivedState();
+      downloadFile(derivedState.csvContent, { type: 'text/csv', extension: 'csv' });
+      setStatus('Exported checklist as CSV.');
+    }
+
+    function handleExportPdf() {
+      updateDerivedState();
+      downloadFile(derivedState.pdfBlob, { type: 'application/pdf', extension: 'pdf' });
+      setStatus('Exported checklist as PDF.');
     }
 
     function handleImport(event) {
@@ -1161,7 +1596,11 @@
     dom.entryList.addEventListener('click', handleEntryClick);
     dom.entryList.addEventListener('dblclick', handleDoubleClick);
     dom.refreshButton.addEventListener('click', handleRefresh);
-    dom.exportButton.addEventListener('click', handleExport);
+    dom.exportButton.addEventListener('click', handleExportJson);
+    dom.exportTextButton.addEventListener('click', handleExportText);
+    dom.exportMarkdownButton.addEventListener('click', handleExportMarkdown);
+    dom.exportCsvButton.addEventListener('click', handleExportCsv);
+    dom.exportPdfButton.addEventListener('click', handleExportPdf);
     dom.saveButton.addEventListener('click', saveState);
     dom.importInput.addEventListener('change', handleImport);
 


### PR DESCRIPTION
## Summary
- add a toolbar with refresh/export actions and a file reference panel to the checklist console
- derive repository context, export payloads, and detected file references within the console script
- keep iframe views in sync so regenerated exports and links follow checklist updates

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da382c073c832db04fc609dc9fde8e