### PR TITLE
Ensure touch guard persists across rapid taps

### DIFF
--- a/ui-v9.html
+++ b/ui-v9.html
@@ -5737,6 +5737,7 @@
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
             ignoreMouseEvents: false,
+            ignoreMouseEventsResetTimer: null,
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -5932,6 +5933,10 @@
             handleStart(e) {
                 const isTouchEvent = e.type && e.type.startsWith('touch');
                 if (isTouchEvent) {
+                    if (this.ignoreMouseEventsResetTimer) {
+                        clearTimeout(this.ignoreMouseEventsResetTimer);
+                        this.ignoreMouseEventsResetTimer = null;
+                    }
                     this.ignoreMouseEvents = true;
                 } else if (this.ignoreMouseEvents) {
                     return;
@@ -5982,7 +5987,13 @@
             handleEnd(e) {
                 const isTouchEvent = e.type && e.type.startsWith('touch');
                 if (isTouchEvent) {
-                    setTimeout(() => { this.ignoreMouseEvents = false; }, 400);
+                    if (this.ignoreMouseEventsResetTimer) {
+                        clearTimeout(this.ignoreMouseEventsResetTimer);
+                    }
+                    this.ignoreMouseEventsResetTimer = setTimeout(() => {
+                        this.ignoreMouseEvents = false;
+                        this.ignoreMouseEventsResetTimer = null;
+                    }, 400);
                 }
                 if (!state.isDragging) return;
                 state.isDragging = false;


### PR DESCRIPTION
## Summary
- keep the ignoreMouseEvents tap guard active across successive touches by tracking the reset timeout
- clear any pending timeout when a new touch begins or the reset is rescheduled so rapid taps do not leak mouse events

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de78511f3c832d9873466d02c80637