### PR TITLE
### failed Fix clear search button layout

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -309,10 +309,21 @@
             flex-grow: 1; padding: 6px 30px 6px 10px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 14px;
         }
         #clear-search-btn {
-            position: absolute; right: 24px; top: 50%; transform: translateY(-50%);
-            color: #9ca3af; cursor: pointer; display: none;
+            display: none;
+            color: #9ca3af;
+            cursor: pointer;
+            background: transparent;
+            border: none;
+            padding: 4px;
+            border-radius: 6px;
+            line-height: 0;
         }
-        #clear-search-btn:hover { color: #6b7280; }
+        #clear-search-btn:hover,
+        #clear-search-btn:focus-visible { color: #6b7280; }
+        #clear-search-btn:focus-visible {
+            outline: 2px solid #3b82f6;
+            outline-offset: 2px;
+        }
         
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
@@ -4983,7 +4994,7 @@
             performSearch() {
                 const searchInput = Utils.elements.omniSearch;
                 const query = searchInput.value.trim();
-                Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
+                Utils.elements.clearSearchBtn.style.display = query ? 'inline-flex' : 'none';
                 state.grid.selected = [];
                 if (!query) { this.resetSearch(); return; }
 

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -309,10 +309,21 @@
             flex-grow: 1; padding: 6px 30px 6px 10px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 14px;
         }
         #clear-search-btn {
-            position: absolute; right: 24px; top: 50%; transform: translateY(-50%);
-            color: #9ca3af; cursor: pointer; display: none;
+            display: none;
+            color: #9ca3af;
+            cursor: pointer;
+            background: transparent;
+            border: none;
+            padding: 4px;
+            border-radius: 6px;
+            line-height: 0;
         }
-        #clear-search-btn:hover { color: #6b7280; }
+        #clear-search-btn:hover,
+        #clear-search-btn:focus-visible { color: #6b7280; }
+        #clear-search-btn:focus-visible {
+            outline: 2px solid #3b82f6;
+            outline-offset: 2px;
+        }
         
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
@@ -5612,7 +5623,7 @@
             
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
-                Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
+                Utils.elements.clearSearchBtn.style.display = query ? 'inline-flex' : 'none';
                 if (!query) { this.resetSearch(); return; }
 
                 const results = this.searchImages(query);


### PR DESCRIPTION
## Summary
- restyle the clear search button in both UI variants to remove absolute positioning and keep the helper trigger tappable
- add focus styling and inline-flex display handling so the clear control aligns with the flex layout when shown

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db400051fc832d998532228fe38662