### PR TITLE
Fix folder navigation regression in ui-v9b

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -4376,11 +4376,14 @@
                 Utils.showScreen('folder-screen');
 
                 try {
+                    if (state.syncManager) {
+                        await state.syncManager.flush({ reason: 'folder-switch' });
                     }
                     state.activeRequests.abort();
+                    state.activeRequests = new AbortController();
                     this.resetViewState({ skipEmptyState: true });
                     await Folders.load();
-                } catch(error) {
+                } catch (error) {
                     Utils.showToast(`Error returning to folders: ${error.message}`, 'error', true);
                     Utils.showScreen('folder-screen');
                 } finally {


### PR DESCRIPTION
## Summary
- restore the folder navigation handler in ui-v9b by flushing pending sync work and resetting request state before reloading folders
- ensure the folder button re-enables correctly after returning to the folder screen

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68de3bc3af80832d89bb83fc4cec957b