### PR TITLE
Slim master footer to keep sort controls clear

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -483,29 +483,32 @@
         
         .master-footer {
             position: fixed; inset: auto 0 0 0;
-            display: flex; flex-wrap: wrap; align-items: center; justify-content: center;
-            gap: 12px;
-            background: rgba(0, 0, 0, 0.82);
-            color: rgba(255, 255, 255, 0.72);
-            padding: 6px 12px;
-            font-size: 11px;
-            z-index: 12;
-            backdrop-filter: blur(12px);
+            display: flex; align-items: center; justify-content: center;
+            flex-wrap: nowrap;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.68);
+            padding: 4px 8px;
+            font-size: 10px;
+            line-height: 1.2;
+            z-index: 6;
+            backdrop-filter: blur(10px);
+            white-space: nowrap;
+            gap: 6px;
         }
-        .master-footer .footer-meta {
+        .master-footer .footer-line {
             display: inline-flex;
             align-items: center;
             gap: 6px;
             font-weight: 500;
             letter-spacing: 0.01em;
         }
-        .master-footer .footer-meta span[aria-hidden="true"] {
+        .master-footer .footer-line span[aria-hidden="true"] {
             color: rgba(255, 255, 255, 0.35);
         }
         .master-footer .footer-actions {
             display: inline-flex;
             align-items: center;
-            gap: 8px;
+            gap: 6px;
         }
         .master-footer .footer-link {
             background: transparent;
@@ -1034,16 +1037,18 @@
                 const suffix = instance === 0 ? '' : `-${instance}`;
                 return `
                     <footer id="master-footer${suffix}" class="master-footer" data-master-footer role="contentinfo">
-                        <span class="footer-meta">
+                        <span class="footer-line">
                             <span class="footer-release">${RELEASE_METADATA.name}</span>
                             <span aria-hidden="true">•</span>
                             <span class="footer-timestamp">${RELEASE_METADATA.timestamp}</span>
                             <span aria-hidden="true">•</span>
                             <span class="footer-summary">${RELEASE_METADATA.summary}</span>
-                        </span>
-                        <span class="footer-actions">
-                            <button type="button" class="footer-link" data-footer-role="sync-log">View Sync Log</button>
-                            <button type="button" class="footer-link" data-footer-role="reset-folder">Reset from Cloud</button>
+                            <span aria-hidden="true">•</span>
+                            <span class="footer-actions">
+                                <button type="button" class="footer-link" data-footer-role="sync-log">View Sync Log</button>
+                                <span aria-hidden="true">•</span>
+                                <button type="button" class="footer-link" data-footer-role="reset-folder">Reset from Cloud</button>
+                            </span>
                         </span>
                     </footer>
                 `.trim();


### PR DESCRIPTION
## Summary
- match the v2 master footer styling to the slimmer legacy footer so it no longer hides controls
- collapse the footer template into a single inline line that fits the reduced height

## Testing
- browser_container.run_playwright_script (simulate sort view and click trash pill counter)


------
https://chatgpt.com/codex/tasks/task_e_68daba1504ac832d8cb092d24a79812f