### PR TITLE
Update V9b footer metadata and actions

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -1,4 +1,4 @@
-<!-- Release: 2024-05-06T00:00:00Z | R1 Baseline Convergence | Footer standardization & schema alignment -->
+<!-- Release: 2024-05-08T00:00:00Z | V9b UI Improvements | Footer standardization and … -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1038,9 +1038,9 @@
         // ===== ORBITAL8 Goji Version - App Root =====
         
         const RELEASE_METADATA = Object.freeze({
-            name: 'R1 Baseline Convergence',
-            timestamp: '2024-05-06T00:00:00Z',
-            summary: 'Footer standardization & schema alignment'
+            name: 'V9b UI Improvements',
+            timestamp: '2024-05-08T00:00:00Z',
+            summary: 'Footer standardization and …'
         });
 
         const Templates = {
@@ -1049,15 +1049,16 @@
                 const metadataText = [
                     RELEASE_METADATA.name,
                     RELEASE_METADATA.timestamp,
-                    RELEASE_METADATA.summary
-                ].filter(Boolean).join(' • ');
+                    'View Synch Log',
+                    'Reset Cloud'
+                ].filter(Boolean).join(' | ');
 
                 return `
                     <footer id="master-footer${suffix}" class="master-footer" data-master-footer role="contentinfo">
                         <span class="footer-meta" aria-label="Release metadata">${metadataText}</span>
                         <span class="footer-actions">
-                            <button type="button" class="footer-link" data-footer-role="sync-log">View Sync Log</button>
-                            <button type="button" class="footer-link" data-footer-role="reset-folder">Reset from Cloud</button>
+                            <button type="button" class="footer-link" data-footer-role="sync-log">View Synch Log</button>
+                            <button type="button" class="footer-link" data-footer-role="reset-folder">Reset Cloud</button>
                         </span>
                     </footer>
                 `.trim();


### PR DESCRIPTION
## Summary
- update the V9b release banner and metadata to reference the UI Improvements drop
- switch the footer metadata string to pipe separators and the updated action labels
- rename the footer buttons to "View Synch Log" and "Reset Cloud"

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbf90ff9c8832d9239a9828ad7f817