### PR TITLE
Prevent double image advancement on tap

### DIFF
--- a/ui-v1.html
+++ b/ui-v1.html
@@ -5736,6 +5736,7 @@
             TRAIL_INTERVAL_MS: 12,
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
+            ignoreMouseEvents: false,
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -5929,6 +5930,12 @@
                 }
             },
             handleStart(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    this.ignoreMouseEvents = true;
+                } else if (this.ignoreMouseEvents) {
+                    return;
+                }
                 this.tapHandled = false;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
@@ -5973,6 +5980,10 @@
                 }
             },
             handleEnd(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    setTimeout(() => { this.ignoreMouseEvents = false; }, 400);
+                }
                 if (!state.isDragging) return;
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -5578,6 +5578,7 @@
             TRAIL_INTERVAL_MS: 12,
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
+            ignoreMouseEvents: false,
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -5771,6 +5772,12 @@
                 }
             },
             handleStart(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    this.ignoreMouseEvents = true;
+                } else if (this.ignoreMouseEvents) {
+                    return;
+                }
                 this.tapHandled = false;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
@@ -5815,6 +5822,10 @@
                 }
             },
             handleEnd(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    setTimeout(() => { this.ignoreMouseEvents = false; }, 400);
+                }
                 if (!state.isDragging) return;
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -5578,6 +5578,7 @@
             TRAIL_INTERVAL_MS: 12,
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
+            ignoreMouseEvents: false,
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -5771,6 +5772,12 @@
                 }
             },
             handleStart(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    this.ignoreMouseEvents = true;
+                } else if (this.ignoreMouseEvents) {
+                    return;
+                }
                 this.tapHandled = false;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
@@ -5815,6 +5822,10 @@
                 }
             },
             handleEnd(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    setTimeout(() => { this.ignoreMouseEvents = false; }, 400);
+                }
                 if (!state.isDragging) return;
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');

--- a/ui-v2-old.html
+++ b/ui-v2-old.html
@@ -3526,6 +3526,7 @@
             TRAIL_INTERVAL_MS: 12,
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
+            ignoreMouseEvents: false,
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -3719,6 +3720,12 @@
                 }
             },
             handleStart(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    this.ignoreMouseEvents = true;
+                } else if (this.ignoreMouseEvents) {
+                    return;
+                }
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
                 const point = e.touches ? e.touches[0] : e;
@@ -3762,6 +3769,10 @@
                 }
             },
             handleEnd(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    setTimeout(() => { this.ignoreMouseEvents = false; }, 400);
+                }
                 if (!state.isDragging) return;
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -5736,6 +5736,7 @@
             TRAIL_INTERVAL_MS: 12,
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
+            ignoreMouseEvents: false,
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -5929,6 +5930,12 @@
                 }
             },
             handleStart(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    this.ignoreMouseEvents = true;
+                } else if (this.ignoreMouseEvents) {
+                    return;
+                }
                 this.tapHandled = false;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
@@ -5973,6 +5980,10 @@
                 }
             },
             handleEnd(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    setTimeout(() => { this.ignoreMouseEvents = false; }, 400);
+                }
                 if (!state.isDragging) return;
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -5736,6 +5736,7 @@
             TRAIL_INTERVAL_MS: 12,
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
+            ignoreMouseEvents: false,
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -5929,6 +5930,12 @@
                 }
             },
             handleStart(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    this.ignoreMouseEvents = true;
+                } else if (this.ignoreMouseEvents) {
+                    return;
+                }
                 this.tapHandled = false;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
@@ -5973,6 +5980,10 @@
                 }
             },
             handleEnd(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    setTimeout(() => { this.ignoreMouseEvents = false; }, 400);
+                }
                 if (!state.isDragging) return;
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -5736,6 +5736,7 @@
             TRAIL_INTERVAL_MS: 12,
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
+            ignoreMouseEvents: false,
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -5929,6 +5930,12 @@
                 }
             },
             handleStart(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    this.ignoreMouseEvents = true;
+                } else if (this.ignoreMouseEvents) {
+                    return;
+                }
                 this.tapHandled = false;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
@@ -5973,6 +5980,10 @@
                 }
             },
             handleEnd(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    setTimeout(() => { this.ignoreMouseEvents = false; }, 400);
+                }
                 if (!state.isDragging) return;
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -5736,6 +5736,7 @@
             TRAIL_INTERVAL_MS: 12,
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
+            ignoreMouseEvents: false,
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -5929,6 +5930,12 @@
                 }
             },
             handleStart(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    this.ignoreMouseEvents = true;
+                } else if (this.ignoreMouseEvents) {
+                    return;
+                }
                 this.tapHandled = false;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
@@ -5973,6 +5980,10 @@
                 }
             },
             handleEnd(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    setTimeout(() => { this.ignoreMouseEvents = false; }, 400);
+                }
                 if (!state.isDragging) return;
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -5736,6 +5736,7 @@
             TRAIL_INTERVAL_MS: 12,
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
+            ignoreMouseEvents: false,
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -5929,6 +5930,12 @@
                 }
             },
             handleStart(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    this.ignoreMouseEvents = true;
+                } else if (this.ignoreMouseEvents) {
+                    return;
+                }
                 this.tapHandled = false;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
@@ -5973,6 +5980,10 @@
                 }
             },
             handleEnd(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    setTimeout(() => { this.ignoreMouseEvents = false; }, 400);
+                }
                 if (!state.isDragging) return;
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -5736,6 +5736,7 @@
             TRAIL_INTERVAL_MS: 12,
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
+            ignoreMouseEvents: false,
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -5929,6 +5930,12 @@
                 }
             },
             handleStart(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    this.ignoreMouseEvents = true;
+                } else if (this.ignoreMouseEvents) {
+                    return;
+                }
                 this.tapHandled = false;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
@@ -5973,6 +5980,10 @@
                 }
             },
             handleEnd(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    setTimeout(() => { this.ignoreMouseEvents = false; }, 400);
+                }
                 if (!state.isDragging) return;
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -5736,6 +5736,7 @@
             TRAIL_INTERVAL_MS: 12,
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
+            ignoreMouseEvents: false,
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -5929,6 +5930,12 @@
                 }
             },
             handleStart(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    this.ignoreMouseEvents = true;
+                } else if (this.ignoreMouseEvents) {
+                    return;
+                }
                 this.tapHandled = false;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
@@ -5973,6 +5980,10 @@
                 }
             },
             handleEnd(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    setTimeout(() => { this.ignoreMouseEvents = false; }, 400);
+                }
                 if (!state.isDragging) return;
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -5736,6 +5736,7 @@
             TRAIL_INTERVAL_MS: 12,
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
+            ignoreMouseEvents: false,
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -5929,6 +5930,12 @@
                 }
             },
             handleStart(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    this.ignoreMouseEvents = true;
+                } else if (this.ignoreMouseEvents) {
+                    return;
+                }
                 this.tapHandled = false;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
@@ -5973,6 +5980,10 @@
                 }
             },
             handleEnd(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    setTimeout(() => { this.ignoreMouseEvents = false; }, 400);
+                }
                 if (!state.isDragging) return;
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -5736,6 +5736,7 @@
             TRAIL_INTERVAL_MS: 12,
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
+            ignoreMouseEvents: false,
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -5929,6 +5930,12 @@
                 }
             },
             handleStart(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    this.ignoreMouseEvents = true;
+                } else if (this.ignoreMouseEvents) {
+                    return;
+                }
                 this.tapHandled = false;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
@@ -5973,6 +5980,10 @@
                 }
             },
             handleEnd(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    setTimeout(() => { this.ignoreMouseEvents = false; }, 400);
+                }
                 if (!state.isDragging) return;
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -5736,6 +5736,7 @@
             TRAIL_INTERVAL_MS: 12,
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
+            ignoreMouseEvents: false,
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -5929,6 +5930,12 @@
                 }
             },
             handleStart(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    this.ignoreMouseEvents = true;
+                } else if (this.ignoreMouseEvents) {
+                    return;
+                }
                 this.tapHandled = false;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
@@ -5973,6 +5980,10 @@
                 }
             },
             handleEnd(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    setTimeout(() => { this.ignoreMouseEvents = false; }, 400);
+                }
                 if (!state.isDragging) return;
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -5736,6 +5736,7 @@
             TRAIL_INTERVAL_MS: 12,
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
+            ignoreMouseEvents: false,
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -5929,6 +5930,12 @@
                 }
             },
             handleStart(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    this.ignoreMouseEvents = true;
+                } else if (this.ignoreMouseEvents) {
+                    return;
+                }
                 this.tapHandled = false;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
@@ -5973,6 +5980,10 @@
                 }
             },
             handleEnd(e) {
+                const isTouchEvent = e.type && e.type.startsWith('touch');
+                if (isTouchEvent) {
+                    setTimeout(() => { this.ignoreMouseEvents = false; }, 400);
+                }
                 if (!state.isDragging) return;
                 state.isDragging = false;
                 Utils.elements.centerImage.classList.remove('dragging');


### PR DESCRIPTION
## Summary
- add a touch-aware ignoreMouseEvents flag to the gesture handlers across the ui-v* variants
- prevent synthetic mouse events after taps from causing double navigation so images only advance or retreat once per tap

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de73087f14832da05cc48521e4d437