### PR TITLE
Fix toast pointer events to keep recycle pill clickable

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -132,8 +132,9 @@
             position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
             background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
             font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
+            pointer-events: none;
         }
-        .toast.show { opacity: 1; }
+        .toast.show { opacity: 1; pointer-events: auto; }
         .toast.success { background: rgba(16, 185, 129, 0.9); }
         .toast.info { background: rgba(59, 130, 246, 0.9); }
         .toast.error { background: rgba(239, 68, 68, 0.9); }


### PR DESCRIPTION
## Summary
- disable pointer events on the toast by default so underlying controls stay clickable
- restore toast pointer interactivity when it is shown so users can still dismiss or interact with it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc2d4ca770832da52e45a4a11fdfec