### PR TITLE
Handle empty hash modifiers in grid search

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -5053,6 +5053,14 @@
                 const terms = lowerCaseQuery.split(/\s+/).filter(t => t);
 
                 const modifiers = terms.filter(t => t.startsWith('#'));
+
+                const hasEmptyModifier = modifiers.some(mod => {
+                    const normalized = TagService.normalizeTagValue(mod);
+                    return !normalized || normalized === '#';
+                });
+                if (hasEmptyModifier) {
+                    return [];
+                }
                 const exclusions = terms.filter(t => t.startsWith('-')).map(t => t.substring(1));
                 const inclusions = terms.filter(t => !t.startsWith('#') && !t.startsWith('-'));
 

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -5676,6 +5676,14 @@
                 const terms = lowerCaseQuery.split(/\s+/).filter(t => t);
 
                 const modifiers = terms.filter(t => t.startsWith('#'));
+
+                const hasEmptyModifier = modifiers.some(mod => {
+                    const normalized = TagService.normalizeTagValue(mod);
+                    return !normalized || normalized === '#';
+                });
+                if (hasEmptyModifier) {
+                    return [];
+                }
                 const exclusions = terms.filter(t => t.startsWith('-')).map(t => t.substring(1));
                 const inclusions = terms.filter(t => !t.startsWith('#') && !t.startsWith('-'));
 


### PR DESCRIPTION
## Summary
- short-circuit grid searches when a modifier is just `#` or normalizes to empty so no files are shown until a real tag is provided

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db05df7708832db08b6533ef5aae94