### PR TITLE
Use folder context for delete cache persistence

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -4852,7 +4852,8 @@
                 const stackLabel = stackBefore ? (STACK_NAMES[stackBefore] || stackBefore) : null;
                 const fileName = name || file?.name || '';
                 const persistState = async () => {
-                    await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
+                    const context = App.getCurrentFolderContext();
+                    await state.dbManager.saveFolderCache(context.folderId, state.imageFiles);
                 };
                 const restoreState = async (reason) => {
                     if (!file) { return false; }


### PR DESCRIPTION
## Summary
- ensure App.deleteFile resolves the current folder context before persisting the cache during deletions

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68db44a5eab0832d805ca50dc3c3caaa