### PR TITLE
Fix details modal lookup

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -6457,7 +6457,9 @@
             currentTab: 'info',
             async show() {
                 try {
-                    const currentFile = state.stacks[state.currentStack][state.currentStackPosition];
+                    const currentFile = (typeof Core?.getCurrentFile === 'function')
+                        ? Core.getCurrentFile()
+                        : state.stacks[state.currentStack]?.[state.currentStackPosition];
                     if (!currentFile) return;
                     const container = Utils.elements.detailsModal;
                     if (!container) return;


### PR DESCRIPTION
## Summary
- ensure the Details modal looks up the current image via Core.getCurrentFile so it always resolves a file before opening

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd17e8fe90832db299decc848dd538