### PR TITLE
Reset grid scroll on open

### DIFF
--- a/index.html
+++ b/index.html
@@ -2978,6 +2978,7 @@
                 Utils.showModal('grid-modal');
                 Utils.elements.gridTitle.textContent = STACK_NAMES[stack] || stack;
                 state.grid.stack = stack;
+                Utils.elements.gridContent.scrollTop = 0;
                 state.grid.isDirty = false;
                 const value = Utils.elements.gridSize.value;
                 Utils.elements.gridContainer.style.gridTemplateColumns = `repeat(${value}, 1fr)`;


### PR DESCRIPTION
## Summary
- reset the grid modal scroll position whenever Grid.open assigns the stack

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbf911d63c832da1ec5a1fd6c6138a