### PR TITLE
Align trash pill behavior with other stacks

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -7191,9 +7191,9 @@
                             if (stackName === 'trash') {
                                 if (wasDifferentStack) {
                                     await UI.switchToStack(stackName);
-                                } else {
-                                    Grid.open(stackName);
+                                    return;
                                 }
+                                Grid.open(stackName);
                             } else if (!wasDifferentStack) {
                                 Grid.open(stackName);
                             } else {


### PR DESCRIPTION
## Summary
- update the trash pill handler to match the other stacks by only opening the grid when the trash stack is already active

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db918893e4832d8bdd44eda9ddf9b0