### PR TITLE
Preselect first grid item when opening

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -4673,9 +4673,13 @@
                 const value = Utils.elements.gridSize.value;
                 Utils.elements.gridContainer.style.gridTemplateColumns = `repeat(${value}, 1fr)`;
                 state.grid.selected = []; state.grid.filtered = [];
+                const activeFiles = state.stacks[stack] || [];
+                if (activeFiles.length > 0) {
+                    state.grid.selected = [activeFiles[0].id];
+                }
                 Utils.elements.gridContainer.innerHTML = '';
                 this.clearDragState();
-                this.initializeLazyLoad(stack);
+                this.initializeLazyLoad(stack, activeFiles);
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -5303,9 +5303,13 @@
                 const value = Utils.elements.gridSize.value;
                 Utils.elements.gridContainer.style.gridTemplateColumns = `repeat(${value}, 1fr)`;
                 state.grid.selected = []; state.grid.filtered = [];
+                const activeFiles = state.stacks[stack] || [];
+                if (activeFiles.length > 0) {
+                    state.grid.selected = [activeFiles[0].id];
+                }
                 Utils.elements.gridContainer.innerHTML = '';
                 this.clearDragState();
-                this.initializeLazyLoad(stack);
+                this.initializeLazyLoad(stack, activeFiles);
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },


### PR DESCRIPTION
## Summary
- preselect the first file in the stack when opening the grid in ui-v2 and ui-v9b
- ensure lazy loading renders the first tile with the selected styling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db05dc5798832d90f83e652ffa14bd