### PR TITLE
Keep focus mode active when stacks empty

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -4619,11 +4619,30 @@
                     this.updateStackCounts();
                     const updatedStack = state.stacks[currentStackName] || [];
                     if (updatedStack.length === 0) {
-                        state.currentStackPosition = 0;
-                        if (state.isFocusMode && exitFocusIfEmpty) {
-                            Gestures.toggleFocusMode();
+                        const findNextStackWithItems = () => {
+                            if (!Array.isArray(STACKS)) return null;
+                            const startIndex = STACKS.indexOf(currentStackName);
+                            const orderedCandidates = startIndex === -1
+                                ? STACKS
+                                : [...STACKS.slice(startIndex + 1), ...STACKS.slice(0, startIndex)];
+                            return orderedCandidates.find(stack => {
+                                if (stack === currentStackName) return false;
+                                const candidateStack = state.stacks[stack];
+                                return Array.isArray(candidateStack) && candidateStack.length > 0;
+                            }) || null;
+                        };
+
+                        const nextStack = findNextStackWithItems();
+                        if (nextStack) {
+                            state.currentStack = nextStack;
+                            state.currentStackPosition = 0;
+                            await this.displayCurrentImage();
+                            this.updateActiveProxTab();
+                        } else {
+                            state.currentStackPosition = 0;
+                            this.showEmptyState();
+                            this.updateActiveProxTab();
                         }
-                        this.showEmptyState();
                     } else {
                         const nextIndex = Math.min(removedIndex, updatedStack.length - 1);
                         state.currentStackPosition = Math.max(0, nextIndex);

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -5260,11 +5260,30 @@
                     this.updateStackCounts();
                     const updatedStack = state.stacks[currentStackName] || [];
                     if (updatedStack.length === 0) {
-                        state.currentStackPosition = 0;
-                        if (state.isFocusMode && exitFocusIfEmpty) {
-                            Gestures.toggleFocusMode();
+                        const findNextStackWithItems = () => {
+                            if (!Array.isArray(STACKS)) return null;
+                            const startIndex = STACKS.indexOf(currentStackName);
+                            const orderedCandidates = startIndex === -1
+                                ? STACKS
+                                : [...STACKS.slice(startIndex + 1), ...STACKS.slice(0, startIndex)];
+                            return orderedCandidates.find(stack => {
+                                if (stack === currentStackName) return false;
+                                const candidateStack = state.stacks[stack];
+                                return Array.isArray(candidateStack) && candidateStack.length > 0;
+                            }) || null;
+                        };
+
+                        const nextStack = findNextStackWithItems();
+                        if (nextStack) {
+                            state.currentStack = nextStack;
+                            state.currentStackPosition = 0;
+                            await this.displayCurrentImage();
+                            this.updateActiveProxTab();
+                        } else {
+                            state.currentStackPosition = 0;
+                            this.showEmptyState();
+                            this.updateActiveProxTab();
                         }
-                        this.showEmptyState();
                     } else {
                         state.currentStackPosition = 0;
                         await this.displayCurrentImage();


### PR DESCRIPTION
## Summary
- keep focus mode active when deleting the last image in a stack in ui-v9b by searching for another populated stack before showing the empty state
- mirror the updated empty-stack deletion handling in ui-v2 so focus mode controls remain reachable across versions

## Testing
- not run (manual testing recommended)

------
https://chatgpt.com/codex/tasks/task_e_68db43ecb8dc832db1336868c871b693