### PR TITLE
Handle Google Drive tokenized download URLs

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -1169,6 +1169,72 @@
                     return candidate;
                 };
 
+                const transientParams = ['confirm', 'token', 'authuser'];
+
+                const stripTransientParamsFromParsed = (parsed) => {
+                    let mutated = false;
+                    for (const param of transientParams) {
+                        if (parsed.searchParams.has(param)) {
+                            parsed.searchParams.delete(param);
+                            mutated = true;
+                        }
+                    }
+                    return mutated;
+                };
+
+                const stripTransientParams = (candidate) => {
+                    if (!candidate) return candidate;
+                    try {
+                        const parsed = new URL(candidate);
+                        const mutated = stripTransientParamsFromParsed(parsed);
+                        return mutated ? parsed.toString() : candidate;
+                    } catch (err) {
+                        return candidate;
+                    }
+                };
+
+                const extractIdFromCandidate = (candidate) => {
+                    if (!candidate || typeof candidate !== 'string') {
+                        return null;
+                    }
+
+                    const candidateTrimmed = candidate.trim();
+
+                    try {
+                        const parsed = new URL(candidateTrimmed);
+                        const directId = parsed.searchParams.get('id') || parsed.searchParams.get('fileId');
+                        if (directId) {
+                            return directId;
+                        }
+                        const pathMatchers = [
+                            /\/d\/([^/]+)/i,
+                            /\/folders\/([^/]+)/i,
+                            /\/download\/([^/?]+)/i,
+                            /\/files\/([^/]+)/i
+                        ];
+                        for (const matcher of pathMatchers) {
+                            const match = parsed.pathname.match(matcher);
+                            if (match) {
+                                return match[1];
+                            }
+                        }
+                    } catch (err) {
+                        // Fall back to manual parsing below.
+                    }
+
+                    const queryIdMatch = candidateTrimmed.match(/[?&](?:id|fileId)=([^&#]+)/i);
+                    if (queryIdMatch) {
+                        return decodeURIComponent(queryIdMatch[1]);
+                    }
+
+                    const pathIdMatch = candidateTrimmed.match(/\/d\/([^/]+)/i);
+                    if (pathIdMatch) {
+                        return pathIdMatch[1];
+                    }
+
+                    return null;
+                };
+
                 const buildUcUrl = (candidateId) => {
                     const resolvedId = candidateId || fileId;
                     if (!resolvedId) return null;
@@ -1178,58 +1244,64 @@
                     return base.toString();
                 };
 
+                const findFileId = (candidate, fallback = null) => {
+                    const extractedId = extractIdFromCandidate(candidate);
+                    if (extractedId) {
+                        return extractedId;
+                    }
+                    return fallback || fileId || null;
+                };
+
                 const ensureUcParams = (candidate, candidateId = null) => {
                     if (!candidate) return buildUcUrl(candidateId);
                     try {
                         const parsed = new URL(candidate);
-                        const resolvedId = candidateId || parsed.searchParams.get('id') || fileId;
+                        const resolvedId = findFileId(candidate, candidateId);
                         if (!resolvedId) {
-                            const pathMatch = parsed.pathname.match(/\/d\/([^/]+)/i);
-                            if (pathMatch) {
-                                return buildUcUrl(pathMatch[1]);
-                            }
                             return null;
                         }
+                        parsed.protocol = 'https:';
+                        parsed.hostname = 'drive.google.com';
                         parsed.pathname = '/uc';
                         parsed.searchParams.set('id', resolvedId);
                         parsed.searchParams.set('export', 'view');
+                        stripTransientParamsFromParsed(parsed);
                         return parsed.toString();
                     } catch (err) {
-                        const idMatch = candidate.match(/[?&]id=([^&#]+)/i);
-                        const resolvedId = candidateId || (idMatch ? decodeURIComponent(idMatch[1]) : fileId);
+                        const resolvedId = findFileId(candidate, candidateId);
                         return buildUcUrl(resolvedId);
                     }
                 };
 
                 const trimmed = url.trim();
+                const sanitized = stripTransientParams(trimmed);
 
-                if (this.isDriveApiDownloadUrl(trimmed)) {
-                    if (/drive\.google\.com\/uc\?/i.test(trimmed)) {
-                        return ensureUcParams(trimmed);
+                if (/googleusercontent\.com/i.test(sanitized)) {
+                    const explicitId = extractIdFromCandidate(sanitized);
+                    if (explicitId) {
+                        return buildUcUrl(explicitId);
                     }
-                    return ensureAltMedia(trimmed);
                 }
 
-                if (/drive\.google\.com\/uc\?/i.test(trimmed)) {
-                    return ensureUcParams(trimmed);
+                if (this.isDriveApiDownloadUrl(sanitized)) {
+                    if (/drive\.google\.com\/uc\?/i.test(sanitized)) {
+                        return ensureUcParams(sanitized);
+                    }
+                    return ensureAltMedia(sanitized);
                 }
 
-                const fileMatch = trimmed.match(/drive\.google\.com\/file\/d\/([^/]+)/i);
+                if (/drive\.google\.com\/uc\?/i.test(sanitized)) {
+                    return ensureUcParams(sanitized);
+                }
+
+                const fileMatch = sanitized.match(/drive\.google\.com\/file\/d\/([^/]+)/i);
                 if (fileMatch) {
                     return buildUcUrl(fileMatch[1]);
                 }
 
-                try {
-                    const parsed = new URL(trimmed);
-                    const resolvedId = parsed.searchParams.get('id') || parsed.searchParams.get('fileId') || fileId;
-                    if (resolvedId) {
-                        return buildUcUrl(resolvedId);
-                    }
-                } catch (err) {
-                    const idMatch = trimmed.match(/[?&]id=([^&#]+)/i);
-                    if (idMatch) {
-                        return buildUcUrl(decodeURIComponent(idMatch[1]));
-                    }
+                const resolvedId = findFileId(sanitized);
+                if (resolvedId) {
+                    return buildUcUrl(resolvedId);
                 }
 
                 return buildUcUrl(fileId);


### PR DESCRIPTION
## Summary
- normalize drive.googleusercontent.com and other tokenized download URLs into canonical https://drive.google.com/uc links
- drop transient query parameters (confirm, token, authuser) while preserving the existing alt=media handling for Drive API URLs
- reuse shared ID extraction so fallback logic consistently rebuilds Drive view links

## Testing
- node <<'NODE' ... NODE

------
https://chatgpt.com/codex/tasks/task_e_68de055e8c08832d9884fe317a8fb4b8