### PR TITLE
Defer navigation updates and restore Drive fallbacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1256,11 +1256,43 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
+            defer(callback, options = {}) {
+                const { priority = 'normal', timeout = 120 } = options;
+                const run = () => {
+                    try {
+                        const result = callback();
+                        if (result && typeof result.then === 'function') {
+                            result.catch(error => console.error('Deferred task failed', error));
+                        }
+                    } catch (error) {
+                        console.error('Deferred task failed', error);
+                    }
+                };
+                if (priority === 'animation' && typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(run);
+                    return;
+                }
+                if (typeof requestIdleCallback === 'function') {
+                    const idleTimeout = priority === 'high' ? Math.min(timeout, 48) : timeout;
+                    requestIdleCallback(run, { timeout: idleTimeout });
+                } else {
+                    const delay = priority === 'high' ? 0 : priority === 'animation' ? 16 : 32;
+                    setTimeout(run, delay);
+                }
+            },
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -3831,13 +3863,13 @@
             }
             getDirectImageURL(image) {
                 if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof image.downloadUrl === 'string' && image.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [image.viewUrl, image.webViewLink, hasViewStyleDownload ? image.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    return permanentLink || `https://drive.google.com/file/d/${image.id}/view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                    return `https://drive.google.com/uc?id=${image.id}&export=view`;
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
+
             downloadCSV(data) {
                 const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = state.grid.stack;
@@ -4665,7 +4697,7 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
@@ -4709,12 +4741,15 @@
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
 
+                    Utils.defer(() => {
+                        Core.updateImageCounters();
+                        Core.updateFavoriteButton();
+                    }, { priority: 'animation' });
+
                     if (currentFile.metadataStatus === 'pending') {
-                        App.processFileMetadata(currentFile);
+                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
-                    
-                    this.updateImageCounters();
-                    this.updateFavoriteButton();
+
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -4822,7 +4857,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -1256,11 +1256,43 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
+            defer(callback, options = {}) {
+                const { priority = 'normal', timeout = 120 } = options;
+                const run = () => {
+                    try {
+                        const result = callback();
+                        if (result && typeof result.then === 'function') {
+                            result.catch(error => console.error('Deferred task failed', error));
+                        }
+                    } catch (error) {
+                        console.error('Deferred task failed', error);
+                    }
+                };
+                if (priority === 'animation' && typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(run);
+                    return;
+                }
+                if (typeof requestIdleCallback === 'function') {
+                    const idleTimeout = priority === 'high' ? Math.min(timeout, 48) : timeout;
+                    requestIdleCallback(run, { timeout: idleTimeout });
+                } else {
+                    const delay = priority === 'high' ? 0 : priority === 'animation' ? 16 : 32;
+                    setTimeout(run, delay);
+                }
+            },
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -3831,13 +3863,13 @@
             }
             getDirectImageURL(image) {
                 if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof image.downloadUrl === 'string' && image.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [image.viewUrl, image.webViewLink, hasViewStyleDownload ? image.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    return permanentLink || `https://drive.google.com/file/d/${image.id}/view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                    return `https://drive.google.com/uc?id=${image.id}&export=view`;
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
+
             downloadCSV(data) {
                 const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = state.grid.stack;
@@ -4665,7 +4697,7 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
@@ -4709,12 +4741,15 @@
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
 
+                    Utils.defer(() => {
+                        Core.updateImageCounters();
+                        Core.updateFavoriteButton();
+                    }, { priority: 'animation' });
+
                     if (currentFile.metadataStatus === 'pending') {
-                        App.processFileMetadata(currentFile);
+                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
-                    
-                    this.updateImageCounters();
-                    this.updateFavoriteButton();
+
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -4822,7 +4857,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -1188,18 +1188,43 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof file.downloadUrl === 'string' && file.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [file.viewUrl, file.webViewLink, hasViewStyleDownload ? file.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    if (permanentLink) { return permanentLink; }
-                    const apiDownloadLink = [file.driveApiDownloadUrl, file.webContentLink, !hasViewStyleDownload ? file.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    return apiDownloadLink || `https://www.googleapis.com/drive/v3/files/${file.id}?alt=media`;
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
+            defer(callback, options = {}) {
+                const { priority = 'normal', timeout = 120 } = options;
+                const run = () => {
+                    try {
+                        const result = callback();
+                        if (result && typeof result.then === 'function') {
+                            result.catch(error => console.error('Deferred task failed', error));
+                        }
+                    } catch (error) {
+                        console.error('Deferred task failed', error);
+                    }
+                };
+                if (priority === 'animation' && typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(run);
+                    return;
+                }
+                if (typeof requestIdleCallback === 'function') {
+                    const idleTimeout = priority === 'high' ? Math.min(timeout, 48) : timeout;
+                    requestIdleCallback(run, { timeout: idleTimeout });
+                } else {
+                    const delay = priority === 'high' ? 0 : priority === 'animation' ? 16 : 32;
+                    setTimeout(run, delay);
+                }
+            },
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -3745,13 +3770,13 @@
             }
             getDirectImageURL(image) {
                 if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof image.downloadUrl === 'string' && image.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [image.viewUrl, image.webViewLink, hasViewStyleDownload ? image.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    return permanentLink || `https://drive.google.com/file/d/${image.id}/view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                    return `https://drive.google.com/uc?id=${image.id}&export=view`;
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
+
             downloadCSV(data) {
                 const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = state.grid.stack;
@@ -4512,7 +4537,7 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
@@ -4556,12 +4581,15 @@
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
 
+                    Utils.defer(() => {
+                        Core.updateImageCounters();
+                        Core.updateFavoriteButton();
+                    }, { priority: 'animation' });
+
                     if (currentFile.metadataStatus === 'pending') {
-                        App.processFileMetadata(currentFile);
+                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
-                    
-                    this.updateImageCounters();
-                    this.updateFavoriteButton();
+
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -4669,7 +4697,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -1188,18 +1188,43 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof file.downloadUrl === 'string' && file.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [file.viewUrl, file.webViewLink, hasViewStyleDownload ? file.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    if (permanentLink) { return permanentLink; }
-                    const apiDownloadLink = [file.driveApiDownloadUrl, file.webContentLink, !hasViewStyleDownload ? file.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    return apiDownloadLink || `https://www.googleapis.com/drive/v3/files/${file.id}?alt=media`;
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
+            defer(callback, options = {}) {
+                const { priority = 'normal', timeout = 120 } = options;
+                const run = () => {
+                    try {
+                        const result = callback();
+                        if (result && typeof result.then === 'function') {
+                            result.catch(error => console.error('Deferred task failed', error));
+                        }
+                    } catch (error) {
+                        console.error('Deferred task failed', error);
+                    }
+                };
+                if (priority === 'animation' && typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(run);
+                    return;
+                }
+                if (typeof requestIdleCallback === 'function') {
+                    const idleTimeout = priority === 'high' ? Math.min(timeout, 48) : timeout;
+                    requestIdleCallback(run, { timeout: idleTimeout });
+                } else {
+                    const delay = priority === 'high' ? 0 : priority === 'animation' ? 16 : 32;
+                    setTimeout(run, delay);
+                }
+            },
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -3745,13 +3770,13 @@
             }
             getDirectImageURL(image) {
                 if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof image.downloadUrl === 'string' && image.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [image.viewUrl, image.webViewLink, hasViewStyleDownload ? image.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    return permanentLink || `https://drive.google.com/file/d/${image.id}/view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                    return `https://drive.google.com/uc?id=${image.id}&export=view`;
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
+
             downloadCSV(data) {
                 const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = state.grid.stack;
@@ -4512,7 +4537,7 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
@@ -4556,12 +4581,15 @@
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
 
+                    Utils.defer(() => {
+                        Core.updateImageCounters();
+                        Core.updateFavoriteButton();
+                    }, { priority: 'animation' });
+
                     if (currentFile.metadataStatus === 'pending') {
-                        App.processFileMetadata(currentFile);
+                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
-                    
-                    this.updateImageCounters();
-                    this.updateFavoriteButton();
+
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -4669,7 +4697,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();

--- a/ui-v2-old.html
+++ b/ui-v2-old.html
@@ -1172,13 +1172,44 @@
             },
 
             getFallbackImageUrl(file) {
-                 if (state.providerType === 'googledrive') {
-                    return file.downloadUrl || `https://www.googleapis.com/drive/v3/files/${file.id}?alt=media`;
+                if (state.providerType === 'googledrive') {
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
+            defer(callback, options = {}) {
+                const { priority = 'normal', timeout = 120 } = options;
+                const run = () => {
+                    try {
+                        const result = callback();
+                        if (result && typeof result.then === 'function') {
+                            result.catch(error => console.error('Deferred task failed', error));
+                        }
+                    } catch (error) {
+                        console.error('Deferred task failed', error);
+                    }
+                };
+                if (priority === 'animation' && typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(run);
+                    return;
+                }
+                if (typeof requestIdleCallback === 'function') {
+                    const idleTimeout = priority === 'high' ? Math.min(timeout, 48) : timeout;
+                    requestIdleCallback(run, { timeout: idleTimeout });
+                } else {
+                    const delay = priority === 'high' ? 0 : priority === 'animation' ? 16 : 32;
+                    setTimeout(run, delay);
+                }
+            },
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -2194,10 +2225,14 @@
                 } return '';
             }
             getDirectImageURL(image) {
-                if (state.providerType === 'googledrive') { return `https://drive.google.com/uc?id=${image.id}&export=view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                if (state.providerType === 'googledrive') {
+                    return `https://drive.google.com/uc?id=${image.id}&export=view`;
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
+
             downloadCSV(data) {
                 const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = state.grid.stack;
@@ -2635,7 +2670,7 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
@@ -2678,12 +2713,15 @@
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
 
+                    Utils.defer(() => {
+                        Core.updateImageCounters();
+                        Core.updateFavoriteButton();
+                    }, { priority: 'animation' });
+
                     if (currentFile.metadataStatus === 'pending') {
-                        App.processFileMetadata(currentFile);
+                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
-                    
-                    this.updateImageCounters();
-                    this.updateFavoriteButton();
+
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -2768,7 +2806,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -1256,11 +1256,43 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
+            defer(callback, options = {}) {
+                const { priority = 'normal', timeout = 120 } = options;
+                const run = () => {
+                    try {
+                        const result = callback();
+                        if (result && typeof result.then === 'function') {
+                            result.catch(error => console.error('Deferred task failed', error));
+                        }
+                    } catch (error) {
+                        console.error('Deferred task failed', error);
+                    }
+                };
+                if (priority === 'animation' && typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(run);
+                    return;
+                }
+                if (typeof requestIdleCallback === 'function') {
+                    const idleTimeout = priority === 'high' ? Math.min(timeout, 48) : timeout;
+                    requestIdleCallback(run, { timeout: idleTimeout });
+                } else {
+                    const delay = priority === 'high' ? 0 : priority === 'animation' ? 16 : 32;
+                    setTimeout(run, delay);
+                }
+            },
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -3831,13 +3863,13 @@
             }
             getDirectImageURL(image) {
                 if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof image.downloadUrl === 'string' && image.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [image.viewUrl, image.webViewLink, hasViewStyleDownload ? image.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    return permanentLink || `https://drive.google.com/file/d/${image.id}/view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                    return `https://drive.google.com/uc?id=${image.id}&export=view`;
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
+
             downloadCSV(data) {
                 const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = state.grid.stack;
@@ -4665,7 +4697,7 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
@@ -4709,12 +4741,15 @@
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
 
+                    Utils.defer(() => {
+                        Core.updateImageCounters();
+                        Core.updateFavoriteButton();
+                    }, { priority: 'animation' });
+
                     if (currentFile.metadataStatus === 'pending') {
-                        App.processFileMetadata(currentFile);
+                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
-                    
-                    this.updateImageCounters();
-                    this.updateFavoriteButton();
+
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -4822,7 +4857,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -1256,11 +1256,43 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
+            defer(callback, options = {}) {
+                const { priority = 'normal', timeout = 120 } = options;
+                const run = () => {
+                    try {
+                        const result = callback();
+                        if (result && typeof result.then === 'function') {
+                            result.catch(error => console.error('Deferred task failed', error));
+                        }
+                    } catch (error) {
+                        console.error('Deferred task failed', error);
+                    }
+                };
+                if (priority === 'animation' && typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(run);
+                    return;
+                }
+                if (typeof requestIdleCallback === 'function') {
+                    const idleTimeout = priority === 'high' ? Math.min(timeout, 48) : timeout;
+                    requestIdleCallback(run, { timeout: idleTimeout });
+                } else {
+                    const delay = priority === 'high' ? 0 : priority === 'animation' ? 16 : 32;
+                    setTimeout(run, delay);
+                }
+            },
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -3831,13 +3863,13 @@
             }
             getDirectImageURL(image) {
                 if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof image.downloadUrl === 'string' && image.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [image.viewUrl, image.webViewLink, hasViewStyleDownload ? image.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    return permanentLink || `https://drive.google.com/file/d/${image.id}/view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                    return `https://drive.google.com/uc?id=${image.id}&export=view`;
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
+
             downloadCSV(data) {
                 const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = state.grid.stack;
@@ -4665,7 +4697,7 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
@@ -4709,12 +4741,15 @@
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
 
+                    Utils.defer(() => {
+                        Core.updateImageCounters();
+                        Core.updateFavoriteButton();
+                    }, { priority: 'animation' });
+
                     if (currentFile.metadataStatus === 'pending') {
-                        App.processFileMetadata(currentFile);
+                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
-                    
-                    this.updateImageCounters();
-                    this.updateFavoriteButton();
+
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -4822,7 +4857,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -1256,11 +1256,43 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
+            defer(callback, options = {}) {
+                const { priority = 'normal', timeout = 120 } = options;
+                const run = () => {
+                    try {
+                        const result = callback();
+                        if (result && typeof result.then === 'function') {
+                            result.catch(error => console.error('Deferred task failed', error));
+                        }
+                    } catch (error) {
+                        console.error('Deferred task failed', error);
+                    }
+                };
+                if (priority === 'animation' && typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(run);
+                    return;
+                }
+                if (typeof requestIdleCallback === 'function') {
+                    const idleTimeout = priority === 'high' ? Math.min(timeout, 48) : timeout;
+                    requestIdleCallback(run, { timeout: idleTimeout });
+                } else {
+                    const delay = priority === 'high' ? 0 : priority === 'animation' ? 16 : 32;
+                    setTimeout(run, delay);
+                }
+            },
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -3831,13 +3863,13 @@
             }
             getDirectImageURL(image) {
                 if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof image.downloadUrl === 'string' && image.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [image.viewUrl, image.webViewLink, hasViewStyleDownload ? image.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    return permanentLink || `https://drive.google.com/file/d/${image.id}/view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                    return `https://drive.google.com/uc?id=${image.id}&export=view`;
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
+
             downloadCSV(data) {
                 const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = state.grid.stack;
@@ -4665,7 +4697,7 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
@@ -4709,12 +4741,15 @@
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
 
+                    Utils.defer(() => {
+                        Core.updateImageCounters();
+                        Core.updateFavoriteButton();
+                    }, { priority: 'animation' });
+
                     if (currentFile.metadataStatus === 'pending') {
-                        App.processFileMetadata(currentFile);
+                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
-                    
-                    this.updateImageCounters();
-                    this.updateFavoriteButton();
+
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -4822,7 +4857,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -1256,11 +1256,43 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
+            defer(callback, options = {}) {
+                const { priority = 'normal', timeout = 120 } = options;
+                const run = () => {
+                    try {
+                        const result = callback();
+                        if (result && typeof result.then === 'function') {
+                            result.catch(error => console.error('Deferred task failed', error));
+                        }
+                    } catch (error) {
+                        console.error('Deferred task failed', error);
+                    }
+                };
+                if (priority === 'animation' && typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(run);
+                    return;
+                }
+                if (typeof requestIdleCallback === 'function') {
+                    const idleTimeout = priority === 'high' ? Math.min(timeout, 48) : timeout;
+                    requestIdleCallback(run, { timeout: idleTimeout });
+                } else {
+                    const delay = priority === 'high' ? 0 : priority === 'animation' ? 16 : 32;
+                    setTimeout(run, delay);
+                }
+            },
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -3831,13 +3863,13 @@
             }
             getDirectImageURL(image) {
                 if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof image.downloadUrl === 'string' && image.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [image.viewUrl, image.webViewLink, hasViewStyleDownload ? image.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    return permanentLink || `https://drive.google.com/file/d/${image.id}/view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                    return `https://drive.google.com/uc?id=${image.id}&export=view`;
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
+
             downloadCSV(data) {
                 const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = state.grid.stack;
@@ -4665,7 +4697,7 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
@@ -4709,12 +4741,15 @@
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
 
+                    Utils.defer(() => {
+                        Core.updateImageCounters();
+                        Core.updateFavoriteButton();
+                    }, { priority: 'animation' });
+
                     if (currentFile.metadataStatus === 'pending') {
-                        App.processFileMetadata(currentFile);
+                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
-                    
-                    this.updateImageCounters();
-                    this.updateFavoriteButton();
+
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -4822,7 +4857,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -1256,11 +1256,43 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
+            defer(callback, options = {}) {
+                const { priority = 'normal', timeout = 120 } = options;
+                const run = () => {
+                    try {
+                        const result = callback();
+                        if (result && typeof result.then === 'function') {
+                            result.catch(error => console.error('Deferred task failed', error));
+                        }
+                    } catch (error) {
+                        console.error('Deferred task failed', error);
+                    }
+                };
+                if (priority === 'animation' && typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(run);
+                    return;
+                }
+                if (typeof requestIdleCallback === 'function') {
+                    const idleTimeout = priority === 'high' ? Math.min(timeout, 48) : timeout;
+                    requestIdleCallback(run, { timeout: idleTimeout });
+                } else {
+                    const delay = priority === 'high' ? 0 : priority === 'animation' ? 16 : 32;
+                    setTimeout(run, delay);
+                }
+            },
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -3831,13 +3863,13 @@
             }
             getDirectImageURL(image) {
                 if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof image.downloadUrl === 'string' && image.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [image.viewUrl, image.webViewLink, hasViewStyleDownload ? image.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    return permanentLink || `https://drive.google.com/file/d/${image.id}/view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                    return `https://drive.google.com/uc?id=${image.id}&export=view`;
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
+
             downloadCSV(data) {
                 const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = state.grid.stack;
@@ -4665,7 +4697,7 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
@@ -4709,12 +4741,15 @@
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
 
+                    Utils.defer(() => {
+                        Core.updateImageCounters();
+                        Core.updateFavoriteButton();
+                    }, { priority: 'animation' });
+
                     if (currentFile.metadataStatus === 'pending') {
-                        App.processFileMetadata(currentFile);
+                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
-                    
-                    this.updateImageCounters();
-                    this.updateFavoriteButton();
+
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -4822,7 +4857,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -1256,11 +1256,43 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
+            defer(callback, options = {}) {
+                const { priority = 'normal', timeout = 120 } = options;
+                const run = () => {
+                    try {
+                        const result = callback();
+                        if (result && typeof result.then === 'function') {
+                            result.catch(error => console.error('Deferred task failed', error));
+                        }
+                    } catch (error) {
+                        console.error('Deferred task failed', error);
+                    }
+                };
+                if (priority === 'animation' && typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(run);
+                    return;
+                }
+                if (typeof requestIdleCallback === 'function') {
+                    const idleTimeout = priority === 'high' ? Math.min(timeout, 48) : timeout;
+                    requestIdleCallback(run, { timeout: idleTimeout });
+                } else {
+                    const delay = priority === 'high' ? 0 : priority === 'animation' ? 16 : 32;
+                    setTimeout(run, delay);
+                }
+            },
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -3831,13 +3863,13 @@
             }
             getDirectImageURL(image) {
                 if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof image.downloadUrl === 'string' && image.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [image.viewUrl, image.webViewLink, hasViewStyleDownload ? image.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    return permanentLink || `https://drive.google.com/file/d/${image.id}/view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                    return `https://drive.google.com/uc?id=${image.id}&export=view`;
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
+
             downloadCSV(data) {
                 const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = state.grid.stack;
@@ -4665,7 +4697,7 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
@@ -4709,12 +4741,15 @@
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
 
+                    Utils.defer(() => {
+                        Core.updateImageCounters();
+                        Core.updateFavoriteButton();
+                    }, { priority: 'animation' });
+
                     if (currentFile.metadataStatus === 'pending') {
-                        App.processFileMetadata(currentFile);
+                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
-                    
-                    this.updateImageCounters();
-                    this.updateFavoriteButton();
+
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -4822,7 +4857,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -1256,11 +1256,43 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
+            defer(callback, options = {}) {
+                const { priority = 'normal', timeout = 120 } = options;
+                const run = () => {
+                    try {
+                        const result = callback();
+                        if (result && typeof result.then === 'function') {
+                            result.catch(error => console.error('Deferred task failed', error));
+                        }
+                    } catch (error) {
+                        console.error('Deferred task failed', error);
+                    }
+                };
+                if (priority === 'animation' && typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(run);
+                    return;
+                }
+                if (typeof requestIdleCallback === 'function') {
+                    const idleTimeout = priority === 'high' ? Math.min(timeout, 48) : timeout;
+                    requestIdleCallback(run, { timeout: idleTimeout });
+                } else {
+                    const delay = priority === 'high' ? 0 : priority === 'animation' ? 16 : 32;
+                    setTimeout(run, delay);
+                }
+            },
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -3831,13 +3863,13 @@
             }
             getDirectImageURL(image) {
                 if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof image.downloadUrl === 'string' && image.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [image.viewUrl, image.webViewLink, hasViewStyleDownload ? image.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    return permanentLink || `https://drive.google.com/file/d/${image.id}/view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                    return `https://drive.google.com/uc?id=${image.id}&export=view`;
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
+
             downloadCSV(data) {
                 const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = state.grid.stack;
@@ -4665,7 +4697,7 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
@@ -4709,12 +4741,15 @@
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
 
+                    Utils.defer(() => {
+                        Core.updateImageCounters();
+                        Core.updateFavoriteButton();
+                    }, { priority: 'animation' });
+
                     if (currentFile.metadataStatus === 'pending') {
-                        App.processFileMetadata(currentFile);
+                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
-                    
-                    this.updateImageCounters();
-                    this.updateFavoriteButton();
+
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -4822,7 +4857,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -1256,11 +1256,43 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
+            defer(callback, options = {}) {
+                const { priority = 'normal', timeout = 120 } = options;
+                const run = () => {
+                    try {
+                        const result = callback();
+                        if (result && typeof result.then === 'function') {
+                            result.catch(error => console.error('Deferred task failed', error));
+                        }
+                    } catch (error) {
+                        console.error('Deferred task failed', error);
+                    }
+                };
+                if (priority === 'animation' && typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(run);
+                    return;
+                }
+                if (typeof requestIdleCallback === 'function') {
+                    const idleTimeout = priority === 'high' ? Math.min(timeout, 48) : timeout;
+                    requestIdleCallback(run, { timeout: idleTimeout });
+                } else {
+                    const delay = priority === 'high' ? 0 : priority === 'animation' ? 16 : 32;
+                    setTimeout(run, delay);
+                }
+            },
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -3831,13 +3863,13 @@
             }
             getDirectImageURL(image) {
                 if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof image.downloadUrl === 'string' && image.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [image.viewUrl, image.webViewLink, hasViewStyleDownload ? image.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    return permanentLink || `https://drive.google.com/file/d/${image.id}/view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                    return `https://drive.google.com/uc?id=${image.id}&export=view`;
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
+
             downloadCSV(data) {
                 const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = state.grid.stack;
@@ -4665,7 +4697,7 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
@@ -4709,12 +4741,15 @@
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
 
+                    Utils.defer(() => {
+                        Core.updateImageCounters();
+                        Core.updateFavoriteButton();
+                    }, { priority: 'animation' });
+
                     if (currentFile.metadataStatus === 'pending') {
-                        App.processFileMetadata(currentFile);
+                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
-                    
-                    this.updateImageCounters();
-                    this.updateFavoriteButton();
+
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -4822,7 +4857,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -1256,11 +1256,43 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
+            defer(callback, options = {}) {
+                const { priority = 'normal', timeout = 120 } = options;
+                const run = () => {
+                    try {
+                        const result = callback();
+                        if (result && typeof result.then === 'function') {
+                            result.catch(error => console.error('Deferred task failed', error));
+                        }
+                    } catch (error) {
+                        console.error('Deferred task failed', error);
+                    }
+                };
+                if (priority === 'animation' && typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(run);
+                    return;
+                }
+                if (typeof requestIdleCallback === 'function') {
+                    const idleTimeout = priority === 'high' ? Math.min(timeout, 48) : timeout;
+                    requestIdleCallback(run, { timeout: idleTimeout });
+                } else {
+                    const delay = priority === 'high' ? 0 : priority === 'animation' ? 16 : 32;
+                    setTimeout(run, delay);
+                }
+            },
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -3831,13 +3863,13 @@
             }
             getDirectImageURL(image) {
                 if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof image.downloadUrl === 'string' && image.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [image.viewUrl, image.webViewLink, hasViewStyleDownload ? image.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    return permanentLink || `https://drive.google.com/file/d/${image.id}/view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                    return `https://drive.google.com/uc?id=${image.id}&export=view`;
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
+
             downloadCSV(data) {
                 const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = state.grid.stack;
@@ -4665,7 +4697,7 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
@@ -4709,12 +4741,15 @@
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
 
+                    Utils.defer(() => {
+                        Core.updateImageCounters();
+                        Core.updateFavoriteButton();
+                    }, { priority: 'animation' });
+
                     if (currentFile.metadataStatus === 'pending') {
-                        App.processFileMetadata(currentFile);
+                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
-                    
-                    this.updateImageCounters();
-                    this.updateFavoriteButton();
+
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -4822,7 +4857,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -1256,11 +1256,43 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
+            defer(callback, options = {}) {
+                const { priority = 'normal', timeout = 120 } = options;
+                const run = () => {
+                    try {
+                        const result = callback();
+                        if (result && typeof result.then === 'function') {
+                            result.catch(error => console.error('Deferred task failed', error));
+                        }
+                    } catch (error) {
+                        console.error('Deferred task failed', error);
+                    }
+                };
+                if (priority === 'animation' && typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(run);
+                    return;
+                }
+                if (typeof requestIdleCallback === 'function') {
+                    const idleTimeout = priority === 'high' ? Math.min(timeout, 48) : timeout;
+                    requestIdleCallback(run, { timeout: idleTimeout });
+                } else {
+                    const delay = priority === 'high' ? 0 : priority === 'animation' ? 16 : 32;
+                    setTimeout(run, delay);
+                }
+            },
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -3831,13 +3863,13 @@
             }
             getDirectImageURL(image) {
                 if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof image.downloadUrl === 'string' && image.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [image.viewUrl, image.webViewLink, hasViewStyleDownload ? image.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    return permanentLink || `https://drive.google.com/file/d/${image.id}/view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                    return `https://drive.google.com/uc?id=${image.id}&export=view`;
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
+
             downloadCSV(data) {
                 const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = state.grid.stack;
@@ -4665,7 +4697,7 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
@@ -4709,12 +4741,15 @@
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
 
+                    Utils.defer(() => {
+                        Core.updateImageCounters();
+                        Core.updateFavoriteButton();
+                    }, { priority: 'animation' });
+
                     if (currentFile.metadataStatus === 'pending') {
-                        App.processFileMetadata(currentFile);
+                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
-                    
-                    this.updateImageCounters();
-                    this.updateFavoriteButton();
+
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -4822,7 +4857,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -1256,11 +1256,43 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
+            defer(callback, options = {}) {
+                const { priority = 'normal', timeout = 120 } = options;
+                const run = () => {
+                    try {
+                        const result = callback();
+                        if (result && typeof result.then === 'function') {
+                            result.catch(error => console.error('Deferred task failed', error));
+                        }
+                    } catch (error) {
+                        console.error('Deferred task failed', error);
+                    }
+                };
+                if (priority === 'animation' && typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(run);
+                    return;
+                }
+                if (typeof requestIdleCallback === 'function') {
+                    const idleTimeout = priority === 'high' ? Math.min(timeout, 48) : timeout;
+                    requestIdleCallback(run, { timeout: idleTimeout });
+                } else {
+                    const delay = priority === 'high' ? 0 : priority === 'animation' ? 16 : 32;
+                    setTimeout(run, delay);
+                }
+            },
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -3831,13 +3863,13 @@
             }
             getDirectImageURL(image) {
                 if (state.providerType === 'googledrive') {
-                    const hasViewStyleDownload = typeof image.downloadUrl === 'string' && image.downloadUrl.includes('https://drive.google.com/file/d/');
-                    const permanentLink = [image.viewUrl, image.webViewLink, hasViewStyleDownload ? image.downloadUrl : null]
-                        .find(url => typeof url === 'string' && url.length > 0);
-                    return permanentLink || `https://drive.google.com/file/d/${image.id}/view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                    return `https://drive.google.com/uc?id=${image.id}&export=view`;
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
+
             downloadCSV(data) {
                 const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = state.grid.stack;
@@ -4665,7 +4697,7 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
@@ -4709,12 +4741,15 @@
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
 
+                    Utils.defer(() => {
+                        Core.updateImageCounters();
+                        Core.updateFavoriteButton();
+                    }, { priority: 'animation' });
+
                     if (currentFile.metadataStatus === 'pending') {
-                        App.processFileMetadata(currentFile);
+                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
-                    
-                    this.updateImageCounters();
-                    this.updateFavoriteButton();
+
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -4822,7 +4857,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();

--- a/ui.html
+++ b/ui.html
@@ -1161,13 +1161,44 @@
             },
 
             getFallbackImageUrl(file) {
-                 if (state.providerType === 'googledrive') {
-                    return file.downloadUrl || `https://www.googleapis.com/drive/v3/files/${file.id}?alt=media`;
+                if (state.providerType === 'googledrive') {
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
+            defer(callback, options = {}) {
+                const { priority = 'normal', timeout = 120 } = options;
+                const run = () => {
+                    try {
+                        const result = callback();
+                        if (result && typeof result.then === 'function') {
+                            result.catch(error => console.error('Deferred task failed', error));
+                        }
+                    } catch (error) {
+                        console.error('Deferred task failed', error);
+                    }
+                };
+                if (priority === 'animation' && typeof requestAnimationFrame === 'function') {
+                    requestAnimationFrame(run);
+                    return;
+                }
+                if (typeof requestIdleCallback === 'function') {
+                    const idleTimeout = priority === 'high' ? Math.min(timeout, 48) : timeout;
+                    requestIdleCallback(run, { timeout: idleTimeout });
+                } else {
+                    const delay = priority === 'high' ? 0 : priority === 'animation' ? 16 : 32;
+                    setTimeout(run, delay);
+                }
+            },
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -1730,10 +1761,14 @@
                 } return '';
             }
             getDirectImageURL(image) {
-                if (state.providerType === 'googledrive') { return `https://drive.google.com/uc?id=${image.id}&export=view`;
-                } else if (state.providerType === 'onedrive') { return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`; }
+                if (state.providerType === 'googledrive') {
+                    return `https://drive.google.com/uc?id=${image.id}&export=view`;
+                } else if (state.providerType === 'onedrive') {
+                    return image.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${image.id}/content`;
+                }
                 return '';
             }
+
             downloadCSV(data) {
                 const folderName = state.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = state.grid.stack;
@@ -2171,7 +2206,7 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
@@ -2214,12 +2249,15 @@
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
 
+                    Utils.defer(() => {
+                        Core.updateImageCounters();
+                        Core.updateFavoriteButton();
+                    }, { priority: 'animation' });
+
                     if (currentFile.metadataStatus === 'pending') {
-                        App.processFileMetadata(currentFile);
+                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
-                    
-                    this.updateImageCounters();
-                    this.updateFavoriteButton();
+
                 } catch (error) {
                      Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
@@ -2304,7 +2342,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();


### PR DESCRIPTION
## Summary
- add deferred execution helpers so navigation UI updates and metadata writes run off the primary image-change path for the index and ui builds
- restore Google Drive thumbnail fallbacks and reuse the uc?id=... export link for stable sharing in every ui variant

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68def1910acc832d8cdf89db3d869781