### PR TITLE
Mirror folder return guard in ui-v9b

### DIFF
--- a/index.html
+++ b/index.html
@@ -1043,7 +1043,8 @@
             folderMoveMode: { active: false, files: [] },
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
-            modalLayout: {}
+            modalLayout: {},
+            isReturningToFolders: false
         };
         const Utils = {
             elements: {},
@@ -2627,17 +2628,37 @@
                 Utils.showScreen('app-container');
             },
             async returnToFolderSelection() {
+                if (state.isReturningToFolders) return;
+
+                state.isReturningToFolders = true;
+                const { backButton, backButtonSpinner } = Utils.elements;
+
+                if (backButton) {
+                    backButton.disabled = true;
+                }
+                if (backButtonSpinner) {
+                    backButtonSpinner.style.display = 'inline-block';
+                }
+
                 try {
                     if (state.syncManager) {
                         state.syncManager.requestSync();
                     }
-                    state.activeRequests.abort(); 
+                    state.activeRequests.abort();
                     this.resetViewState();
                     Utils.showScreen('folder-screen');
                     await Folders.load();
                 } catch(error) {
                     Utils.showToast(`Error returning to folders: ${error.message}`, 'error', true);
                     Utils.showScreen('folder-screen');
+                } finally {
+                    if (backButton) {
+                        backButton.disabled = false;
+                    }
+                    if (backButtonSpinner) {
+                        backButtonSpinner.style.display = 'none';
+                    }
+                    state.isReturningToFolders = false;
                 }
             },
             resetViewState() {
@@ -4023,6 +4044,8 @@
                 Utils.elements.actionConfirm.disabled = true; Utils.elements.actionCancel.textContent = "Close";
             },
             executeFolderMove() {
+                if (state.isReturningToFolders) return;
+
                 state.folderMoveMode = { active: true, files: [...state.grid.selected], };
                 this.hide(); Grid.close(); App.returnToFolderSelection();
                 Utils.showToast(`Select destination folder for ${state.folderMoveMode.files.length} images`, 'info', true);
@@ -4519,6 +4542,8 @@
             },
 
             async handleFolderMoveSelection(folderId, folderName) {
+                if (state.isReturningToFolders) return;
+
                 const filesToMove = state.folderMoveMode.files;
                 Utils.showScreen('loading-screen'); Utils.updateLoadingProgress(0, filesToMove.length);
                 try {
@@ -5031,7 +5056,10 @@
                 Utils.elements.authBackButton.addEventListener('click', () => App.backToProviderSelection());
             },
             setupFolderManagement() {
-                Utils.elements.backButton.addEventListener('click', () => App.returnToFolderSelection());
+                Utils.elements.backButton.addEventListener('click', () => {
+                    if (state.isReturningToFolders) return;
+                    App.returnToFolderSelection();
+                });
 
                 Utils.elements.folderBackButton.addEventListener('click', () => App.backToProviderSelection());
                 Utils.elements.folderLogoutButton.addEventListener('click', async () => {
@@ -5064,6 +5092,7 @@
                 Utils.elements.cancelLoading.addEventListener('click', () => {
                     if (state.metadataExtractor) { state.metadataExtractor.abort(); }
                     state.activeRequests.abort();
+                    if (state.isReturningToFolders) return;
                     App.returnToFolderSelection();
                     Utils.showToast('Loading cancelled', 'info', true);
                 });
@@ -5110,7 +5139,10 @@
                         Utils.elements.selectAnotherFolderBtn.style.display = 'block';
                     }
                 });
-                Utils.elements.selectAnotherFolderBtn.addEventListener('click', () => { App.returnToFolderSelection(); });
+                Utils.elements.selectAnotherFolderBtn.addEventListener('click', () => {
+                    if (state.isReturningToFolders) return;
+                    App.returnToFolderSelection();
+                });
             },
             setupPillCounters() {
                 STACKS.forEach(stackName => {
@@ -5291,7 +5323,10 @@
                         }
                         switch (e.key) {
                             case 'Tab': e.preventDefault(); UI.cycleThroughPills(); break;
-                            case 'Escape': await App.returnToFolderSelection(); break;
+                            case 'Escape':
+                                if (state.isReturningToFolders) break;
+                                await App.returnToFolderSelection();
+                                break;
                         }
                     } catch (error) {
                         Utils.showToast(`Keyboard command failed: ${error.message}`, 'error', true);

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -1096,6 +1096,7 @@
                 lazyLoadState: { allFiles: [], renderedCount: 0, observer: null, batchSize: 20 } },
             tags: new Set(), loadingProgress: { current: 0, total: 0 },
             folderMoveMode: { active: false, files: [] },
+            isReturningToFolders: false,
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
@@ -4809,17 +4810,37 @@
                 Utils.showScreen('app-container');
             },
             async returnToFolderSelection() {
+                if (state.isReturningToFolders) return;
+
+                state.isReturningToFolders = true;
+                const { backButton, backButtonSpinner } = Utils.elements;
+
+                if (backButton) {
+                    backButton.disabled = true;
+                }
+                if (backButtonSpinner) {
+                    backButtonSpinner.style.display = 'inline-block';
+                }
+
                 try {
                     if (state.syncManager) {
                         await state.syncManager.flush({ reason: 'folder-switch' });
                     }
-                    state.activeRequests.abort(); 
+                    state.activeRequests.abort();
                     this.resetViewState();
                     Utils.showScreen('folder-screen');
                     await Folders.load();
                 } catch(error) {
                     Utils.showToast(`Error returning to folders: ${error.message}`, 'error', true);
                     Utils.showScreen('folder-screen');
+                } finally {
+                    if (backButton) {
+                        backButton.disabled = false;
+                    }
+                    if (backButtonSpinner) {
+                        backButtonSpinner.style.display = 'none';
+                    }
+                    state.isReturningToFolders = false;
                 }
             },
             resetViewState() {
@@ -6409,6 +6430,8 @@
                 Utils.elements.actionConfirm.disabled = true; Utils.elements.actionCancel.textContent = "Close";
             },
             executeFolderMove() {
+                if (state.isReturningToFolders) return;
+
                 state.folderMoveMode = { active: true, files: [...state.grid.selected], };
                 this.hide(); Grid.close(); App.returnToFolderSelection();
                 Utils.showToast(`Select destination folder for ${state.folderMoveMode.files.length} images`, 'info', true);
@@ -6895,6 +6918,8 @@
             },
 
             async handleFolderMoveSelection(folderId, folderName) {
+                if (state.isReturningToFolders) return;
+
                 const filesToMove = state.folderMoveMode.files;
                 Utils.showScreen('loading-screen'); Utils.updateLoadingProgress(0, filesToMove.length);
                 try {
@@ -7104,7 +7129,10 @@
                 Utils.elements.authBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });
             },
             setupFolderManagement() {
-                Utils.elements.backButton.addEventListener('click', () => App.returnToFolderSelection());
+                Utils.elements.backButton.addEventListener('click', () => {
+                    if (state.isReturningToFolders) return;
+                    App.returnToFolderSelection();
+                });
 
                 Utils.elements.folderBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });
                 Utils.elements.folderLogoutButton.addEventListener('click', async () => {
@@ -7137,6 +7165,7 @@
                 Utils.elements.cancelLoading.addEventListener('click', () => {
                     if (state.metadataExtractor) { state.metadataExtractor.abort(); }
                     state.activeRequests.abort();
+                    if (state.isReturningToFolders) return;
                     App.returnToFolderSelection();
                     Utils.showToast('Loading cancelled', 'info', true);
                 });
@@ -7183,7 +7212,10 @@
                         Utils.elements.selectAnotherFolderBtn.style.display = 'block';
                     }
                 });
-                Utils.elements.selectAnotherFolderBtn.addEventListener('click', () => { App.returnToFolderSelection(); });
+                Utils.elements.selectAnotherFolderBtn.addEventListener('click', () => {
+                    if (state.isReturningToFolders) return;
+                    App.returnToFolderSelection();
+                });
             },
             setupPillCounters() {
                 let skipNextGridOpen = false;
@@ -7401,7 +7433,10 @@
                         }
                         switch (e.key) {
                             case 'Tab': e.preventDefault(); UI.cycleThroughPills(); break;
-                            case 'Escape': await App.returnToFolderSelection(); break;
+                            case 'Escape':
+                                if (state.isReturningToFolders) break;
+                                await App.returnToFolderSelection();
+                                break;
                         }
                     } catch (error) {
                         Utils.showToast(`Keyboard command failed: ${error.message}`, 'error', true);


### PR DESCRIPTION
## Summary
- add a shared state flag so return-to-folder navigation is single-run and shows the back button spinner (mirrored in ui-v9b)
- gate folder return entry points in ui-v9b to bail out when navigation is already in flight

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbf91514ac832dbf95ebb2fcdc4bc7