### PR TITLE
Hide details panel when opening grid view

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -5769,6 +5769,7 @@
             _dragMoveHandler: null,
             _dragEndHandler: null,
             open(stack) {
+                Details.hide();
                 Utils.showModal('grid-modal');
                 Utils.elements.gridTitle.textContent = STACK_NAMES[stack] || stack;
                 state.grid.stack = stack;
@@ -8100,7 +8101,7 @@
                 });
             },
             setupDetailsModal() {
-                Utils.elements.detailsButton.addEventListener('click', () => { if (state.stacks[state.currentStack].length > 0) { Details.show(); } });
+                Utils.elements.detailsButton.addEventListener('click', () => { Details.show(); });
                 Utils.elements.detailsClose.addEventListener('click', () => Details.hide());
             },
             setupFocusMode() {


### PR DESCRIPTION
## Summary
- remove the guard around the details button click handler so `Details.show()` controls availability
- hide the details panel before displaying the grid modal to avoid overlapping surfaces

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd1043a9a4832d8645b7d52b41b9ab