### PR TITLE
Use pointer events for gesture handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -4037,6 +4037,8 @@
             hubPressActive: false,
             overlay: null,
             lastHubTap: { time: 0, x: 0, y: 0 },
+            activePointerId: null,
+            activePointerType: null,
             DOUBLE_TAP_MAX_INTERVAL: 320,
             DOUBLE_TAP_MAX_DISTANCE: 28,
             TAP_DISTANCE_THRESHOLD: 26,
@@ -4052,13 +4054,12 @@
                 this.initGestureOverlay();
             },
             setupEventListeners() {
-                Utils.elements.imageViewport.addEventListener('mousedown', this.handleStart.bind(this));
-                document.addEventListener('mousemove', this.handleMove.bind(this));
-                document.addEventListener('mouseup', this.handleEnd.bind(this));
-                Utils.elements.imageViewport.addEventListener('touchstart', this.handleStart.bind(this), { passive: false });
-                document.addEventListener('touchmove', this.handleMove.bind(this), { passive: false });
-                document.addEventListener('touchend', this.handleEnd.bind(this), { passive: false });
-                document.addEventListener('touchcancel', this.handleEnd.bind(this), { passive: false });
+                const viewport = Utils.elements.imageViewport;
+                if (!viewport) return;
+                viewport.addEventListener('pointerdown', this.handleStart.bind(this));
+                document.addEventListener('pointermove', this.handleMove.bind(this));
+                document.addEventListener('pointerup', this.handleEnd.bind(this));
+                document.addEventListener('pointercancel', this.handleEnd.bind(this));
             },
             setupPinchZoom() {
                 Utils.elements.centerImage.addEventListener('touchstart', this.handleTouchStart.bind(this), { passive: false });
@@ -4248,14 +4249,60 @@
                     Utils.showToast(`Flick failed: ${error.message}`, 'error', true);
                 }
             },
+            getPointerDetails(e, preferChangedTouches = false) {
+                if (e.pointerId !== undefined) {
+                    return {
+                        id: e.pointerId,
+                        type: e.pointerType || 'mouse',
+                        clientX: e.clientX,
+                        clientY: e.clientY
+                    };
+                }
+                const touchList = preferChangedTouches ? e.changedTouches : e.touches;
+                if (touchList && touchList.length) {
+                    const touch = touchList[0];
+                    return {
+                        id: touch.identifier,
+                        type: 'touch',
+                        clientX: touch.clientX,
+                        clientY: touch.clientY
+                    };
+                }
+                return {
+                    id: 'mouse',
+                    type: 'mouse',
+                    clientX: e.clientX,
+                    clientY: e.clientY
+                };
+            },
+            isActivePointer(e) {
+                if (this.activePointerId === null) return false;
+                if (e.pointerId !== undefined) {
+                    return e.pointerId === this.activePointerId;
+                }
+                if (e.changedTouches && e.changedTouches.length) {
+                    return Array.from(e.changedTouches).some(t => t.identifier === this.activePointerId);
+                }
+                return this.activePointerId === 'mouse';
+            },
+            resetActivePointer() {
+                this.activePointerId = null;
+                this.activePointerType = null;
+            },
             handleStart(e) {
-                if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
+                const pointer = this.getPointerDetails(e);
+                if (pointer.type === 'touch' && state.isPinching) return;
                 if (state.currentScale > 1.1) return;
-                const point = e.touches ? e.touches[0] : e;
-                const hubInteraction = this.isInHub(point.clientX, point.clientY);
+                if (pointer.type === 'touch' && e.isPrimary === false) return;
+                if (this.activePointerId !== null && this.activePointerId !== pointer.id) return;
+                if (this.activePointerType && this.activePointerType !== pointer.type) return;
+                if (pointer.type === 'touch' && e.touches && e.touches.length > 1) return;
+                const hubInteraction = this.isInHub(pointer.clientX, pointer.clientY);
                 if (!hubInteraction && state.stacks[state.currentStack].length === 0) return;
-                this.startPos = { x: point.clientX, y: point.clientY };
-                this.currentPos = { x: point.clientX, y: point.clientY };
+                this.activePointerId = pointer.id;
+                this.activePointerType = pointer.type;
+                this.startPos = { x: pointer.clientX, y: pointer.clientY };
+                this.currentPos = { x: pointer.clientX, y: pointer.clientY };
                 this.startTimestamp = performance.now();
                 this.gestureStarted = false;
                 state.isDragging = true;
@@ -4263,18 +4310,28 @@
                 if (!hubInteraction) {
                     Utils.elements.centerImage.classList.add('dragging');
                 }
-                this.spawnRipple(point.clientX, point.clientY);
-                this.queueTrail(point.clientX, point.clientY);
+                this.spawnRipple(pointer.clientX, pointer.clientY);
+                this.queueTrail(pointer.clientX, pointer.clientY);
             },
             handleMove(e) {
                 if (!state.isDragging) return;
+                if (this.activePointerId === null) return;
+                if (e.pointerId !== undefined && e.pointerId !== this.activePointerId) return;
+                if (this.activePointerType === 'touch' && state.isPinching) {
+                    state.isDragging = false;
+                    Utils.elements.centerImage.classList.remove('dragging');
+                    this.hideAllEdgeGlows();
+                    this.resetActivePointer();
+                    return;
+                }
                 if (e.touches && e.touches.length > 1) {
                     state.isDragging = false; Utils.elements.centerImage.classList.remove('dragging');
-                    this.hideAllEdgeGlows(); return;
+                    this.hideAllEdgeGlows(); this.resetActivePointer(); return;
                 }
                 e.preventDefault();
-                const point = e.touches ? e.touches[0] : e;
-                this.currentPos = { x: point.clientX, y: point.clientY };
+                const pointer = this.getPointerDetails(e);
+                this.currentPos = { x: pointer.clientX, y: pointer.clientY };
+                const point = pointer;
                 this.queueTrail(point.clientX, point.clientY);
                 if (this.hubPressActive) { return; }
                 if (state.imageFiles.length === 0) return;
@@ -4292,10 +4349,13 @@
                 }
             },
             handleEnd(e) {
-                if (!state.isDragging) return;
+                const matchesPointer = this.isActivePointer(e);
+                if (!matchesPointer) return;
+                if (!state.isDragging) { this.resetActivePointer(); return; }
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');
-                const point = e.changedTouches && e.changedTouches.length ? e.changedTouches[0] : e;
+                const pointer = this.getPointerDetails(e, true);
+                const point = pointer;
                 if (point) { this.currentPos = { x: point.clientX, y: point.clientY }; }
                 this.spawnTrail(this.currentPos.x, this.currentPos.y);
                 const deltaX = this.currentPos.x - this.startPos.x;
@@ -4326,6 +4386,7 @@
                     this.hideAllEdgeGlows();
                     this.hubPressActive = false;
                     this.gestureStarted = false;
+                    this.resetActivePointer();
                     return;
                 }
 
@@ -4351,6 +4412,7 @@
                 this.hideAllEdgeGlows();
                 this.hubPressActive = false;
                 this.gestureStarted = false;
+                this.resetActivePointer();
             },
             getDistance(touch1, touch2) { const dx = touch1.clientX - touch2.clientX; const dy = touch1.clientY - touch2.clientY; return Math.sqrt(dx * dx + dy * dy); },
             getCenter(touch1, touch2) { return { x: (touch1.clientX + touch2.clientX) / 2, y: (touch1.clientY + touch2.clientY) / 2 }; },

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -6423,7 +6423,8 @@
             hubPressActive: false,
             overlay: null,
             lastHubTap: { time: 0, x: 0, y: 0 },
-            tapHandled: false,
+            activePointerId: null,
+            activePointerType: null,
             DOUBLE_TAP_MAX_INTERVAL: 320,
             DOUBLE_TAP_MAX_DISTANCE: 28,
             TAP_DISTANCE_THRESHOLD: 26,
@@ -6438,13 +6439,12 @@
                 this.initGestureOverlay();
             },
             setupEventListeners() {
-                Utils.elements.imageViewport.addEventListener('mousedown', this.handleStart.bind(this));
-                document.addEventListener('mousemove', this.handleMove.bind(this));
-                document.addEventListener('mouseup', this.handleEnd.bind(this));
-                Utils.elements.imageViewport.addEventListener('touchstart', this.handleStart.bind(this), { passive: false });
-                document.addEventListener('touchmove', this.handleMove.bind(this), { passive: false });
-                document.addEventListener('touchend', this.handleEnd.bind(this), { passive: false });
-                document.addEventListener('touchcancel', this.handleEnd.bind(this), { passive: false });
+                const viewport = Utils.elements.imageViewport;
+                if (!viewport) return;
+                viewport.addEventListener('pointerdown', this.handleStart.bind(this));
+                document.addEventListener('pointermove', this.handleMove.bind(this));
+                document.addEventListener('pointerup', this.handleEnd.bind(this));
+                document.addEventListener('pointercancel', this.handleEnd.bind(this));
             },
             setupPinchZoom() {
                 Utils.elements.centerImage.addEventListener('touchstart', this.handleTouchStart.bind(this), { passive: false });
@@ -6624,14 +6624,19 @@
                 }
             },
             handleStart(e) {
-                this.tapHandled = false;
-                if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
+                const pointer = this.getPointerDetails(e);
+                if (pointer.type === 'touch' && state.isPinching) return;
                 if (state.currentScale > 1.1) return;
-                const point = e.touches ? e.touches[0] : e;
-                const hubInteraction = this.isInHub(point.clientX, point.clientY);
+                if (pointer.type === 'touch' && e.isPrimary === false) return;
+                if (this.activePointerId !== null && this.activePointerId !== pointer.id) return;
+                if (this.activePointerType && this.activePointerType !== pointer.type) return;
+                if (pointer.type === 'touch' && e.touches && e.touches.length > 1) return;
+                const hubInteraction = this.isInHub(pointer.clientX, pointer.clientY);
                 if (!hubInteraction && state.stacks[state.currentStack].length === 0) return;
-                this.startPos = { x: point.clientX, y: point.clientY };
-                this.currentPos = { x: point.clientX, y: point.clientY };
+                this.activePointerId = pointer.id;
+                this.activePointerType = pointer.type;
+                this.startPos = { x: pointer.clientX, y: pointer.clientY };
+                this.currentPos = { x: pointer.clientX, y: pointer.clientY };
                 this.startTimestamp = performance.now();
                 this.gestureStarted = false;
                 state.isDragging = true;
@@ -6639,19 +6644,28 @@
                 if (!hubInteraction) {
                     Utils.elements.centerImage.classList.add('dragging');
                 }
-                this.spawnRipple(point.clientX, point.clientY);
-                this.queueTrail(point.clientX, point.clientY);
+                this.spawnRipple(pointer.clientX, pointer.clientY);
+                this.queueTrail(pointer.clientX, pointer.clientY);
             },
             handleMove(e) {
                 if (!state.isDragging) return;
+                if (this.activePointerId === null) return;
+                if (e.pointerId !== undefined && e.pointerId !== this.activePointerId) return;
+                if (this.activePointerType === 'touch' && state.isPinching) {
+                    state.isDragging = false;
+                    Utils.elements.centerImage.classList.remove('dragging');
+                    this.hideAllEdgeGlows();
+                    this.resetActivePointer();
+                    return;
+                }
                 if (e.touches && e.touches.length > 1) {
                     state.isDragging = false; Utils.elements.centerImage.classList.remove('dragging');
-                    this.hideAllEdgeGlows(); return;
+                    this.hideAllEdgeGlows(); this.resetActivePointer(); return;
                 }
                 e.preventDefault();
-                const point = e.touches ? e.touches[0] : e;
-                this.currentPos = { x: point.clientX, y: point.clientY };
-                this.queueTrail(point.clientX, point.clientY);
+                const pointer = this.getPointerDetails(e);
+                this.currentPos = { x: pointer.clientX, y: pointer.clientY };
+                this.queueTrail(pointer.clientX, pointer.clientY);
                 if (this.hubPressActive) { return; }
                 if (state.imageFiles.length === 0) return;
                 const deltaX = this.currentPos.x - this.startPos.x;
@@ -6668,11 +6682,13 @@
                 }
             },
             handleEnd(e) {
-                if (!state.isDragging) return;
+                const matchesPointer = this.isActivePointer(e);
+                if (!matchesPointer) return;
+                if (!state.isDragging) { this.resetActivePointer(); return; }
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');
-                const point = e.changedTouches && e.changedTouches.length ? e.changedTouches[0] : e;
-                if (point) { this.currentPos = { x: point.clientX, y: point.clientY }; }
+                const pointer = this.getPointerDetails(e, true);
+                if (pointer) { this.currentPos = { x: pointer.clientX, y: pointer.clientY }; }
                 this.spawnTrail(this.currentPos.x, this.currentPos.y);
                 const deltaX = this.currentPos.x - this.startPos.x;
                 const deltaY = this.currentPos.y - this.startPos.y;
@@ -6702,6 +6718,7 @@
                     this.hideAllEdgeGlows();
                     this.hubPressActive = false;
                     this.gestureStarted = false;
+                    this.resetActivePointer();
                     return;
                 }
 
@@ -6721,15 +6738,53 @@
                         }
                     }
                 } else if (!this.gestureStarted && isTap) {
-                    if (!this.tapHandled) {
-                        this.tapHandled = true;
-                        this.spawnRipple(this.currentPos.x, this.currentPos.y);
-                        this.handleTap(this.currentPos.x, this.currentPos.y);
-                    }
+                    this.spawnRipple(this.currentPos.x, this.currentPos.y);
+                    this.handleTap(this.currentPos.x, this.currentPos.y);
                 }
                 this.hideAllEdgeGlows();
                 this.hubPressActive = false;
                 this.gestureStarted = false;
+                this.resetActivePointer();
+            },
+            getPointerDetails(e, preferChangedTouches = false) {
+                if (e.pointerId !== undefined) {
+                    return {
+                        id: e.pointerId,
+                        type: e.pointerType || 'mouse',
+                        clientX: e.clientX,
+                        clientY: e.clientY
+                    };
+                }
+                const touchList = preferChangedTouches ? e.changedTouches : e.touches;
+                if (touchList && touchList.length) {
+                    const touch = touchList[0];
+                    return {
+                        id: touch.identifier,
+                        type: 'touch',
+                        clientX: touch.clientX,
+                        clientY: touch.clientY
+                    };
+                }
+                return {
+                    id: 'mouse',
+                    type: 'mouse',
+                    clientX: e.clientX,
+                    clientY: e.clientY
+                };
+            },
+            isActivePointer(e) {
+                if (this.activePointerId === null) return false;
+                if (e.pointerId !== undefined) {
+                    return e.pointerId === this.activePointerId;
+                }
+                if (e.changedTouches && e.changedTouches.length) {
+                    return Array.from(e.changedTouches).some(t => t.identifier === this.activePointerId);
+                }
+                return this.activePointerId === 'mouse';
+            },
+            resetActivePointer() {
+                this.activePointerId = null;
+                this.activePointerType = null;
             },
             getDistance(touch1, touch2) { const dx = touch1.clientX - touch2.clientX; const dy = touch1.clientY - touch2.clientY; return Math.sqrt(dx * dx + dy * dy); },
             getCenter(touch1, touch2) { return { x: (touch1.clientX + touch2.clientX) / 2, y: (touch1.clientY + touch2.clientY) / 2 }; },


### PR DESCRIPTION
## Summary
- replace the mouse and touch listeners with a pointer-based setup that records the active pointer
- guard gesture move/end handlers to ignore non-matching pointer events so taps are only processed once

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dbf918e350832dae2f9e9e427b8cb8