### PR TITLE
Guard metadata persistence with folder context

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -2047,15 +2047,22 @@
             async saveMetadata(fileId, metadata, context = {}) {
                 if (!this.db) return;
                 const folderKey = this.resolveFolderKey(context);
+                if (!folderKey) {
+                    const warning = `DBManager.saveMetadata: Missing folder context for ${fileId}.`;
+                    console.error(warning, { context });
+                    throw new Error(warning);
+                }
+                const normalizedContext = typeof context === 'object' && context !== null ? context : {};
                 return new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('metadata', 'readwrite');
                     const store = transaction.objectStore('metadata');
-                    const record = { id: fileId, metadata };
-                    if (folderKey) {
-                        record.folderKey = folderKey;
-                        record.provider = context.providerType || null;
-                        record.folderId = context.folderId || null;
-                    }
+                    const record = {
+                        id: fileId,
+                        metadata,
+                        folderKey,
+                        provider: normalizedContext.providerType || null,
+                        folderId: normalizedContext.folderId || null
+                    };
                     const request = store.put(record);
                     request.onsuccess = () => resolve();
                     request.onerror = () => reject(request.error);
@@ -3511,8 +3518,9 @@
                 const file = state.imageFiles.find(f => f.id === fileId);
                 if (!file) return;
                 Object.assign(file, updates);
-                await state.dbManager.saveMetadata(file.id, file, { folderId: state.currentFolder.id, providerType: state.providerType });
-                await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
+                const context = App.getCurrentFolderContext();
+                await state.dbManager.saveMetadata(file.id, file, context);
+                await state.dbManager.saveFolderCache(context.folderId, state.imageFiles);
             }
 
             async deleteFile(fileId) {
@@ -3821,6 +3829,16 @@
         }
 
         const App = {
+            getCurrentFolderContext(folderIdOverride = null) {
+                const providerType = state.providerType || null;
+                const folderId = folderIdOverride || state.currentFolder?.id || null;
+                if (!folderId) {
+                    const message = 'App.getCurrentFolderContext: Folder ID is required for metadata persistence.';
+                    console.error(message, { providerType });
+                    throw new Error(message);
+                }
+                return { folderId, providerType };
+            },
             selectProvider(type) {
                 state.providerType = type;
                 const isGoogle = type === 'googledrive';
@@ -4107,8 +4125,9 @@
                         Utils.updateLoadingProgress((diff.changedIds?.length || 0) + (diff.removedIds?.length || 0), (diff.changedIds?.length || 0) + (diff.removedIds?.length || 0), 'Finishing sync...');
                     }
 
+                    const context = App.getCurrentFolderContext(folderId);
                     for (const file of cloudFiles) {
-                        await state.dbManager.saveMetadata(file.id, file, { folderId, providerType: state.providerType });
+                        await state.dbManager.saveMetadata(file.id, file, context);
                     }
                     for (const removed of removedIds) {
                         await state.dbManager.deleteMetadata(removed);
@@ -4214,10 +4233,11 @@
                         return;
                     }
 
+                    const context = App.getCurrentFolderContext(folderId);
                     for (const updatedId of updatedIds) {
                         const updatedFile = mergedFiles.find(file => file.id === updatedId);
                         if (updatedFile) {
-                            await state.dbManager.saveMetadata(updatedId, updatedFile, { folderId, providerType: state.providerType });
+                            await state.dbManager.saveMetadata(updatedId, updatedFile, context);
                         }
                     }
                     if (removedIds.length > 0) {
@@ -4306,10 +4326,11 @@
                         return;
                     }
 
+                    const context = App.getCurrentFolderContext(folderId);
                     for (const updatedId of updatedIds) {
                         const updatedFile = mergedFiles.find(file => file.id === updatedId);
                         if (updatedFile) {
-                        await state.dbManager.saveMetadata(updatedId, updatedFile, { folderId, providerType: state.providerType });
+                            await state.dbManager.saveMetadata(updatedId, updatedFile, context);
                         }
                     }
                     if (removedIds.length > 0) {
@@ -4329,8 +4350,8 @@
                 }
             },
             async processAllMetadata(files, isFirstLoad = false) {
-                 if (isFirstLoad) Utils.updateLoadingProgress(0, files.length, 'Processing files...');
-                 for (let i = 0; i < files.length; i++) {
+                if (isFirstLoad) Utils.updateLoadingProgress(0, files.length, 'Processing files...');
+                for (let i = 0; i < files.length; i++) {
                     const file = files[i];
                     try {
                         const metadata = await state.dbManager.getMetadata(file.id);
@@ -4339,12 +4360,12 @@
                         } else {
                             const defaultMetadata = this.generateDefaultMetadata(file);
                             Object.assign(file, defaultMetadata);
-                            await state.dbManager.saveMetadata(file.id, defaultMetadata, { folderId: state.currentFolder.id, providerType: state.providerType });
+                            await state.dbManager.saveMetadata(file.id, defaultMetadata, App.getCurrentFolderContext());
                         }
                     } catch (error) {
                         console.error(`Failed to process metadata for ${file.name}:`, error);
                     }
-                    if(isFirstLoad) Utils.updateLoadingProgress(i + 1, files.length);
+                    if (isFirstLoad) Utils.updateLoadingProgress(i + 1, files.length);
                 }
                 this.extractMetadataInBackground(files.filter(f => f.mimeType === 'image/png'));
             },
@@ -4403,8 +4424,9 @@
                     if (!file) return;
                     const timestamp = Date.now();
                     Object.assign(file, updates, { localUpdatedAt: timestamp });
-                    await state.dbManager.saveMetadata(file.id, file, { folderId: state.currentFolder.id, providerType: state.providerType });
-                    await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
+                    const context = App.getCurrentFolderContext();
+                    await state.dbManager.saveMetadata(file.id, file, context);
+                    await state.dbManager.saveFolderCache(context.folderId, state.imageFiles);
                     if (state.syncManager) {
                         await state.syncManager.queueLocalChange({
                             fileId,
@@ -4412,9 +4434,9 @@
                             operationType,
                             origin,
                             localUpdatedAt: timestamp,
-                            folderId: state.currentFolder.id,
-                            providerType: state.providerType,
-                            metadataSnapshot: { name: file.name, stack: file.stack, stackSequence: file.stackSequence, folderId: state.currentFolder.id }
+                            folderId: context.folderId,
+                            providerType: context.providerType,
+                            metadataSnapshot: { name: file.name, stack: file.stack, stackSequence: file.stackSequence, folderId: context.folderId }
                         }, { debounce: !skipDebounce });
                     }
                 } catch (error) {
@@ -4552,7 +4574,9 @@
             async processFileMetadata(file) {
                 if (file.metadataStatus === 'loaded' || file.metadataStatus === 'loading' || file.metadataStatus === 'error') return;
                 file.metadataStatus = 'loading';
+                let context = null;
                 try {
+                    context = App.getCurrentFolderContext();
                     const metadata = await state.metadataExtractor.fetchMetadata(file);
                     let finalMetadata = { ...file };
                     if (metadata.error) {
@@ -4563,7 +4587,7 @@
                         finalMetadata.metadataStatus = 'loaded';
                         finalMetadata.extractedMetadata = metadata;
                     }
-                    await state.dbManager.saveMetadata(file.id, finalMetadata, { folderId: state.currentFolder.id, providerType: state.providerType });
+                    await state.dbManager.saveMetadata(file.id, finalMetadata, context);
                     Object.assign(file, finalMetadata);
                 } catch (error) {
                     if (error.name === 'AbortError') return;
@@ -4571,7 +4595,12 @@
                     file.metadataStatus = 'error';
                     file.extractedMetadata = { 'Error': error.message };
                     file.prompt = `Metadata Error: ${error.message}`;
-                    await state.dbManager.saveMetadata(file.id, file, { folderId: state.currentFolder.id, providerType: state.providerType });
+                    try {
+                        context = context || App.getCurrentFolderContext();
+                        await state.dbManager.saveMetadata(file.id, file, context);
+                    } catch (ctxError) {
+                        console.error(`Failed to persist fallback metadata for ${file.name}:`, ctxError);
+                    }
                 }
             }
         };
@@ -5168,10 +5197,11 @@
                     file.stackSequence = timestamp - i;
                 });
 
-                for(const file of newStack) {
-                    await state.dbManager.saveMetadata(file.id, file, { folderId: state.currentFolder.id, providerType: state.providerType });
+                const context = App.getCurrentFolderContext();
+                for (const file of newStack) {
+                    await state.dbManager.saveMetadata(file.id, file, context);
                 }
-                await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
+                await state.dbManager.saveFolderCache(context.folderId, state.imageFiles);
 
                 state.stacks[state.grid.stack] = newStack;
                 state.currentStackPosition = 0;


### PR DESCRIPTION
## Summary
- enforce a folder context requirement when persisting metadata so unscoped records are rejected loudly
- add an App.getCurrentFolderContext helper and route metadata writes through it for consistent folder/provider pairing
- align metadata processing and queue updates with the shared context and improved error logging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dac7f757bc832d8d89e5627a9331f3