### PR TITLE
Cache folder context during metadata processing

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -4738,6 +4738,7 @@
                 }
             },
             async processAllMetadata(files, isFirstLoad = false) {
+                const context = App.getCurrentFolderContext();
                 if (isFirstLoad) Utils.updateLoadingProgress(0, files.length, 'Processing files...');
                 for (let i = 0; i < files.length; i++) {
                     const file = files[i];
@@ -4748,7 +4749,7 @@
                         } else {
                             const defaultMetadata = this.generateDefaultMetadata(file);
                             Object.assign(file, defaultMetadata);
-                            await state.dbManager.saveMetadata(file.id, defaultMetadata, App.getCurrentFolderContext());
+                            await state.dbManager.saveMetadata(file.id, defaultMetadata, context);
                         }
                     } catch (error) {
                         console.error(`Failed to process metadata for ${file.name}:`, error);
@@ -4962,9 +4963,8 @@
             async processFileMetadata(file) {
                 if (file.metadataStatus === 'loaded' || file.metadataStatus === 'loading' || file.metadataStatus === 'error') return;
                 file.metadataStatus = 'loading';
-                let context = null;
+                const context = App.getCurrentFolderContext();
                 try {
-                    context = App.getCurrentFolderContext();
                     const metadata = await state.metadataExtractor.fetchMetadata(file);
                     let finalMetadata = { ...file };
                     if (metadata.error) {
@@ -4984,7 +4984,6 @@
                     file.extractedMetadata = { 'Error': error.message };
                     file.prompt = `Metadata Error: ${error.message}`;
                     try {
-                        context = context || App.getCurrentFolderContext();
                         await state.dbManager.saveMetadata(file.id, file, context);
                     } catch (ctxError) {
                         console.error(`Failed to persist fallback metadata for ${file.name}:`, ctxError);


### PR DESCRIPTION
## Summary
- cache the current folder context before iterating through metadata processing loops
- reuse the cached context when persisting default or fallback metadata so each save shares the same object

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db062ad5b8832da8f3e85ca2970e0d