### PR TITLE
Allow first grid item to move after reordering

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -5990,7 +5990,7 @@
                 
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6002,6 +6002,9 @@
                 await state.dbManager.saveFolderCache(context.folderId, state.imageFiles);
 
                 state.stacks[state.grid.stack] = newStack;
+                if (state.grid.filtered.length === 0) {
+                    state.grid.anchorId = newStack[0] ? newStack[0].id : null;
+                }
                 state.currentStackPosition = 0;
                 Utils.showToast('Stack order updated', 'success');
             }
@@ -6079,6 +6082,10 @@
             }
 
             state.stacks[stackName] = newStackOrder;
+            if (state.grid.filtered.length === 0) {
+                const newAnchor = newStackOrder[0] ? newStackOrder[0].id : null;
+                state.grid.anchorId = newAnchor;
+            }
             if (state.grid.filtered.length > 0) {
                 const filteredIds = new Set(state.grid.filtered.map(file => file.id));
                 state.grid.filtered = newStackOrder.filter(file => filteredIds.has(file.id));


### PR DESCRIPTION
## Summary
- reset the grid anchor to the new top item when the stack order changes without filters
- ensure manual and drag-and-drop reorders update the anchor accordingly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc37b554f4832dbcf3f6b129e5b6ec