### PR TITLE
Ensure trash pill opens grid after switching stacks

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -6479,23 +6479,47 @@
                 STACKS.forEach(stackName => {
                     const pill = document.getElementById(`pill-${stackName}`);
                     if (pill) {
-                        pill.addEventListener('click', async (e) => {
-                            e.stopPropagation();
+                        let pointerActivated = false;
+                        const activatePill = async (event) => {
+                            if (event) {
+                                if (typeof event.preventDefault === 'function') { event.preventDefault(); }
+                                event.stopPropagation();
+                            }
                             if (state.haptic) { state.haptic.triggerFeedback('pillTap'); }
 
+                            const wasDifferentStack = state.currentStack !== stackName;
+                            const comingFromSortMode = !state.isFocusMode;
+
                             if (stackName === 'trash') {
-                                if (state.currentStack !== stackName) {
+                                if (wasDifferentStack) {
                                     await UI.switchToStack(stackName);
+                                    if (comingFromSortMode) {
+                                        Grid.open(stackName);
+                                    }
                                 } else {
                                     Grid.open(stackName);
                                 }
-                            } else if (state.currentStack === stackName) {
+                            } else if (!wasDifferentStack) {
                                 Grid.open(stackName);
                             } else {
-                                UI.switchToStack(stackName);
+                                return UI.switchToStack(stackName);
                             }
 
                             UI.acknowledgePillCounter(stackName);
+                        };
+
+                        pill.addEventListener('pointerup', async (event) => {
+                            pointerActivated = true;
+                            try {
+                                await activatePill(event);
+                            } finally {
+                                setTimeout(() => { pointerActivated = false; }, 150);
+                            }
+                        });
+
+                        pill.addEventListener('click', (event) => {
+                            if (pointerActivated) return;
+                            activatePill(event);
                         });
                     }
                 });


### PR DESCRIPTION
## Summary
- ensure the trash pill opens grid view immediately after switching stacks when invoked from sort mode
- restore the pointer/touch guard on pill counters to prevent duplicate activations on touch hardware

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68dae6d507f8832db8dcdfa7fe808bcf