### PR TITLE
Add focus stack switching modal in focus mode

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -4643,6 +4643,25 @@
                     option.addEventListener('click', () => { this.executeMove(option.dataset.stack); });
                 });
             },
+            setupFocusStackSwitch() {
+                const availableStacks = STACKS.filter(stack => stack !== state.currentStack && state.stacks[stack].length > 0);
+                let content = `<div style="display: flex; flex-direction: column; gap: 8px; margin-bottom: 16px;">`;
+                if (availableStacks.length > 0) {
+                    content += availableStacks.map(stack => `<button class="move-option" data-stack="${stack}" style="width: 100%; text-align: left; padding: 8px 16px; border-radius: 6px; border: none; background: transparent; cursor: pointer; transition: background-color 0.2s;">${STACK_NAMES[stack]} (${state.stacks[stack].length})</button>`).join('');
+                } else {
+                    content += `<p style="color: #4b5563; text-align: center;">No other stacks have images.</p>`;
+                }
+                content += `</div>`;
+                this.show('focus-stack-switch', { title: 'Switch Stack', content, confirmText: 'Cancel' });
+                document.querySelectorAll('.move-option').forEach(option => {
+                    option.addEventListener('click', () => {
+                        const targetStack = option.dataset.stack;
+                        UI.switchToStack(targetStack);
+                        Core.updateImageCounters();
+                        this.hide();
+                    });
+                });
+            },
             setupTagAction() {
                 const selectedIds = state.grid.selected.length > 0 ? [...state.grid.selected] : [];
                 const total = selectedIds.length;


### PR DESCRIPTION
## Summary
- add a focus stack switch modal that enumerates populated stacks with counts
- ensure selecting a stack updates counters before closing the modal

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dae6ca2edc832db53ddba813cc05b7