### PR TITLE
Skip unnecessary folder-switch flush

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -5162,9 +5162,17 @@
                 }
 
                 try {
-                    if (state.syncManager) {
-                        await state.syncManager.flush({ reason: 'folder-switch' });
+                    const syncManager = state.syncManager;
+                    const bufferedCount = syncManager?.pendingMutations?.size || 0;
+                    const hasQueuedWork = Boolean(syncManager?.hasPendingWork);
+                    const hasManifestUpdates = Boolean(syncManager?.pendingManifestUpdates?.size);
+                    const shouldFlush = Boolean(syncManager && (bufferedCount > 0 || hasQueuedWork || hasManifestUpdates));
+
+                    if (shouldFlush) {
+                        Utils.showScreen('folder-screen');
+                        await syncManager.flush({ reason: 'folder-switch' });
                     }
+
                     state.activeRequests.abort();
                     this.resetViewState();
                     Utils.showScreen('folder-screen');


### PR DESCRIPTION
## Summary
- avoid awaiting a folder-switch flush when the sync manager has no buffered or queued work
- reveal the folder picker before any required flush so background sync completes without delaying the UI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd10574c34832d8efaf5544340d2ed