### PR TITLE
Mirror v9b grid search selection behavior

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -4980,11 +4980,12 @@
                 const searchInput = Utils.elements.omniSearch;
                 const query = searchInput.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
-                state.grid.selected = [];
                 if (!query) { this.resetSearch(); return; }
 
                 const results = this.searchImages(query);
                 state.grid.filtered = results;
+                state.grid.selected = results.map(file => file.id);
+                this.updateSelectionUI();
 
                 Utils.elements.gridContainer.innerHTML = '';
                 if (results.length === 0) {
@@ -4994,7 +4995,6 @@
                 }
 
                 this.initializeLazyLoad(state.grid.stack, results);
-                this.updateSelectionUI();
                 state.grid.isDirty = true;
             },
 


### PR DESCRIPTION
## Summary
- update Grid.performSearch in ui-v2 to select search results and refresh the selection UI
- clear and toggle the grid container while letting lazy loading handle selected tile styling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db05e77a94832d921e8b1122e40610