### PR TITLE
Use Google Drive view links for permanent URLs

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -1205,8 +1205,16 @@
 
                 const fileMatch = url.match(/drive\.google\.com\/file\/d\/([^/]+)/i);
                 const resolvedId = (fileMatch && fileMatch[1]) || fileId;
+                if (fileMatch) {
+                    // Preserve original view URLs so the permanent link stays in the Google Drive UI shape.
+                    if (/\/view(\?|#|$)/i.test(url)) {
+                        return url;
+                    }
+                    return `https://drive.google.com/file/d/${fileMatch[1]}/view`;
+                }
+
                 if (resolvedId) {
-                    return `https://drive.google.com/uc?id=${resolvedId}&export=view`;
+                    return `https://drive.google.com/file/d/${resolvedId}/view`;
                 }
 
                 return null;
@@ -1249,7 +1257,7 @@
                 }
 
                 if (fileId) {
-                    return `https://drive.google.com/uc?id=${fileId}&export=view`;
+                    return `https://drive.google.com/file/d/${fileId}/view`;
                 }
 
                 return null;


### PR DESCRIPTION
## Summary
- preserve Google Drive file view links instead of converting them to download URLs when normalizing
- ensure the permanent link fallback reconstructs the /file/d/<id>/view form when necessary
- keep UI components referencing Drive permanent links pointing at the shareable view URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddc295e6dc832d97923f320181c622