### PR TITLE
Preserve stack order on close

### DIFF
--- a/index.html
+++ b/index.html
@@ -3509,18 +3509,25 @@
 
             async reorderStackOnClose() {
                 const stackArray = state.stacks[state.grid.stack];
-                let topItems = []; let bottomItems = [];
+                if (!Array.isArray(stackArray)) { return; }
+
+                let topItems = [];
+                let bottomItems = [];
 
                 if (state.grid.filtered.length > 0) {
                     const filteredIds = new Set(state.grid.filtered.map(f => f.id));
-                    topItems = state.grid.filtered.sort((a, b) => a.name.localeCompare(b.name));
-                    bottomItems = stackArray.filter(f => !filteredIds.has(f.id));
+                    stackArray.forEach(file => {
+                        if (filteredIds.has(file.id)) { topItems.push(file); }
+                        else { bottomItems.push(file); }
+                    });
                 } else if (state.grid.selected.length > 0) {
                     const selectedIds = new Set(state.grid.selected);
-                    topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
-                    bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
+                    stackArray.forEach(file => {
+                        if (selectedIds.has(file.id)) { topItems.push(file); }
+                        else { bottomItems.push(file); }
+                    });
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
                 

--- a/ui.html
+++ b/ui.html
@@ -2729,18 +2729,25 @@
 
             async reorderStackOnClose() {
                 const stackArray = state.stacks[state.grid.stack];
-                let topItems = []; let bottomItems = [];
+                if (!Array.isArray(stackArray)) { return; }
+
+                let topItems = [];
+                let bottomItems = [];
 
                 if (state.grid.filtered.length > 0) {
                     const filteredIds = new Set(state.grid.filtered.map(f => f.id));
-                    topItems = state.grid.filtered.sort((a, b) => a.name.localeCompare(b.name));
-                    bottomItems = stackArray.filter(f => !filteredIds.has(f.id));
+                    stackArray.forEach(file => {
+                        if (filteredIds.has(file.id)) { topItems.push(file); }
+                        else { bottomItems.push(file); }
+                    });
                 } else if (state.grid.selected.length > 0) {
                     const selectedIds = new Set(state.grid.selected);
-                    topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
-                    bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
+                    stackArray.forEach(file => {
+                        if (selectedIds.has(file.id)) { topItems.push(file); }
+                        else { bottomItems.push(file); }
+                    });
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
                 


### PR DESCRIPTION
## Summary
- update Grid.reorderStackOnClose to keep filtered and selected items in their existing stack order
- ensure stack reordering exits early when no stack data is available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db05fb80bc832dbbe852ac933aeb6b