### PR TITLE
Improve IndexedDB reconnection handling in v9b UI

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -2043,9 +2043,17 @@
         class DBManager {
             constructor() {
                 this.db = null;
+                this.initPromise = null;
+                this.reconnectPromise = null;
+                this.reconnecting = false;
+                this.dbCloseHandler = () => this.handleDisconnect('close');
+                this.dbVersionChangeHandler = () => this.handleDisconnect('versionchange');
             }
-            async init() {
-                return new Promise((resolve, reject) => {
+            async init(force = false) {
+                if (!force && this.initPromise) {
+                    return this.initPromise;
+                }
+                const openPromise = new Promise((resolve, reject) => {
                     const request = indexedDB.open('Orbital8-Goji-V1', 4);
                     request.onupgradeneeded = (event) => {
                         const db = event.target.result;
@@ -2089,11 +2097,131 @@
                         }
                     };
                     request.onsuccess = (event) => {
-                        this.db = event.target.result;
-                        resolve();
+                        const db = event.target.result;
+                        this.bindDatabase(db);
+                        resolve(db);
                     };
-                    request.onerror = (event) => reject(event.target.error);
+                    request.onblocked = () => {
+                        reject(this.createReconnectionError('IndexedDB upgrade blocked by another session.'));
+                    };
+                    request.onerror = (event) => {
+                        const error = event.target.error || new Error('Failed to open IndexedDB.');
+                        if (this.shouldReconnect(error) || error?.name === 'VersionError') {
+                            error.reconnectPending = true;
+                        }
+                        reject(error);
+                    };
                 });
+                const wrapped = openPromise.then(db => db).catch(error => {
+                    if (this.initPromise === wrapped) {
+                        this.initPromise = null;
+                    }
+                    throw error;
+                });
+                this.initPromise = wrapped;
+                return wrapped;
+            }
+            bindDatabase(db) {
+                if (!db) return;
+                this.db = db;
+                this.reconnecting = false;
+                db.onclose = this.dbCloseHandler;
+                db.onversionchange = this.dbVersionChangeHandler;
+            }
+            handleDisconnect(reason = 'unknown') {
+                if (this.db) {
+                    try {
+                        this.db.onclose = null;
+                        this.db.onversionchange = null;
+                        this.db.close();
+                    } catch (error) {
+                        // Ignore close errors.
+                    }
+                }
+                this.db = null;
+                this.reconnecting = true;
+                this.initPromise = null;
+                if (this.reconnectPromise) {
+                    return this.reconnectPromise;
+                }
+                const reconnect = this.init(true).catch(error => {
+                    if (!error?.reconnectPending) {
+                        console.warn('DBManager: Reconnection attempt failed.', { reason, error });
+                    }
+                    throw error;
+                });
+                this.reconnectPromise = reconnect;
+                reconnect.catch(() => { /* handled above */ });
+                reconnect.finally(() => {
+                    if (this.reconnectPromise === reconnect) {
+                        this.reconnectPromise = null;
+                    }
+                });
+                return reconnect;
+            }
+            createReconnectionError(message = 'IndexedDB reconnection pending.') {
+                const error = new Error(message);
+                error.name = 'IndexedDBReconnecting';
+                error.reconnectPending = true;
+                return error;
+            }
+            shouldReconnect(error) {
+                if (!error || error.reconnectPending) return false;
+                const name = error.name || '';
+                if (name === 'InvalidStateError' || name === 'TransactionInactiveError') return true;
+                const message = String(error.message || '').toLowerCase();
+                return message.includes('connection is closing') || message.includes('the connection is closing') || message.includes('database connection is closing');
+            }
+            async ensureConnection() {
+                try {
+                    await (this.initPromise || this.init());
+                } catch (error) {
+                    if (error?.reconnectPending || this.shouldReconnect(error)) {
+                        const reconnectionError = this.createReconnectionError(error.message);
+                        reconnectionError.cause = error;
+                        throw reconnectionError;
+                    }
+                    throw error;
+                }
+                if (!this.db) {
+                    if (this.reconnecting) {
+                        throw this.createReconnectionError();
+                    }
+                    return null;
+                }
+                if (typeof this.db.closePending === 'boolean' && this.db.closePending) {
+                    this.handleDisconnect('close-pending');
+                    throw this.createReconnectionError('IndexedDB connection is closing.');
+                }
+                return this.db;
+            }
+            async performWithReconnect(executor, fallbackValue) {
+                let attempt = 0;
+                let lastError = null;
+                while (attempt < 2) {
+                    try {
+                        await this.ensureConnection();
+                        if (!this.db) {
+                            return fallbackValue;
+                        }
+                        return await executor();
+                    } catch (error) {
+                        lastError = error;
+                        if (error?.reconnectPending) {
+                            throw error;
+                        }
+                        if (attempt === 0 && this.shouldReconnect(error)) {
+                            this.handleDisconnect('operation-error');
+                            attempt += 1;
+                            continue;
+                        }
+                        throw error;
+                    }
+                }
+                if (lastError) {
+                    throw lastError;
+                }
+                return fallbackValue;
             }
             resolveFolderKey(input) {
                 if (!input) return null;
@@ -2104,47 +2232,42 @@
                 return `${providerType || 'unknown'}::${folderId}`;
             }
             async getFolderCache(folderId) {
-                if (!this.db) return null;
-                return new Promise((resolve, reject) => {
+                return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('folderCache', 'readonly');
                     const store = transaction.objectStore('folderCache');
                     const request = store.get(folderId);
                     request.onsuccess = () => resolve(request.result ? request.result.files : null);
                     request.onerror = () => reject(request.error);
-                });
+                }), null);
             }
             async saveFolderCache(folderId, files) {
-                if (!this.db) return;
-                return new Promise((resolve, reject) => {
+                return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('folderCache', 'readwrite');
                     const store = transaction.objectStore('folderCache');
                     const request = store.put({ folderId, files, timestamp: Date.now() });
                     request.onsuccess = () => resolve();
                     request.onerror = () => reject(request.error);
-                });
+                }));
             }
             async deleteFolderCache(folderId) {
-                if (!this.db) return;
-                return new Promise((resolve, reject) => {
+                return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('folderCache', 'readwrite');
                     const store = transaction.objectStore('folderCache');
                     const request = store.delete(folderId);
                     request.onsuccess = () => resolve();
                     request.onerror = () => reject(request.error);
-                });
+                }));
             }
             async getMetadata(fileId) {
-                if (!this.db) return null;
-                return new Promise((resolve, reject) => {
+                return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('metadata', 'readonly');
                     const store = transaction.objectStore('metadata');
                     const request = store.get(fileId);
                     request.onsuccess = () => resolve(request.result ? request.result.metadata : null);
                     request.onerror = () => reject(request.error);
-                });
+                }), null);
             }
             async saveMetadata(fileId, metadata, context = {}) {
-                if (!this.db) return;
                 const folderKey = this.resolveFolderKey(context);
                 if (!folderKey) {
                     const warning = `DBManager.saveMetadata: Missing folder context for ${fileId}.`;
@@ -2152,7 +2275,7 @@
                     throw new Error(warning);
                 }
                 const normalizedContext = typeof context === 'object' && context !== null ? context : {};
-                return new Promise((resolve, reject) => {
+                return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('metadata', 'readwrite');
                     const store = transaction.objectStore('metadata');
                     const record = {
@@ -2165,23 +2288,21 @@
                     const request = store.put(record);
                     request.onsuccess = () => resolve();
                     request.onerror = () => reject(request.error);
-                });
+                }));
             }
             async deleteMetadata(fileId) {
-                if (!this.db) return;
-                return new Promise((resolve, reject) => {
+                return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('metadata', 'readwrite');
                     const store = transaction.objectStore('metadata');
                     const request = store.delete(fileId);
                     request.onsuccess = () => resolve();
                     request.onerror = () => reject(request.error);
-                });
+                }));
             }
             async deleteMetadataByFolder(context) {
-                if (!this.db) return;
                 const folderKey = this.resolveFolderKey(context);
                 if (!folderKey) return;
-                return new Promise((resolve, reject) => {
+                return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('metadata', 'readwrite');
                     const store = transaction.objectStore('metadata');
                     const index = store.index('folderKey');
@@ -2192,10 +2313,9 @@
                         keys.forEach(key => store.delete(key));
                     };
                     request.onerror = () => reject(request.error);
-                });
+                }));
             }
             async addToSyncQueue(operation) {
-                if (!this.db) return null;
                 const entry = {
                     fileId: operation.fileId,
                     updates: operation.updates || {},
@@ -2209,17 +2329,16 @@
                     providerType: operation.providerType || null,
                     folderKey: operation.folderKey || null
                 };
-                return new Promise((resolve, reject) => {
+                return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('syncQueue', 'readwrite');
                     const store = transaction.objectStore('syncQueue');
                     const request = store.add(entry);
                     request.onsuccess = () => resolve(request.result);
                     request.onerror = () => reject(request.error);
-                });
+                }), null);
             }
             async readSyncQueue() {
-                if (!this.db) return [];
-                return new Promise((resolve, reject) => {
+                return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('syncQueue', 'readonly');
                     const store = transaction.objectStore('syncQueue');
                     const request = store.getAll();
@@ -2229,22 +2348,20 @@
                         resolve(results);
                     };
                     request.onerror = () => reject(request.error);
-                });
+                }), []);
             }
             async deleteFromSyncQueue(ids) {
-                if (!this.db) return;
                 const targetIds = Array.isArray(ids) ? ids : [ids];
-                return new Promise((resolve, reject) => {
+                return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('syncQueue', 'readwrite');
                     const store = transaction.objectStore('syncQueue');
                     targetIds.forEach(id => { store.delete(id); });
                     transaction.oncomplete = () => resolve();
                     transaction.onerror = () => reject(transaction.error);
-                });
+                }));
             }
             async updateSyncQueueEntry(id, updates) {
-                if (!this.db) return false;
-                return new Promise((resolve, reject) => {
+                return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('syncQueue', 'readwrite');
                     const store = transaction.objectStore('syncQueue');
                     const getRequest = store.get(id);
@@ -2257,27 +2374,25 @@
                         putRequest.onerror = () => reject(putRequest.error);
                     };
                     getRequest.onerror = () => reject(getRequest.error);
-                });
+                }), false);
             }
             async markPendingFlush(ids, pending = true) {
-                if (!this.db) return;
                 const targetIds = Array.isArray(ids) ? ids : [ids];
                 await Promise.all(targetIds.map(id => this.updateSyncQueueEntry(id, { pendingFlush: pending })));
             }
             async getFolderState(context) {
-                if (!this.db) return null;
                 const folderKey = this.resolveFolderKey(context);
                 if (!folderKey) return null;
-                return new Promise((resolve, reject) => {
+                return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('folderState', 'readonly');
                     const store = transaction.objectStore('folderState');
                     const request = store.get(folderKey);
                     request.onsuccess = () => resolve(request.result || null);
                     request.onerror = () => reject(request.error);
-                });
+                }), null);
             }
             async saveFolderState(record) {
-                if (!this.db || !record) return;
+                if (!record) return;
                 const folderKey = this.resolveFolderKey(record);
                 if (!folderKey) return;
                 const payload = {
@@ -2290,40 +2405,38 @@
                     lastCloudAck: record.lastCloudAck || null,
                     updatedAt: Date.now()
                 };
-                return new Promise((resolve, reject) => {
+                return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('folderState', 'readwrite');
                     const store = transaction.objectStore('folderState');
                     const request = store.put(payload);
                     request.onsuccess = () => resolve(payload);
                     request.onerror = () => reject(request.error);
-                });
+                }));
             }
             async deleteFolderState(context) {
-                if (!this.db) return;
                 const folderKey = this.resolveFolderKey(context);
                 if (!folderKey) return;
-                return new Promise((resolve, reject) => {
+                return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('folderState', 'readwrite');
                     const store = transaction.objectStore('folderState');
                     const request = store.delete(folderKey);
                     request.onsuccess = () => resolve();
                     request.onerror = () => reject(request.error);
-                });
+                }));
             }
             async getFolderManifest(context) {
-                if (!this.db) return null;
                 const folderKey = this.resolveFolderKey(context);
                 if (!folderKey) return null;
-                return new Promise((resolve, reject) => {
+                return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('folderManifests', 'readonly');
                     const store = transaction.objectStore('folderManifests');
                     const request = store.get(folderKey);
                     request.onsuccess = () => resolve(request.result || null);
                     request.onerror = () => reject(request.error);
-                });
+                }), null);
             }
             async saveFolderManifest(record) {
-                if (!this.db || !record) return;
+                if (!record) return;
                 const folderKey = this.resolveFolderKey(record);
                 if (!folderKey) return;
                 const payload = {
@@ -2347,25 +2460,24 @@
                 if (record.remoteUpdatedAt || record.updatedAt) {
                     payload.remoteUpdatedAt = record.remoteUpdatedAt || record.updatedAt;
                 }
-                return new Promise((resolve, reject) => {
+                return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('folderManifests', 'readwrite');
                     const store = transaction.objectStore('folderManifests');
                     const request = store.put(payload);
                     request.onsuccess = () => resolve(payload);
                     request.onerror = () => reject(request.error);
-                });
+                }));
             }
             async deleteFolderManifest(context) {
-                if (!this.db) return;
                 const folderKey = this.resolveFolderKey(context);
                 if (!folderKey) return;
-                return new Promise((resolve, reject) => {
+                return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('folderManifests', 'readwrite');
                     const store = transaction.objectStore('folderManifests');
                     const request = store.delete(folderKey);
                     request.onsuccess = () => resolve();
                     request.onerror = () => reject(request.error);
-                });
+                }));
             }
             async clearFolderData(context, fileIds = []) {
                 const folderKey = this.resolveFolderKey(context);
@@ -3011,6 +3123,12 @@
                     }
                     return result;
                 } catch (error) {
+                    if (error?.reconnectPending) {
+                        this.logger?.log({ event: 'sync:reconnect-wait', level: 'warn', details: 'IndexedDB reconnect in progress. Rescheduling sync loop.', data: { reason } });
+                        this.hasPendingWork = true;
+                        this.scheduleProcess('reconnect');
+                        return 'retry';
+                    }
                     this.logger?.log({ event: 'sync:error', level: 'error', details: `Queue processing failed: ${error.message}` });
                     return 'error';
                 } finally {


### PR DESCRIPTION
## Summary
- add reconnection-aware lifecycle hooks to the IndexedDB manager so it reopens after close/version changes
- share an `ensureConnection` guard and retry wrapper across DB helpers to recover from transient `InvalidStateError` closing states
- have the sync queue detect reconnection attempts and reschedule processing so manual flushes complete once the database is back

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc942214c4832d868989b1aad9fbba