### PR TITLE
Sanitize folder cache entries before IndexedDB storage

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -2341,10 +2341,16 @@
                 }), null);
             }
             async saveFolderCache(folderId, files) {
+                const sanitizeEntry = (entry) => this.sanitizeMetadataForStorage(entry);
+                const sanitizedFiles = Array.isArray(files)
+                    ? files
+                        .map(file => sanitizeEntry(file))
+                        .filter(file => file !== undefined)
+                    : sanitizeEntry(files);
                 return this.performWithReconnect(() => new Promise((resolve, reject) => {
                     const transaction = this.db.transaction('folderCache', 'readwrite');
                     const store = transaction.objectStore('folderCache');
-                    const request = store.put({ folderId, files, timestamp: Date.now() });
+                    const request = store.put({ folderId, files: sanitizedFiles, timestamp: Date.now() });
                     request.onsuccess = () => resolve();
                     request.onerror = () => reject(request.error);
                 }));


### PR DESCRIPTION
## Summary
- sanitize folder cache payloads before persisting to IndexedDB
- ensure each cached entry strips non-cloneable properties while retaining existing metadata

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcfd37efa8832dacfcddb1ed8a2db1