### PR TITLE
Ensure grid anchor handles missing current file

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -5060,7 +5060,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -5071,7 +5071,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -5082,7 +5082,17 @@
                     }
                 });
             },
-            
+
+            getCurrentFile() {
+                const stackName = state.currentStack;
+                if (!stackName) { return null; }
+                const stack = state.stacks[stackName];
+                if (!Array.isArray(stack) || stack.length === 0) { return null; }
+                const position = typeof state.currentStackPosition === 'number' ? state.currentStackPosition : 0;
+                if (position < 0 || position >= stack.length) { return null; }
+                return stack[position] || null;
+            },
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -5387,10 +5397,16 @@
                 state.grid.isDirty = false;
                 const value = Utils.elements.gridSize.value;
                 Utils.elements.gridContainer.style.gridTemplateColumns = `repeat(${value}, 1fr)`;
-                const anchorSource = stack === state.currentStack ? Core.getCurrentFile() : (state.stacks[stack]?.[0] || null);
+                const stackFiles = Array.isArray(state.stacks[stack]) ? state.stacks[stack] : [];
+                let anchorSource = null;
+                if (stack === state.currentStack) {
+                    anchorSource = Core.getCurrentFile();
+                }
+                if (!anchorSource && stackFiles.length > 0) {
+                    anchorSource = stackFiles[0];
+                }
                 state.grid.anchorId = anchorSource ? anchorSource.id : null;
                 state.grid.filtered = [];
-                const stackFiles = Array.isArray(state.stacks[stack]) ? state.stacks[stack] : [];
                 const availableIds = new Set(stackFiles.map(file => file.id));
                 state.grid.selected = Array.isArray(state.grid.selected)
                     ? state.grid.selected.filter(id => availableIds.has(id))


### PR DESCRIPTION
## Summary
- add a Core.getCurrentFile helper that safely reports the active stack item
- update Grid.open to tolerate missing anchors and fall back to the stack's first entry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc2d445c78832d810bf74d50d1df71