### PR TITLE
Remember grid modal layout when toggling fullscreen

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -7634,6 +7634,17 @@
                     return state.modalLayout[this.id];
                 }
 
+                storeLastNormalLayout(layout) {
+                    if (!layout || layout.margin === 0) return;
+                    layout.lastNormal = {
+                        width: layout.width,
+                        height: layout.height,
+                        x: layout.x,
+                        y: layout.y,
+                        margin: layout.margin
+                    };
+                }
+
                 getMargin(layout) {
                     return typeof layout.margin === 'number' ? layout.margin : this.defaultMargin;
                 }
@@ -7677,6 +7688,7 @@
                         layout.x = clamped.x;
                         layout.y = clamped.y;
                     }
+                    this.storeLastNormalLayout(layout);
                     return layout;
                 }
 
@@ -7754,6 +7766,7 @@
                         layout.x = clamped.x;
                         layout.y = clamped.y;
                         this.applyTransform(layout);
+                        this.storeLastNormalLayout(layout);
                     };
                     this.onDragEnd = (event) => {
                         if (!this.dragState || event.pointerId !== this.dragState.pointerId) return;
@@ -7873,6 +7886,7 @@
                         this.applySize(newWidth, newHeight);
                         this.applyMargin(layout);
                         this.applyTransform(layout);
+                        this.storeLastNormalLayout(layout);
                     };
 
                     this.onResizeEnd = (event) => {
@@ -7927,7 +7941,22 @@
                         if (this.id === 'details-modal') {
                             this.snapToMaxFit();
                         } else if (this.id === 'grid-modal') {
-                            this.snapToFullscreen();
+                            const layout = this.ensureLayout();
+                            const isFullscreen = layout.margin === 0;
+                            if (isFullscreen && layout.lastNormal) {
+                                layout.width = layout.lastNormal.width;
+                                layout.height = layout.lastNormal.height;
+                                layout.x = layout.lastNormal.x;
+                                layout.y = layout.lastNormal.y;
+                                layout.margin = layout.lastNormal.margin;
+                                this.applySize(layout.width, layout.height);
+                                this.applyMargin(layout);
+                                this.applyTransform(layout);
+                                this.storeLastNormalLayout(layout);
+                            } else {
+                                this.storeLastNormalLayout(layout);
+                                this.snapToFullscreen();
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
## Summary
- store the grid modal's last non-fullscreen geometry before entering fullscreen
- toggle fullscreen on double-click by restoring the saved windowed layout when available
- keep the saved layout up to date during drag and resize interactions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd05caa668832d912ab21955ef8cf0