### PR TITLE
Adjust tag input styling defaults

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -41,17 +41,27 @@
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
         
-        .input, .notes-textarea, .tag-input {
+        .input, .notes-textarea {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
         }
-        .input::placeholder, .tag-input::placeholder { color: rgba(255, 255, 255, 0.5); }
+        .input::placeholder { color: rgba(255, 255, 255, 0.5); }
         .input:focus, .notes-textarea:focus, .tag-input:focus {
             outline: none; border-color: var(--accent); box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.2);
         }
+        .tag-input {
+            width: 100%; padding: 12px 16px; border: 1px solid #d1d5db; border-radius: 12px;
+            background: #f9fafb; color: #111827; font-size: 14px; margin-bottom: 16px;
+        }
+        .tag-input::placeholder { color: #9ca3af; }
         .notes-textarea { min-height: 120px; font-family: inherit; resize: vertical; color: black; }
 
-        #action-modal .tag-input, #grid-modal .input {
+        .screen .tag-input {
+            color: white; background: var(--glass); border-color: var(--border); backdrop-filter: blur(10px);
+        }
+        .screen .tag-input::placeholder { color: rgba(255, 255, 255, 0.6); }
+
+        #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
         


### PR DESCRIPTION
## Summary
- update the default tag input styling to use the black/gray palette and dark text
- add a specific override for tag inputs on dark overlay screens while keeping modal tag fields light themed

## Testing
- not run (CSS change only)


------
https://chatgpt.com/codex/tasks/task_e_68db06034a6c832da869f73a954428ee