### PR TITLE
Fix v9b details button failing due to invalid stack index

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -5483,13 +5483,20 @@
                 });
             },
 
+            normalizeStackIndex(position, length) {
+                if (!Number.isFinite(position) || length <= 0) { return 0; }
+                const coerced = Math.trunc(position);
+                if (coerced <= 0) { return 0; }
+                if (coerced >= length) { return length - 1; }
+                return coerced;
+            },
+
             getCurrentFile() {
                 const stackName = state.currentStack;
                 if (!stackName) { return null; }
                 const stack = state.stacks[stackName];
                 if (!Array.isArray(stack) || stack.length === 0) { return null; }
-                const position = typeof state.currentStackPosition === 'number' ? state.currentStackPosition : 0;
-                if (position < 0 || position >= stack.length) { return null; }
+                const position = this.normalizeStackIndex(state.currentStackPosition, stack.length);
                 return stack[position] || null;
             },
 
@@ -5589,7 +5596,7 @@
             getCurrentFile() {
                 const stackArray = state.stacks[state.currentStack];
                 if (!Array.isArray(stackArray) || stackArray.length === 0) { return null; }
-                const clampedIndex = Math.min(Math.max(state.currentStackPosition, 0), stackArray.length - 1);
+                const clampedIndex = this.normalizeStackIndex(state.currentStackPosition, stackArray.length);
                 return stackArray[clampedIndex] || null;
             },
 
@@ -7430,13 +7437,21 @@
             async nextImage() {
                 const stack = state.stacks[state.currentStack];
                 if (stack.length === 0) return;
-                state.currentStackPosition = (state.currentStackPosition + 1) % stack.length;
+                const baseIndex = Number.isFinite(state.currentStackPosition)
+                    ? Math.trunc(state.currentStackPosition)
+                    : 0;
+                const rawNext = (baseIndex + 1) % stack.length;
+                state.currentStackPosition = Number.isFinite(rawNext) ? rawNext : 0;
                 await Core.displayCurrentImage();
             },
             async prevImage() {
                 const stack = state.stacks[state.currentStack];
                 if (stack.length === 0) return;
-                state.currentStackPosition = (state.currentStackPosition - 1 + stack.length) % stack.length;
+                const baseIndex = Number.isFinite(state.currentStackPosition)
+                    ? Math.trunc(state.currentStackPosition)
+                    : 0;
+                const rawPrev = (baseIndex - 1 + stack.length) % stack.length;
+                state.currentStackPosition = Number.isFinite(rawPrev) ? rawPrev : 0;
                 await Core.displayCurrentImage();
             },
             async deleteCurrentImage() {


### PR DESCRIPTION
## Summary
- harden the v9b Core.getCurrentFile helper so non-finite indices default to zero and always clamp within the stack bounds
- reuse the index normalizer for gesture navigation to prevent modulo arithmetic from producing NaN positions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd91326d68832d8b021c3cc0cffa22