### PR TITLE
Preserve viewer selection after deletions

### DIFF
--- a/performance-v1.html
+++ b/performance-v1.html
@@ -4616,7 +4616,8 @@
                     state.currentStackPosition = 0;
                 }
 
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) {
                     this.showEmptyState();
                     return;
@@ -4769,7 +4770,8 @@
                 const currentStackName = state.currentStack;
                 const currentStackArray = state.stacks[currentStackName];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) return;
 
                 state.isImageTransitioning = true;
@@ -4805,11 +4807,18 @@
                         }
                         this.showEmptyState();
                     } else {
-                        state.currentStackPosition = 0;
+                        let nextIndex = previousPosition;
+                        if (nextIndex >= updatedStack.length) {
+                            nextIndex = updatedStack.length - 1;
+                        }
+                        if (nextIndex < 0) {
+                            nextIndex = 0;
+                        }
+                        state.currentStackPosition = nextIndex;
                         await this.displayCurrentImage();
                     }
                     Utils.showToast('Moved to provider recycle bin. Restore it from your cloud trash if needed.', 'info', true);
-                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: true });
+                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: false });
                 } catch (error) {
                     Utils.showToast(`Failed to delete ${currentFile.name}`, 'error', true);
                 } finally {

--- a/performance.html
+++ b/performance.html
@@ -4539,7 +4539,8 @@
                     state.currentStackPosition = 0;
                 }
 
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) {
                     this.showEmptyState();
                     return;
@@ -4692,7 +4693,8 @@
                 const currentStackName = state.currentStack;
                 const currentStackArray = state.stacks[currentStackName];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) return;
 
                 state.isImageTransitioning = true;
@@ -4728,11 +4730,18 @@
                         }
                         this.showEmptyState();
                     } else {
-                        state.currentStackPosition = 0;
+                        let nextIndex = previousPosition;
+                        if (nextIndex >= updatedStack.length) {
+                            nextIndex = updatedStack.length - 1;
+                        }
+                        if (nextIndex < 0) {
+                            nextIndex = 0;
+                        }
+                        state.currentStackPosition = nextIndex;
                         await this.displayCurrentImage();
                     }
                     Utils.showToast('Moved to provider recycle bin. Restore it from your cloud trash if needed.', 'info', true);
-                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: true });
+                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: false });
                 } catch (error) {
                     Utils.showToast(`Failed to delete ${currentFile.name}`, 'error', true);
                 } finally {

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -4538,7 +4538,8 @@
                     state.currentStackPosition = 0;
                 }
 
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) {
                     this.showEmptyState();
                     return;
@@ -4691,7 +4692,8 @@
                 const currentStackName = state.currentStack;
                 const currentStackArray = state.stacks[currentStackName];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) return;
 
                 state.isImageTransitioning = true;
@@ -4727,11 +4729,18 @@
                         }
                         this.showEmptyState();
                     } else {
-                        state.currentStackPosition = 0;
+                        let nextIndex = previousPosition;
+                        if (nextIndex >= updatedStack.length) {
+                            nextIndex = updatedStack.length - 1;
+                        }
+                        if (nextIndex < 0) {
+                            nextIndex = 0;
+                        }
+                        state.currentStackPosition = nextIndex;
                         await this.displayCurrentImage();
                     }
                     Utils.showToast('Moved to provider recycle bin. Restore it from your cloud trash if needed.', 'info', true);
-                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: true });
+                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: false });
                 } catch (error) {
                     Utils.showToast(`Failed to delete ${currentFile.name}`, 'error', true);
                 } finally {

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -4538,7 +4538,8 @@
                     state.currentStackPosition = 0;
                 }
 
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) {
                     this.showEmptyState();
                     return;
@@ -4691,7 +4692,8 @@
                 const currentStackName = state.currentStack;
                 const currentStackArray = state.stacks[currentStackName];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) return;
 
                 state.isImageTransitioning = true;
@@ -4727,11 +4729,18 @@
                         }
                         this.showEmptyState();
                     } else {
-                        state.currentStackPosition = 0;
+                        let nextIndex = previousPosition;
+                        if (nextIndex >= updatedStack.length) {
+                            nextIndex = updatedStack.length - 1;
+                        }
+                        if (nextIndex < 0) {
+                            nextIndex = 0;
+                        }
+                        state.currentStackPosition = nextIndex;
                         await this.displayCurrentImage();
                     }
                     Utils.showToast('Moved to provider recycle bin. Restore it from your cloud trash if needed.', 'info', true);
-                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: true });
+                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: false });
                 } catch (error) {
                     Utils.showToast(`Failed to delete ${currentFile.name}`, 'error', true);
                 } finally {

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -2701,7 +2701,8 @@
                     state.currentStackPosition = 0;
                 }
 
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) {
                     this.showEmptyState();
                     return;
@@ -2834,7 +2835,8 @@
                 const currentStackName = state.currentStack;
                 const currentStackArray = state.stacks[currentStackName];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) return;
 
                 state.isImageTransitioning = true;
@@ -2852,10 +2854,17 @@
                         }
                         this.showEmptyState();
                     } else {
-                        state.currentStackPosition = 0;
+                        let nextIndex = previousPosition;
+                        if (nextIndex >= updatedStack.length) {
+                            nextIndex = updatedStack.length - 1;
+                        }
+                        if (nextIndex < 0) {
+                            nextIndex = 0;
+                        }
+                        state.currentStackPosition = nextIndex;
                         await this.displayCurrentImage();
                     }
-                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: true });
+                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: false });
                 } catch (error) {
                     Utils.showToast(`Failed to delete ${currentFile.name}`, 'error', true);
                 } finally {

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -3377,7 +3377,8 @@
                     state.currentStackPosition = 0;
                 }
 
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) {
                     this.showEmptyState();
                     return;
@@ -3530,7 +3531,8 @@
                 const currentStackName = state.currentStack;
                 const currentStackArray = state.stacks[currentStackName];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) return;
 
                 state.isImageTransitioning = true;
@@ -3566,11 +3568,18 @@
                         }
                         this.showEmptyState();
                     } else {
-                        state.currentStackPosition = 0;
+                        let nextIndex = previousPosition;
+                        if (nextIndex >= updatedStack.length) {
+                            nextIndex = updatedStack.length - 1;
+                        }
+                        if (nextIndex < 0) {
+                            nextIndex = 0;
+                        }
+                        state.currentStackPosition = nextIndex;
                         await this.displayCurrentImage();
                     }
                     Utils.showToast('Moved to provider recycle bin. Restore it from your cloud trash if needed.', 'info', true);
-                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: true });
+                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: false });
                 } catch (error) {
                     Utils.showToast(`Failed to delete ${currentFile.name}`, 'error', true);
                 } finally {

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -3377,7 +3377,8 @@
                     state.currentStackPosition = 0;
                 }
 
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) {
                     this.showEmptyState();
                     return;
@@ -3530,7 +3531,8 @@
                 const currentStackName = state.currentStack;
                 const currentStackArray = state.stacks[currentStackName];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) return;
 
                 state.isImageTransitioning = true;
@@ -3566,11 +3568,18 @@
                         }
                         this.showEmptyState();
                     } else {
-                        state.currentStackPosition = 0;
+                        let nextIndex = previousPosition;
+                        if (nextIndex >= updatedStack.length) {
+                            nextIndex = updatedStack.length - 1;
+                        }
+                        if (nextIndex < 0) {
+                            nextIndex = 0;
+                        }
+                        state.currentStackPosition = nextIndex;
                         await this.displayCurrentImage();
                     }
                     Utils.showToast('Moved to provider recycle bin. Restore it from your cloud trash if needed.', 'info', true);
-                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: true });
+                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: false });
                 } catch (error) {
                     Utils.showToast(`Failed to delete ${currentFile.name}`, 'error', true);
                 } finally {

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -4538,7 +4538,8 @@
                     state.currentStackPosition = 0;
                 }
 
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) {
                     this.showEmptyState();
                     return;
@@ -4691,7 +4692,8 @@
                 const currentStackName = state.currentStack;
                 const currentStackArray = state.stacks[currentStackName];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) return;
 
                 state.isImageTransitioning = true;
@@ -4727,11 +4729,18 @@
                         }
                         this.showEmptyState();
                     } else {
-                        state.currentStackPosition = 0;
+                        let nextIndex = previousPosition;
+                        if (nextIndex >= updatedStack.length) {
+                            nextIndex = updatedStack.length - 1;
+                        }
+                        if (nextIndex < 0) {
+                            nextIndex = 0;
+                        }
+                        state.currentStackPosition = nextIndex;
                         await this.displayCurrentImage();
                     }
                     Utils.showToast('Moved to provider recycle bin. Restore it from your cloud trash if needed.', 'info', true);
-                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: true });
+                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: false });
                 } catch (error) {
                     Utils.showToast(`Failed to delete ${currentFile.name}`, 'error', true);
                 } finally {

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -4538,7 +4538,8 @@
                     state.currentStackPosition = 0;
                 }
 
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) {
                     this.showEmptyState();
                     return;
@@ -4691,7 +4692,8 @@
                 const currentStackName = state.currentStack;
                 const currentStackArray = state.stacks[currentStackName];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) return;
 
                 state.isImageTransitioning = true;
@@ -4727,11 +4729,18 @@
                         }
                         this.showEmptyState();
                     } else {
-                        state.currentStackPosition = 0;
+                        let nextIndex = previousPosition;
+                        if (nextIndex >= updatedStack.length) {
+                            nextIndex = updatedStack.length - 1;
+                        }
+                        if (nextIndex < 0) {
+                            nextIndex = 0;
+                        }
+                        state.currentStackPosition = nextIndex;
                         await this.displayCurrentImage();
                     }
                     Utils.showToast('Moved to provider recycle bin. Restore it from your cloud trash if needed.', 'info', true);
-                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: true });
+                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: false });
                 } catch (error) {
                     Utils.showToast(`Failed to delete ${currentFile.name}`, 'error', true);
                 } finally {

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -4583,7 +4583,8 @@
                     state.currentStackPosition = 0;
                 }
 
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) {
                     this.showEmptyState();
                     return;
@@ -4736,7 +4737,8 @@
                 const currentStackName = state.currentStack;
                 const currentStackArray = state.stacks[currentStackName];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) return;
 
                 state.isImageTransitioning = true;
@@ -4772,11 +4774,18 @@
                         }
                         this.showEmptyState();
                     } else {
-                        state.currentStackPosition = 0;
+                        let nextIndex = previousPosition;
+                        if (nextIndex >= updatedStack.length) {
+                            nextIndex = updatedStack.length - 1;
+                        }
+                        if (nextIndex < 0) {
+                            nextIndex = 0;
+                        }
+                        state.currentStackPosition = nextIndex;
                         await this.displayCurrentImage();
                     }
                     Utils.showToast('Moved to provider recycle bin. Restore it from your cloud trash if needed.', 'info', true);
-                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: true });
+                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: false });
                 } catch (error) {
                     Utils.showToast(`Failed to delete ${currentFile.name}`, 'error', true);
                 } finally {

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -4527,7 +4527,8 @@
                     state.currentStackPosition = 0;
                 }
 
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) {
                     this.showEmptyState();
                     return;
@@ -4680,7 +4681,8 @@
                 const currentStackName = state.currentStack;
                 const currentStackArray = state.stacks[currentStackName];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) return;
 
                 state.isImageTransitioning = true;
@@ -4716,11 +4718,18 @@
                         }
                         this.showEmptyState();
                     } else {
-                        state.currentStackPosition = 0;
+                        let nextIndex = previousPosition;
+                        if (nextIndex >= updatedStack.length) {
+                            nextIndex = updatedStack.length - 1;
+                        }
+                        if (nextIndex < 0) {
+                            nextIndex = 0;
+                        }
+                        state.currentStackPosition = nextIndex;
                         await this.displayCurrentImage();
                     }
                     Utils.showToast('Moved to provider recycle bin. Restore it from your cloud trash if needed.', 'info', true);
-                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: true });
+                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: false });
                 } catch (error) {
                     Utils.showToast(`Failed to delete ${currentFile.name}`, 'error', true);
                 } finally {

--- a/ui-v9a.htnl
+++ b/ui-v9a.htnl
@@ -4527,7 +4527,8 @@
                     state.currentStackPosition = 0;
                 }
 
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) {
                     this.showEmptyState();
                     return;
@@ -4680,7 +4681,8 @@
                 const currentStackName = state.currentStack;
                 const currentStackArray = state.stacks[currentStackName];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) return;
 
                 state.isImageTransitioning = true;
@@ -4716,11 +4718,18 @@
                         }
                         this.showEmptyState();
                     } else {
-                        state.currentStackPosition = 0;
+                        let nextIndex = previousPosition;
+                        if (nextIndex >= updatedStack.length) {
+                            nextIndex = updatedStack.length - 1;
+                        }
+                        if (nextIndex < 0) {
+                            nextIndex = 0;
+                        }
+                        state.currentStackPosition = nextIndex;
                         await this.displayCurrentImage();
                     }
                     Utils.showToast('Moved to provider recycle bin. Restore it from your cloud trash if needed.', 'info', true);
-                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: true });
+                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: false });
                 } catch (error) {
                     Utils.showToast(`Failed to delete ${currentFile.name}`, 'error', true);
                 } finally {

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -5107,7 +5107,8 @@
                     state.currentStackPosition = 0;
                 }
 
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) {
                     this.showEmptyState();
                     return;
@@ -5260,7 +5261,8 @@
                 const currentStackName = state.currentStack;
                 const currentStackArray = state.stacks[currentStackName];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                const currentFile = currentStackArray[state.currentStackPosition];
+                const previousPosition = state.currentStackPosition;
+                const currentFile = currentStackArray[previousPosition];
                 if (!currentFile) return;
 
                 state.isImageTransitioning = true;
@@ -5320,11 +5322,18 @@
                             }
                         }
                     } else {
-                        state.currentStackPosition = 0;
+                        let nextIndex = previousPosition;
+                        if (nextIndex >= updatedStack.length) {
+                            nextIndex = updatedStack.length - 1;
+                        }
+                        if (nextIndex < 0) {
+                            nextIndex = 0;
+                        }
+                        state.currentStackPosition = nextIndex;
                         await this.displayCurrentImage();
                     }
                     Utils.showToast('Moved to provider recycle bin. Restore it from your cloud trash if needed.', 'info', true);
-                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: true });
+                    Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: false });
                 } catch (error) {
                     Utils.showToast(`Failed to delete ${currentFile.name}`, 'error', true);
                 } finally {


### PR DESCRIPTION
## Summary
- track the previous stack index when removing an item so the next image is shown or the empty state appears when a stack is cleared
- stop grid sync from forcing the first item to be selected after deletions so any surviving selection is preserved

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbf9104154832db907120cf4ac408e