### PR TITLE
Fix skipNextGridOpen logic for pointer stack switching in ui-v9b

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -7192,6 +7192,13 @@
                     if (pill) {
                         let pointerActivated = false;
                         const activatePill = async (event) => {
+                            const isPointerInvocation = Boolean(
+                                pointerActivated ||
+                                (event && (
+                                    (typeof event.pointerType === 'string' && event.pointerType) ||
+                                    (typeof PointerEvent !== 'undefined' && event instanceof PointerEvent)
+                                ))
+                            );
                             if (event) {
                                 if (typeof event.preventDefault === 'function') { event.preventDefault(); }
                                 event.stopPropagation();
@@ -7199,10 +7206,11 @@
                             if (state.haptic) { state.haptic.triggerFeedback('pillTap'); }
 
                             const wasDifferentStack = state.currentStack !== stackName;
+                            const shouldSetSkipNext = wasDifferentStack && !isPointerInvocation;
 
                             if (stackName === 'trash') {
                                 if (wasDifferentStack) {
-                                    skipNextGridOpen = true;
+                                    skipNextGridOpen = shouldSetSkipNext;
                                     await UI.switchToStack(stackName);
                                 }
                                 Grid.open(stackName);
@@ -7213,7 +7221,7 @@
                                     Grid.open(stackName);
                                 }
                             } else {
-                                skipNextGridOpen = true;
+                                skipNextGridOpen = shouldSetSkipNext;
                                 return UI.switchToStack(stackName);
                             }
 


### PR DESCRIPTION
## Summary
- ensure skipNextGridOpen is only set for non-pointer stack switches so pointer taps reopen the grid immediately
- retain the guard preventing duplicate Grid.open calls for synthetic or non-pointer activations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db9a78b808832d8a4cf862d161b798