### PR TITLE
Use permanent Google Drive links in ui-v2 gallery and export

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -1300,8 +1300,14 @@
             },
 
             getFallbackImageUrl(file) {
-                 if (state.providerType === 'googledrive') {
-                    return file.downloadUrl || `https://www.googleapis.com/drive/v3/files/${file.id}?alt=media`;
+                if (state.providerType === 'googledrive') {
+                    const hasViewStyleDownload = typeof file.downloadUrl === 'string' && file.downloadUrl.includes('https://drive.google.com/file/d/');
+                    const permanentLink = [file.viewUrl, file.webViewLink, hasViewStyleDownload ? file.downloadUrl : null]
+                        .find(url => typeof url === 'string' && url.length > 0);
+                    if (permanentLink) { return permanentLink; }
+                    const apiDownloadLink = [file.driveApiDownloadUrl, file.webContentLink, !hasViewStyleDownload ? file.downloadUrl : null]
+                        .find(url => typeof url === 'string' && url.length > 0);
+                    return apiDownloadLink || `https://www.googleapis.com/drive/v3/files/${file.id}?alt=media`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -3219,8 +3225,12 @@
                 } return '';
             }
             getDirectImageURL(image) {
-                if (state.providerType === 'googledrive') { return `https://drive.google.com/uc?id=${image.id}&export=view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                if (state.providerType === 'googledrive') {
+                    return [image.viewUrl, image.webViewLink, `https://drive.google.com/file/d/${image.id}/view`]
+                        .find(url => typeof url === 'string' && url.length > 0) || '';
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
             downloadCSV(data) {


### PR DESCRIPTION
## Summary
- update the gallery fallback URL resolution to prefer permanent Google Drive links before API downloads
- export Google Drive image URLs using their permanent view links instead of the transient `uc` endpoint

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dace529c84832dbc1b054111368cea