### PR TITLE
Mark metadata loads as scheduled before deferred processing

### DIFF
--- a/index.html
+++ b/index.html
@@ -4747,6 +4747,7 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
+                        currentFile.metadataStatus = 'loading';
                         Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
 

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -4747,6 +4747,7 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
+                        currentFile.metadataStatus = 'loading';
                         Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
 

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -4587,6 +4587,7 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
+                        currentFile.metadataStatus = 'loading';
                         Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
 

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -4587,6 +4587,7 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
+                        currentFile.metadataStatus = 'loading';
                         Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
 

--- a/ui-v2-old.html
+++ b/ui-v2-old.html
@@ -2719,6 +2719,7 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
+                        currentFile.metadataStatus = 'loading';
                         Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
 

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -4747,6 +4747,7 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
+                        currentFile.metadataStatus = 'loading';
                         Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
 

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -4747,6 +4747,7 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
+                        currentFile.metadataStatus = 'loading';
                         Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
 

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -4747,6 +4747,7 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
+                        currentFile.metadataStatus = 'loading';
                         Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
 

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -4747,6 +4747,7 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
+                        currentFile.metadataStatus = 'loading';
                         Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
 

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -4747,6 +4747,7 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
+                        currentFile.metadataStatus = 'loading';
                         Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
 

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -4747,6 +4747,7 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
+                        currentFile.metadataStatus = 'loading';
                         Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
 

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -4747,6 +4747,7 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
+                        currentFile.metadataStatus = 'loading';
                         Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
 

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -4747,6 +4747,7 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
+                        currentFile.metadataStatus = 'loading';
                         Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
 

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -4747,6 +4747,7 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
+                        currentFile.metadataStatus = 'loading';
                         Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
 

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -4747,6 +4747,7 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
+                        currentFile.metadataStatus = 'loading';
                         Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
 

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -4747,6 +4747,7 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
+                        currentFile.metadataStatus = 'loading';
                         Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
 

--- a/ui.html
+++ b/ui.html
@@ -2255,6 +2255,7 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
+                        currentFile.metadataStatus = 'loading';
                         Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
                     }
 


### PR DESCRIPTION
## Summary
- record when metadata processing has been scheduled in each UI build
- keep deferred metadata processing in place while preventing redundant queueing

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df19ca8e34832dbf9bfd6e06eaeb94