### PR TITLE
Align v9b master footer styling with legacy app footer

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -461,24 +461,22 @@
         
         .master-footer {
             position: fixed; inset: auto 0 0 0;
-            display: flex; flex-wrap: wrap; align-items: center; justify-content: center;
-            gap: 12px;
+            display: flex; align-items: center; justify-content: center;
+            gap: 10px;
             background: rgba(0, 0, 0, 0.82);
             color: rgba(255, 255, 255, 0.72);
-            padding: 6px 12px;
-            font-size: 11px;
-            z-index: 12;
+            padding: 4px 8px;
+            font-size: 10px;
+            z-index: 8;
             backdrop-filter: blur(12px);
+            text-align: center;
         }
         .master-footer .footer-meta {
             display: inline-flex;
             align-items: center;
-            gap: 6px;
             font-weight: 500;
             letter-spacing: 0.01em;
-        }
-        .master-footer .footer-meta span[aria-hidden="true"] {
-            color: rgba(255, 255, 255, 0.35);
+            white-space: nowrap;
         }
         .master-footer .footer-actions {
             display: inline-flex;
@@ -1009,15 +1007,15 @@
         const Templates = {
             masterFooter(instance = 0) {
                 const suffix = instance === 0 ? '' : `-${instance}`;
+                const metadataText = [
+                    RELEASE_METADATA.name,
+                    RELEASE_METADATA.timestamp,
+                    RELEASE_METADATA.summary
+                ].filter(Boolean).join(' • ');
+
                 return `
                     <footer id="master-footer${suffix}" class="master-footer" data-master-footer role="contentinfo">
-                        <span class="footer-meta">
-                            <span class="footer-release">${RELEASE_METADATA.name}</span>
-                            <span aria-hidden="true">•</span>
-                            <span class="footer-timestamp">${RELEASE_METADATA.timestamp}</span>
-                            <span aria-hidden="true">•</span>
-                            <span class="footer-summary">${RELEASE_METADATA.summary}</span>
-                        </span>
+                        <span class="footer-meta" aria-label="Release metadata">${metadataText}</span>
                         <span class="footer-actions">
                             <button type="button" class="footer-link" data-footer-role="sync-log">View Sync Log</button>
                             <button type="button" class="footer-link" data-footer-role="reset-folder">Reset from Cloud</button>


### PR DESCRIPTION
## Summary
- reduce the master footer padding, font sizing, and stacking context to match the previous app footer footprint
- collapse the release metadata template into a single inline string while leaving the action buttons aligned on the same row

## Testing
- Manual - Verified the recycle pill counter remains visible above the footer in sort mode

------
https://chatgpt.com/codex/tasks/task_e_68dab7e79864832d851ef0d024e4548e