### PR TITLE
Ensure FolderSyncCoordinator is available before wiring delta handling

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -1084,7 +1084,7 @@
         const state = {
             provider: null, providerType: null, dbManager: null, metadataExtractor: null,
             syncManager: null,
-            folderSyncCoordinator: null,
+            folderSyncCoordinator: null, // wired up during init for manifest persistence + background deltas
             syncLog: null, visualCues: null, haptic: null, export: null, currentFolder: { id: null, name: '' },
             imageFiles: [], currentImageLoadId: null, currentStack: 'in', currentStackPosition: 0,
             isFocusMode: false, stacks: { in: [], out: [], priority: [], trash: [] },
@@ -6719,6 +6719,9 @@
                 state.dbManager = new DBManager();
                 await state.dbManager.init();
                 state.syncManager = new SyncManager({ dbManager: state.dbManager, logger: state.syncLog });
+                if (typeof FolderSyncCoordinator !== 'function') {
+                    throw new Error('FolderSyncCoordinator is unavailable in this build.');
+                }
                 state.folderSyncCoordinator = new FolderSyncCoordinator({ dbManager: state.dbManager, logger: state.syncLog });
                 state.folderSyncCoordinator.setDeltaHandler(payload => App.applyDeltaFromCoordinator(payload));
                 state.metadataExtractor = new MetadataExtractor();


### PR DESCRIPTION
## Summary
- clarify the folderSyncCoordinator slot in the shared state for delta handling
- guard FolderSyncCoordinator initialization so the UI fails fast if the class is unavailable
- continue wiring the coordinator to App.applyDeltaFromCoordinator for manifest persistence updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db92b2b208832da0b86d21ad513e9e