### PR TITLE
Normalize Google Drive links across the app

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -1106,6 +1106,57 @@
             isImageTransitioning: false,
             pendingBackgroundProbe: null
         };
+        // Centralized helper to keep Google Drive URL handling consistent across the app.
+        const DriveLinkHelper = {
+            isDriveApiDownloadUrl(url) {
+                if (typeof url !== 'string') return false;
+                return /googleapis\.com\/drive|drive\.googleusercontent\.com|drive\.google\.com\/uc\?/i.test(url);
+            },
+            isGoogleDriveFile(file, providerType = null) {
+                if (!file) return false;
+                const type = providerType || file.providerType || state.providerType || null;
+                if (type === 'googledrive') return true;
+                return Boolean(file.webViewLink || file.webContentLink || file.driveApiDownloadUrl);
+            },
+            computePermanentViewUrl(file) {
+                if (!file) return null;
+                const candidates = [file.viewUrl, file.webViewLink]
+                    .filter(url => typeof url === 'string' && url.length > 0 && !this.isDriveApiDownloadUrl(url));
+                if (candidates.length > 0) {
+                    return candidates[0];
+                }
+                if (typeof file.id === 'string' && file.id.length > 0) {
+                    return `https://drive.google.com/file/d/${file.id}/view`;
+                }
+                return null;
+            },
+            resolveApiDownloadUrl(file) {
+                if (!file) return null;
+                const candidates = [
+                    file.driveApiDownloadUrl,
+                    file.webContentLink,
+                    this.isDriveApiDownloadUrl(file.downloadUrl) ? file.downloadUrl : null
+                ];
+                return candidates.find(url => typeof url === 'string' && url.length > 0) || null;
+            },
+            normalizeFileLinks(file, providerType = null) {
+                if (!this.isGoogleDriveFile(file, providerType)) {
+                    return file;
+                }
+                const permanentLink = this.computePermanentViewUrl(file);
+                const apiDownloadUrl = this.resolveApiDownloadUrl(file);
+                if (apiDownloadUrl) {
+                    file.driveApiDownloadUrl = apiDownloadUrl;
+                } else if (file.driveApiDownloadUrl === undefined) {
+                    file.driveApiDownloadUrl = null;
+                }
+                if (permanentLink) {
+                    file.viewUrl = permanentLink;
+                    file.downloadUrl = permanentLink;
+                }
+                return file;
+            }
+        };
         const Utils = {
             elements: {},
             
@@ -1279,7 +1330,7 @@
             },
             
             getPreferredImageUrl(file) {
-                if (state.providerType === 'googledrive') {
+                if (DriveLinkHelper.isGoogleDriveFile(file, state.providerType)) {
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
@@ -1293,13 +1344,10 @@
             },
 
             getFallbackImageUrl(file) {
-                if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof file.downloadUrl === 'string' && file.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [file.viewUrl, file.webViewLink, hasViewStyleDownload ? file.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
+                if (DriveLinkHelper.isGoogleDriveFile(file, state.providerType)) {
+                    const permanentLink = DriveLinkHelper.computePermanentViewUrl(file);
                     if (permanentLink) { return permanentLink; }
-                    const apiDownloadLink = [file.driveApiDownloadUrl, file.webContentLink, !hasViewStyleDownload ? file.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
+                    const apiDownloadLink = DriveLinkHelper.resolveApiDownloadUrl(file);
                     return apiDownloadLink || `https://www.googleapis.com/drive/v3/files/${file.id}?alt=media`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
@@ -3630,9 +3678,7 @@
                     const files = response.files
                         .filter(file => file.mimeType && file.mimeType.startsWith('image/'))
                         .map(file => {
-                            const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                            const apiDownloadUrl = file.webContentLink || null;
-                            return {
+                            const normalized = {
                                 id: file.id,
                                 name: file.name,
                                 type: 'file',
@@ -3641,12 +3687,14 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
-                                viewUrl,
-                                driveApiDownloadUrl: apiDownloadUrl,
+                                downloadUrl: file.webContentLink || null,
+                                viewUrl: file.viewUrl || file.webViewLink || null,
+                                webViewLink: file.webViewLink,
+                                webContentLink: file.webContentLink,
                                 appProperties: file.appProperties || {},
                                 parents: file.parents
                             };
+                            return DriveLinkHelper.normalizeFileLinks(normalized, 'googledrive');
                         });
                     allFiles.push(...files);
                     nextPageToken = response.nextPageToken;
@@ -3809,14 +3857,12 @@
                     .filter(result => result.status === 'fulfilled')
                     .map(result => {
                         const file = result.value;
-                        const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                        const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
-                        return {
+                        const normalized = {
                             ...file,
-                            downloadUrl: viewUrl,
-                            viewUrl,
-                            driveApiDownloadUrl: apiDownloadUrl
+                            downloadUrl: file.webContentLink || file.downloadUrl || null,
+                            viewUrl: file.viewUrl || file.webViewLink || null
                         };
+                        return DriveLinkHelper.normalizeFileLinks(normalized, 'googledrive');
                     });
             }
             async drillIntoFolder(folder) {
@@ -4149,10 +4195,8 @@
                 } return '';
             }
             getDirectImageURL(image) {
-                if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof image.downloadUrl === 'string' && image.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [image.viewUrl, image.webViewLink, hasViewStyleDownload ? image.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
+                if (DriveLinkHelper.isGoogleDriveFile(image, state.providerType)) {
+                    const permanentLink = DriveLinkHelper.computePermanentViewUrl(image);
                     return permanentLink || `https://drive.google.com/file/d/${image.id}/view`;
                 } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
                 return '';
@@ -4398,6 +4442,7 @@
                 if (normalized.favorite == null) {
                     normalized.favorite = appProps.favorite === 'true';
                 }
+                DriveLinkHelper.normalizeFileLinks(normalized, normalized.providerType || file.providerType || state.providerType);
                 return normalized;
             },
             computeMetadataSignature(file) {
@@ -6101,7 +6146,7 @@
             populateInfoTab(file) {
                 const filename = file.name || 'Unknown';
                 Utils.elements.detailFilename.textContent = filename;
-                if (state.providerType === 'googledrive') { Utils.elements.detailFilenameLink.href = `https://drive.google.com/file/d/${file.id}/view`;
+                if (DriveLinkHelper.isGoogleDriveFile(file, state.providerType)) { Utils.elements.detailFilenameLink.href = DriveLinkHelper.computePermanentViewUrl(file) || '#';
                 } else { Utils.elements.detailFilenameLink.href = file.downloadUrl || '#'; }
                 Utils.elements.detailFilenameLink.style.display = 'inline';
                 const date = file.modifiedTime ? new Date(file.modifiedTime).toLocaleString() : file.createdTime ? new Date(file.createdTime).toLocaleString() : 'Unknown';


### PR DESCRIPTION
## Summary
- add a DriveLinkHelper to normalize Google Drive view/download URLs and retain API download links separately
- update metadata normalization and Drive provider responses to reuse the helper for consistent permanent links
- apply the helper when building export links, detail modal links, and image fallbacks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc8e2ecfd4832da5455c371648d4c3