### PR TITLE
Align trash pill stack switching behavior

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -7153,14 +7153,10 @@
                             if (state.haptic) { state.haptic.triggerFeedback('pillTap'); }
 
                             const wasDifferentStack = state.currentStack !== stackName;
-                            const comingFromSortMode = !state.isFocusMode;
 
                             if (stackName === 'trash') {
                                 if (wasDifferentStack) {
                                     await UI.switchToStack(stackName);
-                                    if (comingFromSortMode) {
-                                        Grid.open(stackName);
-                                    }
                                 } else {
                                     Grid.open(stackName);
                                 }


### PR DESCRIPTION
## Summary
- update trash pill handling to mirror other stacks
- only open the grid when the trash stack is already active while keeping feedback and acknowledgements intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db43e74edc832dbbabf16c68de8918