### PR TITLE
Enhance queue simulator with typed actions and gap testing

### DIFF
--- a/queue-sim.html
+++ b/queue-sim.html
@@ -1,0 +1,895 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Queue Sync Micro Simulation</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --bg: #f6f7fb;
+      --panel: #ffffff;
+      --border: #d6dae5;
+      --green: #2cb35c;
+      --blue: #3182ce;
+      --yellow: #d69e2e;
+      --off: #8a8f9c;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: #222;
+      line-height: 1.5;
+    }
+
+    main {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 32px 24px 64px;
+    }
+
+    h1 {
+      margin-top: 0;
+      font-size: 1.75rem;
+    }
+
+    section {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 20px;
+      margin-top: 20px;
+      box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+    }
+
+    .flex {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    .panel {
+      flex: 1 1 280px;
+      min-width: 260px;
+    }
+
+    fieldset {
+      border: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    .role-picker label {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      margin-right: 16px;
+      font-weight: 600;
+    }
+
+    .toggles {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      margin-top: 12px;
+    }
+
+    .toggle-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 12px;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: rgba(148, 163, 184, 0.08);
+    }
+
+    .toggle-row.inline {
+      justify-content: flex-start;
+      gap: 12px;
+    }
+
+    .form-row {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      margin-top: 12px;
+    }
+
+    select {
+      appearance: none;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 10px 12px;
+      font-weight: 600;
+      background: rgba(148, 163, 184, 0.08);
+    }
+
+    .action-panel {
+      margin-top: 12px;
+    }
+
+    .action-note {
+      margin: 0 0 6px;
+      font-size: 0.9rem;
+      color: #475569;
+    }
+
+    .toggle-row label {
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .toggle-row input[type="checkbox"] {
+      transform: scale(1.2);
+    }
+
+    button {
+      appearance: none;
+      border: none;
+      border-radius: 999px;
+      padding: 10px 18px;
+      font-weight: 600;
+      background: #1f2937;
+      color: #fff;
+      cursor: pointer;
+      transition: transform 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    button[disabled] {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+
+    button:hover:not([disabled]) {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 20px rgba(15, 23, 42, 0.2);
+    }
+
+    button.secondary {
+      background: transparent;
+      color: #1f2937;
+      border: 1px solid var(--border);
+      box-shadow: none;
+    }
+
+    .img-wrap {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      align-items: flex-start;
+    }
+
+    .img-wrap img {
+      width: 140px;
+      height: 140px;
+      border-radius: 16px;
+      border: 1px solid var(--border);
+      box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+      object-fit: cover;
+    }
+
+    .flag-status {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 12px;
+      width: 100%;
+    }
+
+    .flag-card {
+      border-radius: 12px;
+      padding: 12px 14px;
+      border: 1px solid var(--border);
+      background: rgba(241, 245, 249, 0.7);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-weight: 600;
+    }
+
+    .flag-card.deleted {
+      opacity: 0.7;
+    }
+
+    .flag-card .state {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-weight: 700;
+    }
+
+    .state-dot {
+      width: 12px;
+      height: 12px;
+      border-radius: 999px;
+      background: var(--off);
+    }
+
+    .state-dot.on.green { background: var(--green); }
+    .state-dot.on.blue { background: var(--blue); }
+    .state-dot.on.yellow { background: var(--yellow); }
+
+    .flag-card.deleted .state-label {
+      font-style: italic;
+      color: #64748b;
+    }
+
+    .log-controls {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-bottom: 12px;
+    }
+
+    pre {
+      background: #0f172a;
+      color: #f8fafc;
+      padding: 16px;
+      border-radius: 12px;
+      overflow: auto;
+      max-height: 320px;
+      margin: 0;
+      font-size: 0.9rem;
+    }
+
+    .status-line {
+      margin-top: 12px;
+      font-size: 0.9rem;
+      color: #475569;
+    }
+
+    .status-line strong {
+      color: #0f172a;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+
+      section {
+        background: rgba(15, 23, 42, 0.65);
+        border-color: rgba(148, 163, 184, 0.3);
+      }
+
+      button.secondary {
+        color: #e2e8f0;
+        border-color: rgba(148, 163, 184, 0.4);
+      }
+
+      .toggle-row {
+        background: rgba(30, 41, 59, 0.7);
+        border-color: rgba(148, 163, 184, 0.3);
+      }
+
+      .flag-card {
+        background: rgba(30, 41, 59, 0.75);
+        border-color: rgba(148, 163, 184, 0.3);
+      }
+
+      .status-line strong {
+        color: #e2e8f0;
+      }
+
+      select {
+        background: rgba(51, 65, 85, 0.7);
+        color: #e2e8f0;
+      }
+
+      .action-note {
+        color: #94a3b8;
+      }
+
+      .flag-card.deleted .state-label {
+        color: #cbd5f5;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Event-Driven Queue Simulation</h1>
+    <p>
+      Open this file in two browser tabs. Set one tab to <strong>Device A</strong> (publisher) and the
+      other to <strong>Device B</strong> (consumer). Device A publishes typed transactions (full-set, upsert,
+      delete) into a shared queue stored in <code>localStorage</code>. Each consumer processes only entries
+      newer than its stored watermark so you can validate incremental updates end to end.
+    </p>
+
+    <section>
+      <h2>Hands-on validation script</h2>
+      <ol>
+        <li>Open <code>queue-sim.html</code> in two or three tabs. Set one tab to <strong>Device A</strong>
+          (publisher), one to <strong>Device B</strong>, and optionally a third to <strong>Device C</strong> to
+          mirror a second consumer.</li>
+        <li>With Device A on <em>Publish full state</em>, choose an initial combination (for example: Green ON,
+          Blue OFF, Yellow ON) and press <strong>Publish update</strong>. Devices B and C should apply the entry
+          immediately through the storage event.</li>
+        <li>Switch Device A to <em>Upsert single flag</em>, target a single color, and publish both the ON and OFF
+          variants. Confirm the consumers append one log entry per upsert without replaying earlier history.</li>
+        <li>Change Device A to <em>Delete flag</em> and remove one color. Check that the shared display shows a dash
+          for the deleted flag and that both consumers record a delete transaction.</li>
+        <li>Refresh the Device C tab (or close and reopen it) and use <strong>Process new updates</strong> to prove it
+          resumes from its stored watermark rather than replaying the entire backlog.</li>
+        <li>Use <strong>Drop oldest entry</strong> to prune the retained window, then refresh Device B. The next
+          processing run should warn that the watermark predates the retained queue, exercising the full-reload
+          contingency.</li>
+      </ol>
+      <p>
+        After completing the flow, press <strong>Copy latest log</strong> on Device B or C to share the captured
+        output. Use the reset controls to clear the queue or per-device watermark before rerunning the script.
+      </p>
+    </section>
+
+    <section>
+      <h2>Choose your role</h2>
+      <fieldset class="role-picker">
+        <label><input type="radio" name="role" value="A" checked /> Device A (publish changes)</label>
+        <label><input type="radio" name="role" value="B" /> Device B (process queue)</label>
+        <label><input type="radio" name="role" value="C" /> Device C (process queue)</label>
+      </fieldset>
+      <p class="status-line" id="ack-line"></p>
+    </section>
+
+    <section class="flex">
+      <div class="panel" id="publisher-panel">
+        <h2>Device A &mdash; publish update</h2>
+        <p>Choose an operation and enqueue it for the consumers.</p>
+        <div class="form-row">
+          <label for="action-select">Operation</label>
+          <select id="action-select">
+            <option value="setFlags">Publish full state</option>
+            <option value="upsertFlag">Upsert single flag</option>
+            <option value="deleteFlag">Delete flag</option>
+          </select>
+        </div>
+        <div class="action-panel" data-action-panel="setFlags">
+          <p class="action-note">Send the entire flag set as one transaction.</p>
+          <div class="toggles">
+            <div class="toggle-row">
+              <label for="flag-green">Green</label>
+              <input type="checkbox" id="flag-green" data-flag-toggle="green" />
+            </div>
+            <div class="toggle-row">
+              <label for="flag-blue">Blue</label>
+              <input type="checkbox" id="flag-blue" data-flag-toggle="blue" />
+            </div>
+            <div class="toggle-row">
+              <label for="flag-yellow">Yellow</label>
+              <input type="checkbox" id="flag-yellow" data-flag-toggle="yellow" />
+            </div>
+          </div>
+        </div>
+        <div class="action-panel" data-action-panel="upsertFlag" hidden>
+          <p class="action-note">Update just one flag without touching the others.</p>
+          <div class="form-row">
+            <label for="upsert-flag">Flag</label>
+            <select id="upsert-flag">
+              <option value="green">Green</option>
+              <option value="blue">Blue</option>
+              <option value="yellow">Yellow</option>
+            </select>
+          </div>
+          <div class="toggle-row inline">
+            <label for="upsert-value">Set to ON</label>
+            <input type="checkbox" id="upsert-value" />
+          </div>
+        </div>
+        <div class="action-panel" data-action-panel="deleteFlag" hidden>
+          <p class="action-note">Remove a flag entirely to simulate a delete.</p>
+          <div class="form-row">
+            <label for="delete-flag">Flag</label>
+            <select id="delete-flag">
+              <option value="green">Green</option>
+              <option value="blue">Blue</option>
+              <option value="yellow">Yellow</option>
+            </select>
+          </div>
+        </div>
+        <div class="log-controls" style="margin-top:16px;">
+          <button id="publish-btn">Publish update</button>
+          <button class="secondary" id="reset-queue-btn">Clear queue</button>
+          <button class="secondary" id="drop-oldest-btn">Drop oldest entry</button>
+        </div>
+        <p class="status-line" id="queue-line"></p>
+      </div>
+
+      <div class="panel">
+        <h2>Shared flag display</h2>
+        <div class="img-wrap">
+          <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIwAAACMCAYAAAD5nd/tAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJ
+bWFnZVJlYWR5ccllPAAABhVJREFUeNrsnQtu2zAQhVeQ///SbiEOQkXIBqQE1TKoPY1TGVtCqhk+NEH5YZ5W3lbE8vC2WzznrbYbb7rttttt9z
+n3+X9AWUBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIhVAiNJna/qfU5JW+abtd82
+B3cDaXW1P1cZKbXGjS+FuEmVYj5dZ8rV6pg7n2X5+SbuS2XvyMGxrWt9HjsmN8QuuiiW8uQGiVNSkxsZ96if9Otd5xPKX88d3SWjfo8V3RcZuH
+KM2rVkgbiC4qc+DlH61JNW1Lu1DdIMpPGI93Y32bo7wqLx8k+2cs6GyZf3mfuJ4MjM79SDckzKLOaqy4wt5NwPDB+t9/m0THTut3o/68Z7i9FfP
+lmnfI2Kdm48O8dbNF7gskn5uCaZfrpX37WAh9Up1Im1XtfqsZW0wv1kXx1qiXBgZS8ps0X3Ud+WkzLIzLYa/kPp2NK77m87660ObmOY9q3DHvu
+PmXtQZ9+Hzy4Yq59tR1HxZJ1gXG1Ds2lpnKNCCFpbXCO7MHGHj5Y0shYjS6z5N3HVcY3moF1zjnmVji+a3KbKvHGbJUW3mOTw38NEyG4MXHe5h4
+U8MhYbDiKZKXUmPyhk/y0qnLs6z8cXbi96+F2Sfyay09SPkl7yZWeuI01n/Nu70re2n61/1PVdv4Mjb6hfeTyGbzTfZUXJNhrXSvUu1Lg0ip9J
+Di5yY7W2vlcESytvQfG1SFL2zNBGVY1qXVreTwQ17Wk7eay7KUqS2Fpqxea3ieS7hY7sk9e3pPyJG6UrfI+6zy/ls3elP1rPfjX+YdSq3X5HtpL
+u4KtnnSruW+o5rdtfW7s5eeYZz7G6N1uYz3m2GqzZV/nNnMRo95tRro1pnXf8q41ox7zbDWx61r7XawV/L0TvHVpssqR0bM3uk3m9SPdF1Gyr9X
+VP5WfZk5TrKXot8nMd6lY73H3WMRbtGcLzb7nXM/03VGyr9XtFuS5w7L+P4ckr/a/kr9YtV2dpHt9wWj1t7DXSI8F4cQq7P069nPE2Ulcl3S/UZ
++42kcmn37DcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAZfwCq5pwe9WH4G4AAAAA
+SUVORK5CYII=" alt="Shared demo image" />
+          <div class="flag-status" id="flag-status">
+            <div class="flag-card" data-flag="green">
+              <span>Green</span>
+              <span class="state"><span class="state-dot"></span><span class="state-label">OFF</span></span>
+            </div>
+            <div class="flag-card" data-flag="blue">
+              <span>Blue</span>
+              <span class="state"><span class="state-dot"></span><span class="state-label">OFF</span></span>
+            </div>
+            <div class="flag-card" data-flag="yellow">
+              <span>Yellow</span>
+              <span class="state"><span class="state-dot"></span><span class="state-label">OFF</span></span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Device B &mdash; process updates</h2>
+      <p>Process new queue entries or reset the consumer watermark.</p>
+      <div class="log-controls">
+        <button id="process-btn">Process new updates</button>
+        <button class="secondary" id="reset-ack-btn">Reset last seen</button>
+        <button class="secondary" id="copy-log-btn">Copy latest log</button>
+      </div>
+      <pre id="log" aria-live="polite"></pre>
+    </section>
+  </main>
+
+  <script>
+    (function () {
+      const CLOUD_QUEUE_KEY = 'queueSim:cloudQueue';
+      const LAST_ACK_KEY_PREFIX = 'queueSim:lastAck:';
+      const ROLE_KEY = 'queueSim:lastRole';
+      const MAX_QUEUE_LENGTH = 4000;
+      const flags = ['green', 'blue', 'yellow'];
+
+      const roleInputs = Array.from(document.querySelectorAll('input[name="role"]'));
+      const publishBtn = document.getElementById('publish-btn');
+      const resetQueueBtn = document.getElementById('reset-queue-btn');
+      const dropOldestBtn = document.getElementById('drop-oldest-btn');
+      const processBtn = document.getElementById('process-btn');
+      const resetAckBtn = document.getElementById('reset-ack-btn');
+      const copyLogBtn = document.getElementById('copy-log-btn');
+      const actionSelect = document.getElementById('action-select');
+      const actionPanels = Array.from(document.querySelectorAll('[data-action-panel]'));
+      const upsertFlagSelect = document.getElementById('upsert-flag');
+      const upsertValueInput = document.getElementById('upsert-value');
+      const deleteFlagSelect = document.getElementById('delete-flag');
+      const logOutput = document.getElementById('log');
+      const ackLine = document.getElementById('ack-line');
+      const queueLine = document.getElementById('queue-line');
+      const publisherPanel = document.getElementById('publisher-panel');
+      const toggleInputByFlag = new Map();
+      flags.forEach(flag => {
+        const el = document.querySelector(`input[data-flag-toggle="${flag}"]`);
+        if (el) {
+          toggleInputByFlag.set(flag, el);
+        }
+      });
+      const toggleInputs = Array.from(toggleInputByFlag.values());
+      const flagCards = new Map(Array.from(document.querySelectorAll('.flag-card')).map(card => [card.dataset.flag, card]));
+
+      let currentRole = localStorage.getItem(ROLE_KEY) || 'A';
+      let flagState = createEmptyState();
+
+      roleInputs.forEach(input => {
+        input.checked = input.value === currentRole;
+        input.addEventListener('change', () => {
+          if (!input.checked) return;
+          setRole(input.value);
+          if (input.value !== 'A') {
+            processQueue('role-change');
+          }
+        });
+      });
+
+      actionSelect.addEventListener('change', updateActionUI);
+
+      publishBtn.addEventListener('click', () => {
+        const entry = buildEntryFromUI();
+        if (!entry) {
+          return;
+        }
+        const stored = appendEntry(entry);
+        log(`Device A published → ${describeEntry(stored)}`);
+        updateQueueLine();
+        hydrateFromQueue();
+      });
+
+      resetQueueBtn.addEventListener('click', () => {
+        setQueue([]);
+        flagState = createEmptyState();
+        updateFlagCards();
+        log('Queue cleared (retained window reset).');
+        updateQueueLine();
+      });
+
+      dropOldestBtn.addEventListener('click', () => {
+        const queue = getQueue();
+        if (!queue.length) {
+          log('Queue empty — nothing to drop.');
+          return;
+        }
+        const removed = queue.shift();
+        setQueue(queue);
+        const ts = removed && removed.ts ? formatTs(removed.ts) : 'unknown time';
+        const idSnippet = removed && removed.id ? `${removed.id.slice(0, 8)}…` : 'legacy entry';
+        log(`Dropped oldest entry @ ${ts} (${idSnippet}) to simulate retention.`);
+        updateQueueLine();
+        hydrateFromQueue();
+      });
+
+      processBtn.addEventListener('click', () => {
+        processQueue('manual');
+      });
+
+      resetAckBtn.addEventListener('click', () => {
+        setAck(currentRole, 0);
+        log(`Last-seen watermark cleared for Device ${currentRole}.`);
+      });
+
+      copyLogBtn.addEventListener('click', async () => {
+        const text = logOutput.textContent.trim();
+        if (!text) {
+          log('ℹ️  Log is empty — run the steps above before copying.');
+          return;
+        }
+        try {
+          await navigator.clipboard.writeText(text);
+          log('📋 Log copied to clipboard.');
+        } catch (err) {
+          console.warn('Clipboard copy failed:', err);
+          selectLogFallback();
+          log('⚠️  Clipboard unavailable. Log highlighted for manual copy.');
+        }
+      });
+
+      window.addEventListener('storage', event => {
+        if (event.key === CLOUD_QUEUE_KEY) {
+          updateQueueLine();
+          hydrateFromQueue();
+          if (currentRole !== 'A') {
+            processQueue('storage');
+          }
+        }
+      });
+
+      initializeUI();
+
+      function initializeUI() {
+        setRole(currentRole);
+        hydrateFromQueue();
+        updateQueueLine();
+        if (currentRole !== 'A') {
+          processQueue('startup');
+        }
+      }
+
+      function setRole(role) {
+        currentRole = role;
+        localStorage.setItem(ROLE_KEY, role);
+        const isPublisher = role === 'A';
+        publisherPanel.style.opacity = isPublisher ? '1' : '0.55';
+        publishBtn.disabled = !isPublisher;
+        resetQueueBtn.disabled = !isPublisher;
+        dropOldestBtn.disabled = !isPublisher;
+        processBtn.disabled = isPublisher;
+        resetAckBtn.disabled = isPublisher;
+        copyLogBtn.disabled = false;
+        roleInputs.forEach(input => (input.checked = input.value === role));
+        updateAckLine();
+        updateActionUI();
+      }
+
+      function readToggleState() {
+        return flags.reduce((acc, flag) => {
+          const input = toggleInputByFlag.get(flag);
+          acc[flag] = input ? Boolean(input.checked) : false;
+          return acc;
+        }, {});
+      }
+
+      function buildEntryFromUI() {
+        const action = actionSelect.value;
+        if (action === 'setFlags') {
+          return { type: 'setFlags', payload: { flags: readToggleState() } };
+        }
+        if (action === 'upsertFlag') {
+          const flag = upsertFlagSelect.value;
+          if (!flag) {
+            log('Select a flag before publishing an upsert.');
+            return null;
+          }
+          return { type: 'upsertFlag', payload: { flag, value: Boolean(upsertValueInput.checked) } };
+        }
+        if (action === 'deleteFlag') {
+          const flag = deleteFlagSelect.value;
+          if (!flag) {
+            log('Choose which flag to delete before publishing.');
+            return null;
+          }
+          return { type: 'deleteFlag', payload: { flag } };
+        }
+        log(`Unknown action: ${action}`);
+        return null;
+      }
+
+      function appendEntry(entry) {
+        const queue = getQueue();
+        const enriched = {
+          id: crypto.randomUUID(),
+          ts: Date.now(),
+          ...entry
+        };
+        queue.push(enriched);
+        if (queue.length > MAX_QUEUE_LENGTH) {
+          queue.splice(0, queue.length - MAX_QUEUE_LENGTH);
+        }
+        setQueue(queue);
+        return enriched;
+      }
+
+      function getQueue() {
+        const raw = localStorage.getItem(CLOUD_QUEUE_KEY);
+        if (!raw) return [];
+        try {
+          const parsed = JSON.parse(raw);
+          return Array.isArray(parsed) ? parsed : [];
+        } catch (err) {
+          console.warn('Unable to parse stored queue:', err);
+          return [];
+        }
+      }
+
+      function setQueue(queue) {
+        localStorage.setItem(CLOUD_QUEUE_KEY, JSON.stringify(queue));
+      }
+
+      function getAck(role) {
+        const raw = localStorage.getItem(LAST_ACK_KEY_PREFIX + role);
+        if (!raw) return 0;
+        const value = Number(raw);
+        return Number.isFinite(value) ? value : 0;
+      }
+
+      function setAck(role, value) {
+        localStorage.setItem(LAST_ACK_KEY_PREFIX + role, String(value || 0));
+        updateAckLine();
+      }
+
+      function processQueue(reason) {
+        const queue = getQueue()
+          .slice()
+          .sort((a, b) => (a.ts || 0) - (b.ts || 0))
+          .map(normalizeEntry)
+          .filter(Boolean);
+        const ack = getAck(currentRole);
+        const earliest = queue.length ? queue[0].ts : null;
+
+        if (!queue.length) {
+          if (reason === 'manual') {
+            log('Queue empty — nothing to process.');
+          }
+          return;
+        }
+
+        if (ack && earliest && ack < earliest) {
+          log(`⚠️  Watermark (${formatTs(ack)}) predates retained window (${formatTs(earliest)}). Trigger full reload.`);
+        }
+
+        const newEntries = queue.filter(entry => (entry.ts || 0) > ack);
+        if (!newEntries.length) {
+          if (reason !== 'storage') {
+            log('No updates newer than last processed watermark.');
+          }
+          return;
+        }
+
+        newEntries.forEach(entry => {
+          applyEntry(entry);
+          const idSnippet = entry.id ? `${entry.id.slice(0, 8)}…` : 'legacy entry';
+          log(`✅ Applied ${describeEntry(entry)} @ ${formatTs(entry.ts)} (${idSnippet})`);
+        });
+
+        const latestTs = newEntries[newEntries.length - 1].ts || Date.now();
+        setAck(currentRole, latestTs);
+      }
+
+      function applyEntry(entry) {
+        mutateState(entry);
+        updateFlagCards();
+      }
+
+      function mutateState(entry) {
+        if (!entry || !entry.type) {
+          return;
+        }
+        switch (entry.type) {
+          case 'setFlags': {
+            const flagsPayload = entry.payload && entry.payload.flags ? entry.payload.flags : {};
+            flags.forEach(flag => {
+              const hasFlag = Object.prototype.hasOwnProperty.call(flagsPayload, flag);
+              const next = hasFlag ? flagsPayload[flag] : false;
+              flagState[flag] = next ? 'on' : 'off';
+            });
+            break;
+          }
+          case 'upsertFlag': {
+            const flag = entry.payload && entry.payload.flag;
+            if (flag) {
+              const value = entry.payload.value ? 'on' : 'off';
+              flagState[flag] = value;
+            }
+            break;
+          }
+          case 'deleteFlag': {
+            const flag = entry.payload && entry.payload.flag;
+            if (flag) {
+              flagState[flag] = 'deleted';
+            }
+            break;
+          }
+          default: {
+            console.warn('Unknown entry type:', entry);
+          }
+        }
+      }
+
+      function hydrateFromQueue() {
+        const queue = getQueue()
+          .slice()
+          .sort((a, b) => (a.ts || 0) - (b.ts || 0))
+          .map(normalizeEntry)
+          .filter(Boolean);
+        flagState = createEmptyState();
+        queue.forEach(entry => mutateState(entry));
+        updateFlagCards();
+      }
+
+      function createEmptyState() {
+        return flags.reduce((acc, flag) => {
+          acc[flag] = 'off';
+          return acc;
+        }, {});
+      }
+
+      function updateFlagCards() {
+        flagCards.forEach((card, flag) => {
+          const dot = card.querySelector('.state-dot');
+          const label = card.querySelector('.state-label');
+          const state = flagState[flag] || 'off';
+          const isOn = state === 'on';
+          const isDeleted = state === 'deleted';
+          card.classList.toggle('deleted', isDeleted);
+          dot.classList.toggle('on', isOn);
+          dot.classList.toggle('green', isOn && flag === 'green');
+          dot.classList.toggle('blue', isOn && flag === 'blue');
+          dot.classList.toggle('yellow', isOn && flag === 'yellow');
+          label.textContent = isDeleted ? '—' : isOn ? 'ON' : 'OFF';
+        });
+      }
+
+      function updateAckLine() {
+        const ack = getAck(currentRole);
+        const formatted = ack ? formatTs(ack) : 'none';
+        ackLine.innerHTML = `Device <strong>${currentRole}</strong> last processed update: <strong>${formatted}</strong>`;
+      }
+
+      function updateQueueLine() {
+        const queue = getQueue();
+        if (!queue.length) {
+          queueLine.textContent = 'Queue is empty.';
+          return;
+        }
+        const ordered = queue
+          .slice()
+          .sort((a, b) => (a.ts || 0) - (b.ts || 0));
+        const earliest = ordered[0];
+        const latest = ordered[ordered.length - 1];
+        queueLine.textContent = `Retained entries: ${ordered.length}/${MAX_QUEUE_LENGTH} window (earliest @ ${formatTs(earliest.ts)}, latest @ ${formatTs(latest.ts)})`;
+      }
+
+      function describeFlags(state) {
+        return flags
+          .map(flag => `${capitalize(flag)} ${state && state[flag] ? 'ON' : 'off'}`)
+          .join(', ');
+      }
+
+      function describeEntry(entry) {
+        if (!entry) {
+          return 'unknown entry';
+        }
+        switch (entry.type) {
+          case 'setFlags': {
+            const state = entry.payload && entry.payload.flags ? entry.payload.flags : {};
+            return `setFlags → ${describeFlags(state)}`;
+          }
+          case 'upsertFlag': {
+            const flag = entry.payload && entry.payload.flag;
+            if (!flag) {
+              return 'upsert (missing flag)';
+            }
+            return `upsert ${capitalize(flag)} ${entry.payload.value ? 'ON' : 'off'}`;
+          }
+          case 'deleteFlag': {
+            const flag = entry.payload && entry.payload.flag;
+            return flag ? `delete ${capitalize(flag)}` : 'delete (missing flag)';
+          }
+          default:
+            return 'unknown entry';
+        }
+      }
+
+      function normalizeEntry(raw) {
+        if (!raw) {
+          return null;
+        }
+        if (raw.type && raw.payload) {
+          return raw;
+        }
+        if (raw.state) {
+          return { ...raw, type: 'setFlags', payload: { flags: raw.state } };
+        }
+        return raw;
+      }
+
+      function updateActionUI() {
+        const action = actionSelect.value;
+        actionPanels.forEach(panel => {
+          panel.hidden = panel.dataset.actionPanel !== action;
+        });
+        const isPublisher = currentRole === 'A';
+        actionSelect.disabled = !isPublisher;
+        toggleInputs.forEach(input => {
+          if (input) {
+            input.disabled = !isPublisher || action !== 'setFlags';
+          }
+        });
+        if (upsertFlagSelect) {
+          upsertFlagSelect.disabled = !isPublisher || action !== 'upsertFlag';
+        }
+        if (upsertValueInput) {
+          upsertValueInput.disabled = !isPublisher || action !== 'upsertFlag';
+        }
+        if (deleteFlagSelect) {
+          deleteFlagSelect.disabled = !isPublisher || action !== 'deleteFlag';
+        }
+      }
+
+      function capitalize(str) {
+        if (!str) return '';
+        return str.charAt(0).toUpperCase() + str.slice(1);
+      }
+
+      function formatTs(ts) {
+        if (!ts) {
+          return 'unknown';
+        }
+        return new Date(ts).toLocaleTimeString([], { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
+      }
+
+      function log(message) {
+        const time = new Date().toLocaleTimeString([], { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
+        logOutput.textContent = `[${time}] ${message}\n` + logOutput.textContent;
+      }
+
+      function selectLogFallback() {
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(logOutput);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add UI controls and validation steps for publishing full-state, upsert, and delete transactions plus a Device C consumer
- extend the simulator logic to store typed queue entries, replay them per action, and expose gap testing via drop-oldest retention controls

## Testing
- Not run (HTML-only change)

------
https://chatgpt.com/codex/tasks/task_e_68dc085ed50c832dbddab0f71898edd3