### PR TITLE
Restore uniform stack pill counters

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -198,10 +198,9 @@
         .edge-glow.active { opacity: 1; }
         
         .pill-counter {
-            position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px;
-            color: #f9fafb; opacity: 0; transition: all 0.3s ease;
-            cursor: pointer; z-index: 10; min-width: 70px; text-align: center;
-            display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px;
+            position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
+            color: black; opacity: 0; transition: all 0.3s ease;
+            cursor: pointer; z-index: 10; min-width: 50px; text-align: center;
         }
         .pill-counter.visible { opacity: 0.9; }
         .pill-counter.active {
@@ -213,16 +212,6 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-
-        .pill-counter .pill-label {
-            font-size: 12px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase;
-        }
-        .pill-counter:not(.active) .pill-label { color: rgba(249, 250, 251, 0.9); }
-        .pill-counter.active .pill-label { color: #111827; }
-
-        .pill-counter .pill-count {
-            font-size: 20px; font-weight: 700;
-        }
         
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
@@ -845,22 +834,10 @@
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
         
-        <div class="pill-counter top" id="pill-priority" data-stack="priority">
-            <span class="pill-label"></span>
-            <span class="pill-count" aria-live="polite">0</span>
-        </div>
-        <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">
-            <span class="pill-label"></span>
-            <span class="pill-count" aria-live="polite">0</span>
-        </div>
-        <div class="pill-counter left active" id="pill-in" data-stack="in">
-            <span class="pill-label"></span>
-            <span class="pill-count" aria-live="polite">0</span>
-        </div>
-        <div class="pill-counter right" id="pill-out" data-stack="out">
-            <span class="pill-label"></span>
-            <span class="pill-count" aria-live="polite">0</span>
-        </div>
+        <div class="pill-counter top" id="pill-priority" data-stack="priority" aria-live="polite">0</div>
+        <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash" aria-live="polite">0</div>
+        <div class="pill-counter left active" id="pill-in" data-stack="in" aria-live="polite">0</div>
+        <div class="pill-counter right" id="pill-out" data-stack="out" aria-live="polite">0</div>
         
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
@@ -5104,16 +5081,8 @@
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) {
                         const label = STACK_NAMES[stack] || stack;
-                        const pillLabel = pill.querySelector('.pill-label');
-                        const pillCount = pill.querySelector('.pill-count');
-                        if (pillLabel) {
-                            pillLabel.textContent = label;
-                        }
-                        if (pillCount) {
-                            const displayCount = count > 999 ? ':)' : count;
-                            pillCount.textContent = displayCount;
-                            pillCount.setAttribute('aria-label', `${label} stack has ${count} item${count === 1 ? '' : 's'}`);
-                        }
+                        const displayCount = count > 999 ? ':)' : count;
+                        pill.textContent = displayCount;
                         pill.setAttribute('aria-label', `${label} stack (${count} item${count === 1 ? '' : 's'})`);
                         pill.classList.toggle('visible', count > 0);
                     }


### PR DESCRIPTION
## Summary
- remove the stack pill counter labels and return to the compact single-value layout
- revert the counter styling and update the stack count logic to output the number directly on the pill

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc3b6d34d4832d9de89a81a5ebcbdf