### PR TITLE
Fix trash stack first-click behavior

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -7440,21 +7440,15 @@
                             const wasDifferentStack = state.currentStack !== stackName;
                             const shouldSetSkipNext = wasDifferentStack && !isPointerInvocation;
 
-                            if (stackName === 'trash') {
-                                if (wasDifferentStack) {
-                                    skipNextGridOpen = shouldSetSkipNext;
-                                    await UI.switchToStack(stackName);
-                                }
-                                Grid.open(stackName);
-                            } else if (!wasDifferentStack) {
-                                const shouldSkip = skipNextGridOpen && !state.isFocusMode;
-                                skipNextGridOpen = false;
-                                if (!shouldSkip) {
-                                    Grid.open(stackName);
-                                }
-                            } else {
+                            if (wasDifferentStack) {
                                 skipNextGridOpen = shouldSetSkipNext;
                                 return UI.switchToStack(stackName);
+                            }
+
+                            const shouldSkip = skipNextGridOpen && !state.isFocusMode;
+                            skipNextGridOpen = false;
+                            if (!shouldSkip) {
+                                Grid.open(stackName);
                             }
 
                             UI.acknowledgePillCounter(stackName);


### PR DESCRIPTION
## Summary
- adjust the trash stack pill logic so the first activation only switches stacks
- only open the grid modal when the recycle stack is already active to align with other stacks

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc513ce678832d9e91482b98063095