### PR TITLE
Add labels to stack pill counters in ui-v9b

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -197,18 +197,31 @@
         .edge-glow.active { opacity: 1; }
         
         .pill-counter {
-            position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
-            color: black; opacity: 0; transition: all 0.3s ease;
-            cursor: pointer; z-index: 10; min-width: 50px; text-align: center;
+            position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px;
+            color: #f9fafb; opacity: 0; transition: all 0.3s ease;
+            cursor: pointer; z-index: 10; min-width: 70px; text-align: center;
+            display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px;
         }
         .pill-counter.visible { opacity: 0.9; }
-        .pill-counter.active { font-weight: 700; background: white; opacity: 1; border: 3px solid black; }
+        .pill-counter.active {
+            background: white; opacity: 1; border: 3px solid black; color: #111827;
+        }
         .pill-counter:not(.active) { background: rgba(128, 128, 128, 0.4); border: none; }
         .pill-counter:hover { opacity: 1; transform: scale(1.05); }
         .pill-counter.top { top: 10px; left: 50%; transform: translateX(-50%); }
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
+
+        .pill-counter .pill-label {
+            font-size: 12px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase;
+        }
+        .pill-counter:not(.active) .pill-label { color: rgba(249, 250, 251, 0.9); }
+        .pill-counter.active .pill-label { color: #111827; }
+
+        .pill-counter .pill-count {
+            font-size: 20px; font-weight: 700;
+        }
         
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
@@ -831,10 +844,22 @@
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
         
-        <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
-        <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
-        <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
-        <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
+        <div class="pill-counter top" id="pill-priority" data-stack="priority">
+            <span class="pill-label"></span>
+            <span class="pill-count" aria-live="polite">0</span>
+        </div>
+        <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">
+            <span class="pill-label"></span>
+            <span class="pill-count" aria-live="polite">0</span>
+        </div>
+        <div class="pill-counter left active" id="pill-in" data-stack="in">
+            <span class="pill-label"></span>
+            <span class="pill-count" aria-live="polite">0</span>
+        </div>
+        <div class="pill-counter right" id="pill-out" data-stack="out">
+            <span class="pill-label"></span>
+            <span class="pill-count" aria-live="polite">0</span>
+        </div>
         
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
@@ -5077,7 +5102,18 @@
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) {
-                        pill.textContent = count > 999 ? ':)' : count;
+                        const label = STACK_NAMES[stack] || stack;
+                        const pillLabel = pill.querySelector('.pill-label');
+                        const pillCount = pill.querySelector('.pill-count');
+                        if (pillLabel) {
+                            pillLabel.textContent = label;
+                        }
+                        if (pillCount) {
+                            const displayCount = count > 999 ? ':)' : count;
+                            pillCount.textContent = displayCount;
+                            pillCount.setAttribute('aria-label', `${label} stack has ${count} item${count === 1 ? '' : 's'}`);
+                        }
+                        pill.setAttribute('aria-label', `${label} stack (${count} item${count === 1 ? '' : 's'})`);
                         pill.classList.toggle('visible', count > 0);
                     }
                 });


### PR DESCRIPTION
## Summary
- show stack labels alongside the stage counters in `ui-v9b.html`
- style pill counters to accommodate label and count text while keeping the active-state contrast
- update the counter logic to populate labels, counts, and accessible descriptions from the shared stack map

## Testing
- Not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dc085ed50c832dbddab0f71898edd3