### PR TITLE
Apply R1 footer standard and sync schema alignment

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -1086,6 +1086,11 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set()
         };
+
+        const getCurrentFolderContext = () => ({
+            providerType: state.providerType,
+            folderId: state.currentFolder?.id || null
+        });
         const Utils = {
             elements: {},
             
@@ -2519,7 +2524,7 @@
                 const file = state.imageFiles.find(f => f.id === fileId);
                 if (!file) return;
                 Object.assign(file, updates);
-                await state.dbManager.saveMetadata(file.id, file);
+                await state.dbManager.saveMetadata(file.id, file, getCurrentFolderContext());
                 await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
             }
 
@@ -2883,7 +2888,7 @@
                     for (const updatedId of updatedIds) {
                         const updatedFile = mergedFiles.find(file => file.id === updatedId);
                         if (updatedFile) {
-                            await state.dbManager.saveMetadata(updatedId, updatedFile);
+                            await state.dbManager.saveMetadata(updatedId, updatedFile, getCurrentFolderContext());
                         }
                     }
                     if (removedIds.length > 0) {
@@ -2932,7 +2937,7 @@
                     for (const updatedId of updatedIds) {
                         const updatedFile = mergedFiles.find(file => file.id === updatedId);
                         if (updatedFile) {
-                            await state.dbManager.saveMetadata(updatedId, updatedFile);
+                            await state.dbManager.saveMetadata(updatedId, updatedFile, getCurrentFolderContext());
                         }
                     }
                     if (removedIds.length > 0) {
@@ -2962,7 +2967,7 @@
                         } else {
                             const defaultMetadata = this.generateDefaultMetadata(file);
                             Object.assign(file, defaultMetadata);
-                            await state.dbManager.saveMetadata(file.id, defaultMetadata);
+                            await state.dbManager.saveMetadata(file.id, defaultMetadata, getCurrentFolderContext());
                         }
                     } catch (error) {
                         console.error(`Failed to process metadata for ${file.name}:`, error);
@@ -3024,7 +3029,7 @@
                     const file = state.imageFiles.find(f => f.id === fileId);
                     if (!file) return;
                     Object.assign(file, updates);
-                    await state.dbManager.saveMetadata(file.id, file);
+                    await state.dbManager.saveMetadata(file.id, file, getCurrentFolderContext());
                     await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
                 } catch (error) {
                     Utils.showToast(`Failed to update metadata: ${error.message}`, 'error', true);
@@ -3093,7 +3098,7 @@
                         finalMetadata.metadataStatus = 'loaded';
                         finalMetadata.extractedMetadata = metadata;
                     }
-                    await state.dbManager.saveMetadata(file.id, finalMetadata);
+                    await state.dbManager.saveMetadata(file.id, finalMetadata, getCurrentFolderContext());
                     Object.assign(file, finalMetadata);
                 } catch (error) {
                     if (error.name === 'AbortError') return;
@@ -3101,7 +3106,7 @@
                     file.metadataStatus = 'error';
                     file.extractedMetadata = { 'Error': error.message };
                     file.prompt = `Metadata Error: ${error.message}`;
-                    await state.dbManager.saveMetadata(file.id, file);
+                    await state.dbManager.saveMetadata(file.id, file, getCurrentFolderContext());
                 }
             }
         };
@@ -3776,7 +3781,7 @@
                 });
 
                 for(const file of newStack) {
-                    await state.dbManager.saveMetadata(file.id, file);
+                    await state.dbManager.saveMetadata(file.id, file, getCurrentFolderContext());
                 }
                 await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
 
@@ -3842,7 +3847,7 @@
 
             if (state.dbManager && typeof state.dbManager.saveMetadata === 'function') {
                 for (const file of newStackOrder) {
-                    await state.dbManager.saveMetadata(file.id, file);
+                    await state.dbManager.saveMetadata(file.id, file, getCurrentFolderContext());
                 }
                 if (state.currentFolder?.id && typeof state.dbManager.saveFolderCache === 'function') {
                     await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);


### PR DESCRIPTION
## Summary
- replace the placeholder footers in ui-v9b.html and ui-v2.html with a shared release-metadata template, style updates, and refreshed SyncActivityLogger bindings so every screen renders the required master footer links
- port the v9 DBManager, diagnostics logger, and folder reset workflow into ui-v2.html to align its IndexedDB schema and recovery tools with the v9b baseline
- ensure metadata saves include the active provider/folder context so folder-scoped cleanup can purge associated records

## Testing
- not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68da951f31a8832d8f5ab547c4887cb7