### PR TITLE
Restore original ui-v9b pills and add queue simulation harness

### DIFF
--- a/queue-sim.html
+++ b/queue-sim.html
@@ -1,0 +1,557 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Queue Sync Micro Simulation</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --bg: #f6f7fb;
+      --panel: #ffffff;
+      --border: #d6dae5;
+      --green: #2cb35c;
+      --blue: #3182ce;
+      --yellow: #d69e2e;
+      --off: #8a8f9c;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: #222;
+      line-height: 1.5;
+    }
+
+    main {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 32px 24px 64px;
+    }
+
+    h1 {
+      margin-top: 0;
+      font-size: 1.75rem;
+    }
+
+    section {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 20px;
+      margin-top: 20px;
+      box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+    }
+
+    .flex {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    .panel {
+      flex: 1 1 280px;
+      min-width: 260px;
+    }
+
+    fieldset {
+      border: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    .role-picker label {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      margin-right: 16px;
+      font-weight: 600;
+    }
+
+    .toggles {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      margin-top: 12px;
+    }
+
+    .toggle-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 12px;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: rgba(148, 163, 184, 0.08);
+    }
+
+    .toggle-row label {
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .toggle-row input[type="checkbox"] {
+      transform: scale(1.2);
+    }
+
+    button {
+      appearance: none;
+      border: none;
+      border-radius: 999px;
+      padding: 10px 18px;
+      font-weight: 600;
+      background: #1f2937;
+      color: #fff;
+      cursor: pointer;
+      transition: transform 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    button[disabled] {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+
+    button:hover:not([disabled]) {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 20px rgba(15, 23, 42, 0.2);
+    }
+
+    button.secondary {
+      background: transparent;
+      color: #1f2937;
+      border: 1px solid var(--border);
+      box-shadow: none;
+    }
+
+    .img-wrap {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      align-items: flex-start;
+    }
+
+    .img-wrap img {
+      width: 140px;
+      height: 140px;
+      border-radius: 16px;
+      border: 1px solid var(--border);
+      box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+      object-fit: cover;
+    }
+
+    .flag-status {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 12px;
+      width: 100%;
+    }
+
+    .flag-card {
+      border-radius: 12px;
+      padding: 12px 14px;
+      border: 1px solid var(--border);
+      background: rgba(241, 245, 249, 0.7);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-weight: 600;
+    }
+
+    .flag-card .state {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-weight: 700;
+    }
+
+    .state-dot {
+      width: 12px;
+      height: 12px;
+      border-radius: 999px;
+      background: var(--off);
+    }
+
+    .state-dot.on.green { background: var(--green); }
+    .state-dot.on.blue { background: var(--blue); }
+    .state-dot.on.yellow { background: var(--yellow); }
+
+    .log-controls {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-bottom: 12px;
+    }
+
+    pre {
+      background: #0f172a;
+      color: #f8fafc;
+      padding: 16px;
+      border-radius: 12px;
+      overflow: auto;
+      max-height: 320px;
+      margin: 0;
+      font-size: 0.9rem;
+    }
+
+    .status-line {
+      margin-top: 12px;
+      font-size: 0.9rem;
+      color: #475569;
+    }
+
+    .status-line strong {
+      color: #0f172a;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+
+      section {
+        background: rgba(15, 23, 42, 0.65);
+        border-color: rgba(148, 163, 184, 0.3);
+      }
+
+      button.secondary {
+        color: #e2e8f0;
+        border-color: rgba(148, 163, 184, 0.4);
+      }
+
+      .toggle-row {
+        background: rgba(30, 41, 59, 0.7);
+        border-color: rgba(148, 163, 184, 0.3);
+      }
+
+      .flag-card {
+        background: rgba(30, 41, 59, 0.75);
+        border-color: rgba(148, 163, 184, 0.3);
+      }
+
+      .status-line strong {
+        color: #e2e8f0;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Event-Driven Queue Simulation</h1>
+    <p>
+      Open this file in two browser tabs. Set one tab to <strong>Device A</strong> (publisher) and the
+      other to <strong>Device B</strong> (consumer). Device A publishes color flag updates into a shared
+      queue stored in <code>localStorage</code>. Device B processes any entries newer than its stored
+      watermark to confirm it only applies incremental changes.
+    </p>
+
+    <section>
+      <h2>Choose your role</h2>
+      <fieldset class="role-picker">
+        <label><input type="radio" name="role" value="A" checked /> Device A (publish changes)</label>
+        <label><input type="radio" name="role" value="B" /> Device B (process queue)</label>
+      </fieldset>
+      <p class="status-line" id="ack-line"></p>
+    </section>
+
+    <section class="flex">
+      <div class="panel" id="publisher-panel">
+        <h2>Device A &mdash; publish update</h2>
+        <p>Select the flag states, then push an update into the queue.</p>
+        <div class="toggles">
+          <div class="toggle-row">
+            <label for="flag-green">Green</label>
+            <input type="checkbox" id="flag-green" data-flag="green" />
+          </div>
+          <div class="toggle-row">
+            <label for="flag-blue">Blue</label>
+            <input type="checkbox" id="flag-blue" data-flag="blue" />
+          </div>
+          <div class="toggle-row">
+            <label for="flag-yellow">Yellow</label>
+            <input type="checkbox" id="flag-yellow" data-flag="yellow" />
+          </div>
+        </div>
+        <div class="log-controls" style="margin-top:16px;">
+          <button id="publish-btn">Publish update</button>
+          <button class="secondary" id="reset-queue-btn">Clear queue</button>
+        </div>
+        <p class="status-line" id="queue-line"></p>
+      </div>
+
+      <div class="panel">
+        <h2>Shared flag display</h2>
+        <div class="img-wrap">
+          <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIwAAACMCAYAAAD5nd/tAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJ
+bWFnZVJlYWR5ccllPAAABhVJREFUeNrsnQtu2zAQhVeQ///SbiEOQkXIBqQE1TKoPY1TGVtCqhk+NEH5YZ5W3lbE8vC2WzznrbYbb7rttttt9z
+n3+X9AWUBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIhVAiNJna/qfU5JW+abtd82
+B3cDaXW1P1cZKbXGjS+FuEmVYj5dZ8rV6pg7n2X5+SbuS2XvyMGxrWt9HjsmN8QuuiiW8uQGiVNSkxsZ96if9Otd5xPKX88d3SWjfo8V3RcZuH
+KM2rVkgbiC4qc+DlH61JNW1Lu1DdIMpPGI93Y32bo7wqLx8k+2cs6GyZf3mfuJ4MjM79SDckzKLOaqy4wt5NwPDB+t9/m0THTut3o/68Z7i9FfP
+lmnfI2Kdm48O8dbNF7gskn5uCaZfrpX37WAh9Up1Im1XtfqsZW0wv1kXx1qiXBgZS8ps0X3Ud+WkzLIzLYa/kPp2NK77m87660ObmOY9q3DHvu
+PmXtQZ9+Hzy4Yq59tR1HxZJ1gXG1Ds2lpnKNCCFpbXCO7MHGHj5Y0shYjS6z5N3HVcY3moF1zjnmVji+a3KbKvHGbJUW3mOTw38NEyG4MXHe5h4
+U8MhYbDiKZKXUmPyhk/y0qnLs6z8cXbi96+F2Sfyay09SPkl7yZWeuI01n/Nu70re2n61/1PVdv4Mjb6hfeTyGbzTfZUXJNhrXSvUu1Lg0ip9J
+Di5yY7W2vlcESytvQfG1SFL2zNBGVY1qXVreTwQ17Wk7eay7KUqS2Fpqxea3ieS7hY7sk9e3pPyJG6UrfI+6zy/ls3elP1rPfjX+YdSq3X5HtpL
+u4KtnnSruW+o5rdtfW7s5eeYZz7G6N1uYz3m2GqzZV/nNnMRo95tRro1pnXf8q41ox7zbDWx61r7XawV/L0TvHVpssqR0bM3uk3m9SPdF1Gyr9X
+VP5WfZk5TrKXot8nMd6lY73H3WMRbtGcLzb7nXM/03VGyr9XtFuS5w7L+P4ckr/a/kr9YtV2dpHt9wWj1t7DXSI8F4cQq7P069nPE2Ulcl3S/UZ
++42kcmn37DcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAZfwCq5pwe9WH4G4AAAAA
+SUVORK5CYII=" alt="Shared demo image" />
+          <div class="flag-status" id="flag-status">
+            <div class="flag-card" data-flag="green">
+              <span>Green</span>
+              <span class="state"><span class="state-dot"></span><span class="state-label">OFF</span></span>
+            </div>
+            <div class="flag-card" data-flag="blue">
+              <span>Blue</span>
+              <span class="state"><span class="state-dot"></span><span class="state-label">OFF</span></span>
+            </div>
+            <div class="flag-card" data-flag="yellow">
+              <span>Yellow</span>
+              <span class="state"><span class="state-dot"></span><span class="state-label">OFF</span></span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Device B &mdash; process updates</h2>
+      <p>Process new queue entries or reset the consumer watermark.</p>
+      <div class="log-controls">
+        <button id="process-btn">Process new updates</button>
+        <button class="secondary" id="reset-ack-btn">Reset last seen</button>
+      </div>
+      <pre id="log" aria-live="polite"></pre>
+    </section>
+  </main>
+
+  <script>
+    (function () {
+      const CLOUD_QUEUE_KEY = 'queueSim:cloudQueue';
+      const LAST_ACK_KEY_PREFIX = 'queueSim:lastAck:';
+      const ROLE_KEY = 'queueSim:lastRole';
+      const MAX_QUEUE_LENGTH = 128;
+      const flags = ['green', 'blue', 'yellow'];
+
+      const roleInputs = Array.from(document.querySelectorAll('input[name="role"]'));
+      const publishBtn = document.getElementById('publish-btn');
+      const resetQueueBtn = document.getElementById('reset-queue-btn');
+      const processBtn = document.getElementById('process-btn');
+      const resetAckBtn = document.getElementById('reset-ack-btn');
+      const logOutput = document.getElementById('log');
+      const ackLine = document.getElementById('ack-line');
+      const queueLine = document.getElementById('queue-line');
+      const publisherPanel = document.getElementById('publisher-panel');
+      const toggleInputs = flags.map(flag => document.querySelector(`input[data-flag="${flag}"]`));
+      const flagCards = new Map(Array.from(document.querySelectorAll('.flag-card')).map(card => [card.dataset.flag, card]));
+
+      let currentRole = localStorage.getItem(ROLE_KEY) || 'A';
+      let flagState = { green: false, blue: false, yellow: false };
+
+      roleInputs.forEach(input => {
+        input.checked = input.value === currentRole;
+        input.addEventListener('change', () => {
+          if (!input.checked) return;
+          setRole(input.value);
+        });
+      });
+
+      publishBtn.addEventListener('click', () => {
+        const state = readToggleState();
+        appendEntry(state);
+        log(`Device A published → ${describeState(state)}`);
+        updateQueueLine();
+      });
+
+      resetQueueBtn.addEventListener('click', () => {
+        setQueue([]);
+        log('Queue cleared (retained window reset).');
+        updateQueueLine();
+      });
+
+      processBtn.addEventListener('click', () => {
+        processQueue('manual');
+      });
+
+      resetAckBtn.addEventListener('click', () => {
+        setAck(currentRole, 0);
+        log(`Last-seen watermark cleared for Device ${currentRole}.`);
+      });
+
+      window.addEventListener('storage', event => {
+        if (event.key === CLOUD_QUEUE_KEY) {
+          updateQueueLine();
+          if (currentRole === 'B') {
+            processQueue('storage');
+          }
+        }
+      });
+
+      initializeUI();
+      updateQueueLine();
+      processQueue('startup');
+
+      function initializeUI() {
+        setRole(currentRole);
+        updateAckLine();
+        updateFlagCards();
+      }
+
+      function setRole(role) {
+        currentRole = role;
+        localStorage.setItem(ROLE_KEY, role);
+        const isPublisher = role === 'A';
+        publisherPanel.style.opacity = isPublisher ? '1' : '0.55';
+        toggleInputs.forEach(input => {
+          input.disabled = !isPublisher;
+        });
+        publishBtn.disabled = !isPublisher;
+        resetQueueBtn.disabled = !isPublisher;
+        processBtn.disabled = isPublisher;
+        resetAckBtn.disabled = isPublisher;
+        roleInputs.forEach(input => (input.checked = input.value === role));
+        updateAckLine();
+        if (role === 'B') {
+          processQueue('role-change');
+        }
+      }
+
+      function readToggleState() {
+        return flags.reduce((acc, flag) => {
+          const input = document.querySelector(`input[data-flag="${flag}"]`);
+          acc[flag] = input.checked;
+          return acc;
+        }, {});
+      }
+
+      function appendEntry(state) {
+        const queue = getQueue();
+        queue.push({
+          id: crypto.randomUUID(),
+          ts: Date.now(),
+          state
+        });
+        if (queue.length > MAX_QUEUE_LENGTH) {
+          queue.splice(0, queue.length - MAX_QUEUE_LENGTH);
+        }
+        setQueue(queue);
+      }
+
+      function getQueue() {
+        const raw = localStorage.getItem(CLOUD_QUEUE_KEY);
+        if (!raw) return [];
+        try {
+          const parsed = JSON.parse(raw);
+          return Array.isArray(parsed) ? parsed : [];
+        } catch (err) {
+          console.warn('Unable to parse stored queue:', err);
+          return [];
+        }
+      }
+
+      function setQueue(queue) {
+        localStorage.setItem(CLOUD_QUEUE_KEY, JSON.stringify(queue));
+      }
+
+      function getAck(role) {
+        const raw = localStorage.getItem(LAST_ACK_KEY_PREFIX + role);
+        if (!raw) return 0;
+        const value = Number(raw);
+        return Number.isFinite(value) ? value : 0;
+      }
+
+      function setAck(role, value) {
+        localStorage.setItem(LAST_ACK_KEY_PREFIX + role, String(value || 0));
+        updateAckLine();
+      }
+
+      function processQueue(reason) {
+        const queue = getQueue().slice().sort((a, b) => a.ts - b.ts);
+        const ack = getAck(currentRole);
+        const earliest = queue.length ? queue[0].ts : null;
+
+        if (!queue.length) {
+          if (reason === 'manual') {
+            log('Queue empty — nothing to process.');
+          }
+          return;
+        }
+
+        if (ack && earliest && ack < earliest) {
+          log(`⚠️  Watermark (${formatTs(ack)}) predates retained window (${formatTs(earliest)}). Trigger full reload.`);
+        }
+
+        const newEntries = queue.filter(entry => entry.ts > ack);
+        if (!newEntries.length) {
+          if (reason !== 'storage') {
+            log('No updates newer than last processed watermark.');
+          }
+          return;
+        }
+
+        newEntries.forEach(entry => {
+          applyState(entry.state);
+          log(`✅ Applied ${describeState(entry.state)} @ ${formatTs(entry.ts)} (id ${entry.id.slice(0, 8)}…)`);
+        });
+
+        const latestTs = newEntries[newEntries.length - 1].ts;
+        setAck(currentRole, latestTs);
+      }
+
+      function applyState(state) {
+        flagState = { ...flagState, ...state };
+        updateFlagCards();
+      }
+
+      function updateFlagCards() {
+        flagCards.forEach((card, flag) => {
+          const dot = card.querySelector('.state-dot');
+          const label = card.querySelector('.state-label');
+          const isOn = Boolean(flagState[flag]);
+          dot.classList.toggle('on', isOn);
+          dot.classList.toggle('green', isOn && flag === 'green');
+          dot.classList.toggle('blue', isOn && flag === 'blue');
+          dot.classList.toggle('yellow', isOn && flag === 'yellow');
+          label.textContent = isOn ? 'ON' : 'OFF';
+        });
+      }
+
+      function updateAckLine() {
+        const ack = getAck(currentRole);
+        const formatted = ack ? formatTs(ack) : 'none';
+        ackLine.innerHTML = `Device <strong>${currentRole}</strong> last processed update: <strong>${formatted}</strong>`;
+      }
+
+      function updateQueueLine() {
+        const queue = getQueue();
+        if (!queue.length) {
+          queueLine.textContent = 'Queue is empty.';
+          return;
+        }
+        const latest = queue[queue.length - 1];
+        queueLine.textContent = `Retained entries: ${queue.length} (latest @ ${formatTs(latest.ts)})`;
+      }
+
+      function describeState(state) {
+        return flags
+          .map(flag => `${capitalize(flag)} ${state[flag] ? 'ON' : 'off'}`)
+          .join(', ');
+      }
+
+      function capitalize(str) {
+        return str.charAt(0).toUpperCase() + str.slice(1);
+      }
+
+      function formatTs(ts) {
+        return new Date(ts).toLocaleTimeString([], { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
+      }
+
+      function log(message) {
+        const time = new Date().toLocaleTimeString([], { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
+        logOutput.textContent = `[${time}] ${message}\n` + logOutput.textContent;
+      }
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- revert the stack pill markup and styling in `ui-v9b.html` to the pre-label state
- add `queue-sim.html`, a self-contained harness that simulates an event-driven queue with device roles, flag toggles, and storage-driven updates

## Testing
- Not run (HTML demo only)


------
https://chatgpt.com/codex/tasks/task_e_68dc085ed50c832dbddab0f71898edd3