### PR TITLE
Fix trash pill grid activation timing

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -7175,6 +7175,7 @@
                 Utils.elements.selectAnotherFolderBtn.addEventListener('click', () => { App.returnToFolderSelection(); });
             },
             setupPillCounters() {
+                let skipNextGridOpen = false;
                 STACKS.forEach(stackName => {
                     const pill = document.getElementById(`pill-${stackName}`);
                     if (pill) {
@@ -7190,13 +7191,23 @@
 
                             if (stackName === 'trash') {
                                 if (wasDifferentStack) {
+                                    skipNextGridOpen = true;
                                     await UI.switchToStack(stackName);
                                 } else {
-                                    Grid.open(stackName);
+                                    const shouldSkip = skipNextGridOpen && !state.isFocusMode;
+                                    skipNextGridOpen = false;
+                                    if (!shouldSkip) {
+                                        Grid.open(stackName);
+                                    }
                                 }
                             } else if (!wasDifferentStack) {
-                                Grid.open(stackName);
+                                const shouldSkip = skipNextGridOpen && !state.isFocusMode;
+                                skipNextGridOpen = false;
+                                if (!shouldSkip) {
+                                    Grid.open(stackName);
+                                }
                             } else {
+                                skipNextGridOpen = true;
                                 return UI.switchToStack(stackName);
                             }
 


### PR DESCRIPTION
## Summary
- add a guard to skip the automatic grid popup right after switching stacks
- make the trash pill follow the same switch-vs-open logic as other stacks while preserving pointer guards

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db918f3e1c832d97ab405e66a0eb1b