### PR TITLE
Await sync manager shutdown when returning to provider selection

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -3867,8 +3867,17 @@
                     authButton.textContent = `Connect ${isGoogle ? 'Drive' : 'OneDrive'}`;
                 }
             },
-            backToProviderSelection() {
-                if(state.syncManager) state.syncManager.stop();
+            async backToProviderSelection() {
+                try {
+                    if (state.syncManager) {
+                        if (typeof state.syncManager.flush === 'function') {
+                            await state.syncManager.flush({ reason: 'provider-switch' });
+                        }
+                        await state.syncManager.stop();
+                    }
+                } catch (error) {
+                    state.syncLog?.log?.({ event: 'provider:back:error', level: 'error', details: `Failed to stop sync manager: ${error.message}` });
+                }
                 state.provider = null;
                 state.providerType = null;
                 state.syncManager?.setProviderContext({ provider: null, providerType: null });


### PR DESCRIPTION
## Summary
- make App.backToProviderSelection async so the sync manager can flush pending work
- await a provider-switch flush and sync manager shutdown before clearing provider context
- log an error through the sync log if stopping the sync manager fails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db062d85b8832d826904c109477cf1