### PR TITLE
Remove modifier pill logic from ui v2 search helper

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -343,16 +343,6 @@
         }
         .search-helper-close:hover, .search-helper-close:focus-visible { color: #6b7280; }
         .search-helper-close:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
-        .search-helper-recent {
-            display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px;
-        }
-        .search-helper-recent.hidden { display: none; }
-        .modifier-pill {
-            background: #e5e7eb; border: none; border-radius: 9999px; padding: 4px 10px; font-size: 12px; color: #374151;
-            cursor: pointer;
-        }
-        .modifier-pill:hover, .modifier-pill:focus-visible { background: #d1d5db; }
-        .modifier-pill:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
         .search-helper-popup a {
             display: block; font-size: 12px; color: #3b82f6; text-decoration: none; padding: 4px 8px;
             border-radius: 4px; cursor: pointer;
@@ -899,7 +889,6 @@
                                     <svg style="width: 14px; height: 14px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                                 </button>
                             </div>
-                            <div class="search-helper-recent hidden" id="search-helper-recent"></div>
                             <a class="modifier-link" data-modifier="#favorite">#favorite</a>
                             <a class="modifier-link" data-modifier="#quality:5">#quality:1-5</a>
                             <a class="modifier-link" data-modifier="#content:5">#content:1-5</a>
@@ -1207,7 +1196,6 @@
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    searchHelperRecent: document.getElementById('search-helper-recent'),
                     
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
@@ -6458,8 +6446,7 @@
                     searchHelper,
                     searchHelperIcon,
                     searchHelperPopup,
-                    searchHelperClose,
-                    searchHelperRecent
+                    searchHelperClose
                 } = Utils.elements;
 
                 const modifierLinks = document.querySelectorAll('.modifier-link');
@@ -6472,47 +6459,21 @@
                     Grid.performSearch();
                 };
 
-                if (!searchHelper || !searchHelperIcon || !searchHelperPopup) {
-                    modifierLinks.forEach(link => {
-                        link.addEventListener('click', (event) => {
-                            event.preventDefault();
-                            const modifier = link.dataset.modifier;
-                            if (!modifier) return;
-                            appendModifierToInput(modifier);
-                        });
-                    });
-                    return;
-                }
+                if (searchHelper && searchHelperIcon && searchHelperPopup) {
+                    const setHelperState = (isOpen) => {
+                        const open = Boolean(isOpen);
+                        searchHelper.classList.toggle('is-open', open);
+                        searchHelperPopup.setAttribute('aria-hidden', String(!open));
+                        searchHelperIcon.setAttribute('aria-expanded', String(open));
+                    };
+                    const closeHelper = (focusIcon = false) => {
+                        setHelperState(false);
+                        if (focusIcon) {
+                            searchHelperIcon.focus();
+                        }
+                    };
+                    const openHelper = () => setHelperState(true);
 
-                const hoverMedia = window.matchMedia('(hover: hover)');
-                const setHelperState = (isOpen) => {
-                    const open = Boolean(isOpen);
-                    searchHelper.classList.toggle('is-open', open);
-                    searchHelperPopup.setAttribute('aria-hidden', String(!open));
-                    searchHelperIcon.setAttribute('aria-expanded', String(open));
-                };
-                const resetRecentModifier = () => {
-                    if (!searchHelperRecent) return;
-                    searchHelperRecent.innerHTML = '';
-                    searchHelperRecent.classList.add('hidden');
-                };
-                const closeHelper = (focusIcon = false) => {
-                    setHelperState(false);
-                    resetRecentModifier();
-                    if (focusIcon && searchHelperIcon) {
-                        searchHelperIcon.focus();
-                    }
-                };
-                const openHelper = () => setHelperState(true);
-
-                if (hoverMedia.matches) {
-                    searchHelper.addEventListener('mouseenter', openHelper);
-                    searchHelperIcon.addEventListener('focus', openHelper);
-                    searchHelperIcon.addEventListener('click', (event) => {
-                        event.preventDefault();
-                        openHelper();
-                    });
-                } else {
                     searchHelperIcon.addEventListener('click', (event) => {
                         event.preventDefault();
                         if (searchHelper.classList.contains('is-open')) {
@@ -6521,67 +6482,46 @@
                             openHelper();
                         }
                     });
-                }
 
-                if (searchHelperClose) {
-                    searchHelperClose.addEventListener('click', (event) => {
-                        event.preventDefault();
-                        closeHelper(true);
-                    });
-                }
-
-                const showRecentModifier = (modifier) => {
-                    if (!searchHelperRecent) return;
-                    const pill = document.createElement('button');
-                    pill.type = 'button';
-                    pill.className = 'modifier-pill';
-                    pill.textContent = modifier;
-                    pill.addEventListener('click', () => {
-                        closeHelper(true);
-                    });
-                    searchHelperRecent.innerHTML = '';
-                    searchHelperRecent.appendChild(pill);
-                    searchHelperRecent.classList.remove('hidden');
-                };
-
-                const handleModifierSelection = (modifier) => {
-                    appendModifierToInput(modifier);
-                    if (hoverMedia.matches) {
-                        showRecentModifier(modifier);
-                        openHelper();
-                    } else {
-                        closeHelper();
+                    if (searchHelperClose) {
+                        searchHelperClose.addEventListener('click', (event) => {
+                            event.preventDefault();
+                            closeHelper(true);
+                        });
                     }
-                };
 
-                modifierLinks.forEach(link => {
-                    link.addEventListener('click', (event) => {
-                        event.preventDefault();
-                        const modifier = link.dataset.modifier;
-                        if (!modifier) return;
-                        handleModifierSelection(modifier);
+                    document.addEventListener('click', (event) => {
+                        if (!searchHelper.contains(event.target)) {
+                            closeHelper();
+                        }
                     });
-                });
 
-                document.addEventListener('click', (event) => {
-                    if (!searchHelper.contains(event.target)) {
-                        closeHelper();
-                    }
-                });
+                    const handleEscape = (event) => {
+                        if (event.key === 'Escape') {
+                            closeHelper(true);
+                        }
+                    };
+                    searchHelperIcon.addEventListener('keydown', handleEscape);
+                    searchHelperPopup.addEventListener('keydown', handleEscape);
 
-                const handleEscape = (event) => {
-                    if (event.key === 'Escape') {
-                        closeHelper(true);
-                    }
-                };
-                searchHelperIcon.addEventListener('keydown', handleEscape);
-                searchHelperPopup.addEventListener('keydown', handleEscape);
-
-                const handleMediaChange = () => closeHelper();
-                if (typeof hoverMedia.addEventListener === 'function') {
-                    hoverMedia.addEventListener('change', handleMediaChange);
-                } else if (typeof hoverMedia.addListener === 'function') {
-                    hoverMedia.addListener(handleMediaChange);
+                    modifierLinks.forEach(link => {
+                        link.addEventListener('click', (event) => {
+                            event.preventDefault();
+                            const modifier = link.dataset.modifier;
+                            if (!modifier) return;
+                            appendModifierToInput(modifier);
+                            closeHelper();
+                        });
+                    });
+                } else {
+                    modifierLinks.forEach(link => {
+                        link.addEventListener('click', (event) => {
+                            event.preventDefault();
+                            const modifier = link.dataset.modifier;
+                            if (!modifier) return;
+                            appendModifierToInput(modifier);
+                        });
+                    });
                 }
             },
             setupActionButtons() {


### PR DESCRIPTION
## Summary
- remove the search helper recent modifier UI from ui-v2.html
- simplify setupSearchFunctionality to insert modifiers directly and close the helper
- drop unused modifier pill styles from the CSS block

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db05f070dc832d8e3be6ba01aea14e