### PR TITLE
Convert details modal to floating window

### DIFF
--- a/index.html
+++ b/index.html
@@ -416,10 +416,27 @@
             opacity: 1;
         }
         
-        .details-modal-content {
-            max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column;
-            overflow: auto; min-width: 400px; min-height: 400px;
+        .details-window {
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            z-index: 60;
+            display: flex;
+            flex-direction: column;
+            min-width: 400px;
+            min-height: 400px;
+            max-width: 800px;
+            max-height: 95vh;
+            height: 95vh;
+            background: #ffffff;
+            border-radius: 12px;
+            box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
+            overflow: hidden;
+            will-change: transform;
+            box-sizing: border-box;
         }
+        .details-window.visible { display: flex; }
         .modal-content.modal-content-flush {
             margin: 0;
             border-radius: 0;
@@ -936,87 +953,84 @@
         </div>
     </div>
     
-    <!-- Details Modal -->
-    <div id="details-modal" class="modal hidden">
-        <div class="modal-content details-modal-content">
-            <div id="details-modal-header" class="details-header">
-                <h3 class="details-title">Image Details</h3>
-                <button id="details-close" class="close-btn">
-                    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                </button>
+    <!-- Details Window -->
+    <div id="details-modal" class="details-window hidden floating-window">
+        <div id="details-modal-header" class="details-header">
+            <h3 class="details-title">Image Details</h3>
+            <button id="details-close" class="close-btn">
+                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+            </button>
+        </div>
+
+        <div class="tab-nav">
+            <button class="tab-button active" data-tab="info">Info</button>
+            <button class="tab-button" data-tab="tags">Tags</button>
+            <button class="tab-button" data-tab="notes">Notes</button>
+            <button class="tab-button" data-tab="metadata">Metadata</button>
+        </div>
+
+        <div class="details-content">
+            <div id="tab-info" class="tab-content active">
+                <div style="margin-bottom: 20px;">
+                    <div style="display: flex; align-items: center; margin-bottom: 12px; gap: 12px;">
+                        <span style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Filename:</span>
+                        <a id="detail-filename-link" style="font-size: 14px; color: #3b82f6; flex: 1; word-break: break-word; text-decoration: none;" href="#" target="_blank">
+                            <span id="detail-filename"></span>
+                        </a>
+                    </div>
+                    <div style="display: flex; align-items: center; margin-bottom: 12px; gap: 12px;">
+                        <span style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Date:</span>
+                        <span id="detail-date" style="font-size: 14px; color: #374151; flex: 1; word-break: break-word;"></span>
+                    </div>
+                    <div style="display: flex; align-items: center; margin-bottom: 12px; gap: 12px;">
+                        <span style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Size:</span>
+                        <span id="detail-size" style="font-size: 14px; color: #374151; flex: 1; word-break: break-word;"></span>
+                    </div>
+                </div>
             </div>
-            
-            <div class="tab-nav">
-                <button class="tab-button active" data-tab="info">Info</button>
-                <button class="tab-button" data-tab="tags">Tags</button>
-                <button class="tab-button" data-tab="notes">Notes</button>
-                <button class="tab-button" data-tab="metadata">Metadata</button>
+
+            <div id="tab-tags" class="tab-content">
+                <div style="margin-bottom: 20px;">
+                    <div class="tags-container" id="detail-tags"></div>
+                </div>
             </div>
-            
-            <div class="details-content">
-                <div id="tab-info" class="tab-content active">
-                    <div style="margin-bottom: 20px;">
-                        <div style="display: flex; align-items: center; margin-bottom: 12px; gap: 12px;">
-                            <span style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Filename:</span>
-                            <a id="detail-filename-link" style="font-size: 14px; color: #3b82f6; flex: 1; word-break: break-word; text-decoration: none;" href="#" target="_blank">
-                                <span id="detail-filename"></span>
-                            </a>
-                        </div>
-                        <div style="display: flex; align-items: center; margin-bottom: 12px; gap: 12px;">
-                            <span style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Date:</span>
-                            <span id="detail-date" style="font-size: 14px; color: #374151; flex: 1; word-break: break-word;"></span>
-                        </div>
-                        <div style="display: flex; align-items: center; margin-bottom: 12px; gap: 12px;">
-                            <span style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Size:</span>
-                            <span id="detail-size" style="font-size: 14px; color: #374151; flex: 1; word-break: break-word;"></span>
-                        </div>
+
+            <div id="tab-notes" class="tab-content">
+                <div style="margin-bottom: 24px;">
+                    <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
+                    <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
+                </div>
+
+                <div style="margin-bottom: 20px;">
+                    <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
+                    <div class="star-rating" id="quality-rating" data-rating-type="quality">
+                        <svg class="star" data-rating="1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        <svg class="star" data-rating="2" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        <svg class="star" data-rating="3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        <svg class="star" data-rating="4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                     </div>
                 </div>
-                
-                <div id="tab-tags" class="tab-content">
-                    <div style="margin-bottom: 20px;">
-                        <div class="tags-container" id="detail-tags"></div>
+
+                <div style="margin-bottom: 20px;">
+                    <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
+                    <div class="star-rating" id="content-rating" data-rating-type="content">
+                        <svg class="star" data-rating="1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        <svg class="star" data-rating="2" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        <svg class="star" data-rating="3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        <svg class="star" data-rating="4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                        <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                     </div>
                 </div>
-                
-                <div id="tab-notes" class="tab-content">
-                    <div style="margin-bottom: 24px;">
-                        <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
-                        <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
-                    </div>
-                    
-                    <div style="margin-bottom: 20px;">
-                        <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
-                        <div class="star-rating" id="quality-rating" data-rating-type="quality">
-                            <svg class="star" data-rating="1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
-                            <svg class="star" data-rating="2" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
-                            <svg class="star" data-rating="3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
-                            <svg class="star" data-rating="4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
-                            <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
-                        </div>
-                    </div>
-                    
-                    <div style="margin-bottom: 20px;">
-                        <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
-                        <div class="star-rating" id="content-rating" data-rating-type="content">
-                            <svg class="star" data-rating="1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
-                            <svg class="star" data-rating="2" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
-                            <svg class="star" data-rating="3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
-                            <svg class="star" data-rating="4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
-                            <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
-                        </div>
-                    </div>
-                </div>
-                
-                <div id="tab-metadata" class="tab-content">
-                    <table class="metadata-table" id="metadata-table"></table>
-                </div>
+            </div>
+
+            <div id="tab-metadata" class="tab-content">
+                <table class="metadata-table" id="metadata-table"></table>
             </div>
         </div>
     </div>
-
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
         
@@ -2822,6 +2836,14 @@
                     this.updateImageCounters();
                     this.updateFavoriteButton();
                     Grid.syncWithCurrentImage(currentFile.id);
+                    const detailsContainer = Utils.elements.detailsModal;
+                    if (detailsContainer && !detailsContainer.classList.contains('hidden')) {
+                        if (currentFile.metadataStatus !== 'loaded') {
+                            Details.populateMetadataTab(currentFile);
+                            await App.processFileMetadata(currentFile);
+                        }
+                        Details.populateAllTabs(currentFile);
+                    }
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -3626,13 +3648,24 @@
                         await App.processFileMetadata(currentFile);
                     }
                     this.populateAllTabs(currentFile);
-                    Utils.showModal('details-modal');
+                    const container = Utils.elements.detailsModal;
+                    if (!container) return;
+                    container.classList.remove('hidden');
+                    container.classList.add('visible');
+                    if (DraggableResizable && typeof DraggableResizable.onShow === 'function') {
+                        DraggableResizable.onShow('details-modal');
+                    }
                     this.switchTab('info');
                 } catch (error) {
                     Utils.showToast(`Error showing details: ${error.message}`, 'error', true);
                 }
             },
-            hide() { Utils.hideModal('details-modal'); },
+            hide() {
+                const container = Utils.elements.detailsModal;
+                if (!container) return;
+                container.classList.add('hidden');
+                container.classList.remove('visible');
+            },
             switchTab(tabName) {
                 document.querySelectorAll('.tab-button').forEach(btn => { btn.classList.toggle('active', btn.dataset.tab === tabName); });
                 document.querySelectorAll('.tab-content').forEach(content => { content.classList.toggle('active', content.id === `tab-${tabName}`); });
@@ -4625,8 +4658,9 @@
                     this.id = id;
                     this.modal = modal;
                     this.header = header;
+                    this.isFloating = modal.classList.contains('floating-window');
                     const computed = getComputedStyle(modal);
-                    this.defaultMargin = parseFloat(computed.marginTop) || DEFAULT_MARGIN;
+                    this.defaultMargin = this.isFloating ? 0 : (parseFloat(computed.marginTop) || DEFAULT_MARGIN);
                     const minWidth = parseFloat(computed.minWidth);
                     const minHeight = parseFloat(computed.minHeight);
                     this.minWidth = Number.isFinite(minWidth) ? minWidth : DEFAULT_MIN_WIDTH;
@@ -4705,6 +4739,11 @@
                 }
 
                 applyMargin(layout) {
+                    if (this.isFloating) {
+                        this.modal.style.margin = '0';
+                        this.modal.classList.remove('modal-content-flush');
+                        return;
+                    }
                     const margin = this.getMargin(layout);
                     this.modal.style.margin = `${margin}px`;
                     if (margin === 0) {
@@ -4720,7 +4759,13 @@
                     const baseY = viewport.top + (viewport.height - layout.height) / 2;
                     const translateX = layout.x - baseX;
                     const translateY = layout.y - baseY;
-                    this.modal.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;
+                    if (this.isFloating) {
+                        this.modal.style.top = '50%';
+                        this.modal.style.left = '50%';
+                        this.modal.style.transform = `translate(-50%, -50%) translate3d(${translateX}px, ${translateY}px, 0)`;
+                    } else {
+                        this.modal.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;
+                    }
                 }
 
                 onShow() {
@@ -4731,8 +4776,9 @@
                 }
 
                 isActive() {
+                    if (this.modal.classList.contains('hidden')) { return false; }
                     const container = this.modal.closest('.modal');
-                    return container && !container.classList.contains('hidden');
+                    return container ? !container.classList.contains('hidden') : true;
                 }
 
                 onViewportChange() {
@@ -5013,7 +5059,7 @@
                 this.setupDraggables();
             },
             setupDraggables() {
-                DraggableResizable.register('details-modal', Utils.elements.detailsModal.querySelector('.modal-content'), Utils.elements.detailsModalHeader);
+                DraggableResizable.register('details-modal', Utils.elements.detailsModal, Utils.elements.detailsModalHeader);
                 DraggableResizable.register('grid-modal', Utils.elements.gridModal.querySelector('.modal-content'), Utils.elements.gridModalHeaderMain);
             },
             setupProviderSelection() {


### PR DESCRIPTION
## Summary
- replace the details modal overlay with a fixed-position floating window and refreshed markup
- toggle the details panel visibility directly and repopulate its tabs when the active image changes while visible
- update the draggable/resizable helper to work with the floating container and keep existing registrations intact

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dbf91512b8832db7ec9895098eed4f