### PR TITLE
Fix metadata normalization returning undefined

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -4582,6 +4582,10 @@
                 if (normalized.favorite == null) {
                     normalized.favorite = appProps.favorite === 'true';
                 }
+                DriveLinkHelper.normalizeFileLinks(normalized, normalized.providerType || state.providerType || null);
+                normalized.providerType = normalized.providerType || state.providerType || null;
+                this.markFileMetadataNormalized(normalized);
+                return normalized;
             },
             computeMetadataSignature(file) {
                 if (!file) return 'null';


### PR DESCRIPTION
## Summary
- ensure `normalizeFileMetadata` marks and returns normalized records
- normalize Google Drive links and provider metadata when hydrating cached files

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc9156b338832da7fe186240956f40