### PR TITLE
Normalize cached files during cache hydration

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -4282,7 +4282,8 @@
             async loadImages(options = {}) {
                 const folderId = state.currentFolder.id;
                 const sessionKey = `${state.providerType || 'unknown'}::${folderId}`;
-                const cachedFiles = await state.dbManager.getFolderCache(folderId) || [];
+                let cachedFiles = await state.dbManager.getFolderCache(folderId) || [];
+                cachedFiles = this.normalizeCachedFiles(cachedFiles);
                 const isFirstSessionVisit = !state.sessionVisitedFolders.has(sessionKey);
                 const coordinator = state.folderSyncCoordinator;
                 let preparation = null;
@@ -4365,8 +4366,36 @@
                     state.syncLog?.log({ event: 'manifest:cleanup:error', level: 'warn', details: `Failed to prune duplicate manifests for ${folderId}: ${error.message}` });
                 }
             },
+            markFileMetadataNormalized(file) {
+                if (!file) return file;
+                if (!Object.prototype.hasOwnProperty.call(file, '__metadataNormalized')) {
+                    Object.defineProperty(file, '__metadataNormalized', {
+                        value: true,
+                        enumerable: false,
+                        configurable: true,
+                        writable: false
+                    });
+                }
+                return file;
+            },
+            ensureFileMetadataNormalized(file) {
+                if (!file) return file;
+                if (file.__metadataNormalized) {
+                    return file;
+                }
+                return this.normalizeFileMetadata(file);
+            },
+            normalizeCachedFiles(files = []) {
+                if (!Array.isArray(files) || files.length === 0) {
+                    return files || [];
+                }
+                return files.map(file => this.ensureFileMetadataNormalized(file));
+            },
             normalizeFileMetadata(file) {
                 if (!file) return file;
+                if (file.__metadataNormalized) {
+                    return file;
+                }
                 const normalized = {
                     ...file,
                     appProperties: { ...(file.appProperties || {}) }
@@ -4398,7 +4427,7 @@
                 if (normalized.favorite == null) {
                     normalized.favorite = appProps.favorite === 'true';
                 }
-                return normalized;
+                return this.markFileMetadataNormalized(normalized);
             },
             computeMetadataSignature(file) {
                 if (!file) return 'null';


### PR DESCRIPTION
## Summary
- normalize cached folder entries before hydrating state so cached sessions receive the same metadata cleanup as fresh fetches
- add helpers that mark normalized records to prevent redundant metadata normalization work

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc8e300c50832d8ca9ecf393333240