### PR TITLE
Queue metadata extraction before loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -4604,7 +4604,7 @@
                     if (state.activeRequests.signal.aborted) return;
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending') {
+                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
                             return this.processFileMetadata(file);
                         }
                         return Promise.resolve();
@@ -4747,8 +4747,12 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
-                        currentFile.metadataStatus = 'loading';
-                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
+                        currentFile.metadataStatus = 'queued';
+                        Utils.defer(() => {
+                            if (currentFile.metadataStatus === 'pending' || currentFile.metadataStatus === 'queued') {
+                                App.processFileMetadata(currentFile);
+                            }
+                        }, { priority: 'background', timeout: 300 });
                     }
 
                 } catch (error) {

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -4604,7 +4604,7 @@
                     if (state.activeRequests.signal.aborted) return;
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending') {
+                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
                             return this.processFileMetadata(file);
                         }
                         return Promise.resolve();
@@ -4747,8 +4747,12 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
-                        currentFile.metadataStatus = 'loading';
-                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
+                        currentFile.metadataStatus = 'queued';
+                        Utils.defer(() => {
+                            if (currentFile.metadataStatus === 'pending' || currentFile.metadataStatus === 'queued') {
+                                App.processFileMetadata(currentFile);
+                            }
+                        }, { priority: 'background', timeout: 300 });
                     }
 
                 } catch (error) {

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -4444,7 +4444,7 @@
                     if (state.activeRequests.signal.aborted) return;
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending') {
+                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
                             return this.processFileMetadata(file);
                         }
                         return Promise.resolve();
@@ -4587,8 +4587,12 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
-                        currentFile.metadataStatus = 'loading';
-                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
+                        currentFile.metadataStatus = 'queued';
+                        Utils.defer(() => {
+                            if (currentFile.metadataStatus === 'pending' || currentFile.metadataStatus === 'queued') {
+                                App.processFileMetadata(currentFile);
+                            }
+                        }, { priority: 'background', timeout: 300 });
                     }
 
                 } catch (error) {

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -4444,7 +4444,7 @@
                     if (state.activeRequests.signal.aborted) return;
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending') {
+                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
                             return this.processFileMetadata(file);
                         }
                         return Promise.resolve();
@@ -4587,8 +4587,12 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
-                        currentFile.metadataStatus = 'loading';
-                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
+                        currentFile.metadataStatus = 'queued';
+                        Utils.defer(() => {
+                            if (currentFile.metadataStatus === 'pending' || currentFile.metadataStatus === 'queued') {
+                                App.processFileMetadata(currentFile);
+                            }
+                        }, { priority: 'background', timeout: 300 });
                     }
 
                 } catch (error) {

--- a/ui-v2-old.html
+++ b/ui-v2-old.html
@@ -2577,7 +2577,7 @@
                     if (state.activeRequests.signal.aborted) return;
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending') {
+                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
                             return this.processFileMetadata(file);
                         }
                         return Promise.resolve();
@@ -2719,8 +2719,12 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
-                        currentFile.metadataStatus = 'loading';
-                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
+                        currentFile.metadataStatus = 'queued';
+                        Utils.defer(() => {
+                            if (currentFile.metadataStatus === 'pending' || currentFile.metadataStatus === 'queued') {
+                                App.processFileMetadata(currentFile);
+                            }
+                        }, { priority: 'background', timeout: 300 });
                     }
 
                 } catch (error) {

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -4604,7 +4604,7 @@
                     if (state.activeRequests.signal.aborted) return;
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending') {
+                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
                             return this.processFileMetadata(file);
                         }
                         return Promise.resolve();
@@ -4747,8 +4747,12 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
-                        currentFile.metadataStatus = 'loading';
-                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
+                        currentFile.metadataStatus = 'queued';
+                        Utils.defer(() => {
+                            if (currentFile.metadataStatus === 'pending' || currentFile.metadataStatus === 'queued') {
+                                App.processFileMetadata(currentFile);
+                            }
+                        }, { priority: 'background', timeout: 300 });
                     }
 
                 } catch (error) {

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -4604,7 +4604,7 @@
                     if (state.activeRequests.signal.aborted) return;
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending') {
+                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
                             return this.processFileMetadata(file);
                         }
                         return Promise.resolve();
@@ -4747,8 +4747,12 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
-                        currentFile.metadataStatus = 'loading';
-                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
+                        currentFile.metadataStatus = 'queued';
+                        Utils.defer(() => {
+                            if (currentFile.metadataStatus === 'pending' || currentFile.metadataStatus === 'queued') {
+                                App.processFileMetadata(currentFile);
+                            }
+                        }, { priority: 'background', timeout: 300 });
                     }
 
                 } catch (error) {

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -4604,7 +4604,7 @@
                     if (state.activeRequests.signal.aborted) return;
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending') {
+                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
                             return this.processFileMetadata(file);
                         }
                         return Promise.resolve();
@@ -4747,8 +4747,12 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
-                        currentFile.metadataStatus = 'loading';
-                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
+                        currentFile.metadataStatus = 'queued';
+                        Utils.defer(() => {
+                            if (currentFile.metadataStatus === 'pending' || currentFile.metadataStatus === 'queued') {
+                                App.processFileMetadata(currentFile);
+                            }
+                        }, { priority: 'background', timeout: 300 });
                     }
 
                 } catch (error) {

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -4604,7 +4604,7 @@
                     if (state.activeRequests.signal.aborted) return;
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending') {
+                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
                             return this.processFileMetadata(file);
                         }
                         return Promise.resolve();
@@ -4747,8 +4747,12 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
-                        currentFile.metadataStatus = 'loading';
-                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
+                        currentFile.metadataStatus = 'queued';
+                        Utils.defer(() => {
+                            if (currentFile.metadataStatus === 'pending' || currentFile.metadataStatus === 'queued') {
+                                App.processFileMetadata(currentFile);
+                            }
+                        }, { priority: 'background', timeout: 300 });
                     }
 
                 } catch (error) {

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -4604,7 +4604,7 @@
                     if (state.activeRequests.signal.aborted) return;
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending') {
+                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
                             return this.processFileMetadata(file);
                         }
                         return Promise.resolve();
@@ -4747,8 +4747,12 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
-                        currentFile.metadataStatus = 'loading';
-                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
+                        currentFile.metadataStatus = 'queued';
+                        Utils.defer(() => {
+                            if (currentFile.metadataStatus === 'pending' || currentFile.metadataStatus === 'queued') {
+                                App.processFileMetadata(currentFile);
+                            }
+                        }, { priority: 'background', timeout: 300 });
                     }
 
                 } catch (error) {

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -4604,7 +4604,7 @@
                     if (state.activeRequests.signal.aborted) return;
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending') {
+                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
                             return this.processFileMetadata(file);
                         }
                         return Promise.resolve();
@@ -4747,8 +4747,12 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
-                        currentFile.metadataStatus = 'loading';
-                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
+                        currentFile.metadataStatus = 'queued';
+                        Utils.defer(() => {
+                            if (currentFile.metadataStatus === 'pending' || currentFile.metadataStatus === 'queued') {
+                                App.processFileMetadata(currentFile);
+                            }
+                        }, { priority: 'background', timeout: 300 });
                     }
 
                 } catch (error) {

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -4604,7 +4604,7 @@
                     if (state.activeRequests.signal.aborted) return;
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending') {
+                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
                             return this.processFileMetadata(file);
                         }
                         return Promise.resolve();
@@ -4747,8 +4747,12 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
-                        currentFile.metadataStatus = 'loading';
-                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
+                        currentFile.metadataStatus = 'queued';
+                        Utils.defer(() => {
+                            if (currentFile.metadataStatus === 'pending' || currentFile.metadataStatus === 'queued') {
+                                App.processFileMetadata(currentFile);
+                            }
+                        }, { priority: 'background', timeout: 300 });
                     }
 
                 } catch (error) {

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -4604,7 +4604,7 @@
                     if (state.activeRequests.signal.aborted) return;
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending') {
+                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
                             return this.processFileMetadata(file);
                         }
                         return Promise.resolve();
@@ -4747,8 +4747,12 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
-                        currentFile.metadataStatus = 'loading';
-                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
+                        currentFile.metadataStatus = 'queued';
+                        Utils.defer(() => {
+                            if (currentFile.metadataStatus === 'pending' || currentFile.metadataStatus === 'queued') {
+                                App.processFileMetadata(currentFile);
+                            }
+                        }, { priority: 'background', timeout: 300 });
                     }
 
                 } catch (error) {

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -4604,7 +4604,7 @@
                     if (state.activeRequests.signal.aborted) return;
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending') {
+                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
                             return this.processFileMetadata(file);
                         }
                         return Promise.resolve();
@@ -4747,8 +4747,12 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
-                        currentFile.metadataStatus = 'loading';
-                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
+                        currentFile.metadataStatus = 'queued';
+                        Utils.defer(() => {
+                            if (currentFile.metadataStatus === 'pending' || currentFile.metadataStatus === 'queued') {
+                                App.processFileMetadata(currentFile);
+                            }
+                        }, { priority: 'background', timeout: 300 });
                     }
 
                 } catch (error) {

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -4604,7 +4604,7 @@
                     if (state.activeRequests.signal.aborted) return;
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending') {
+                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
                             return this.processFileMetadata(file);
                         }
                         return Promise.resolve();
@@ -4747,8 +4747,12 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
-                        currentFile.metadataStatus = 'loading';
-                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
+                        currentFile.metadataStatus = 'queued';
+                        Utils.defer(() => {
+                            if (currentFile.metadataStatus === 'pending' || currentFile.metadataStatus === 'queued') {
+                                App.processFileMetadata(currentFile);
+                            }
+                        }, { priority: 'background', timeout: 300 });
                     }
 
                 } catch (error) {

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -4604,7 +4604,7 @@
                     if (state.activeRequests.signal.aborted) return;
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending') {
+                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
                             return this.processFileMetadata(file);
                         }
                         return Promise.resolve();
@@ -4747,8 +4747,12 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
-                        currentFile.metadataStatus = 'loading';
-                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
+                        currentFile.metadataStatus = 'queued';
+                        Utils.defer(() => {
+                            if (currentFile.metadataStatus === 'pending' || currentFile.metadataStatus === 'queued') {
+                                App.processFileMetadata(currentFile);
+                            }
+                        }, { priority: 'background', timeout: 300 });
                     }
 
                 } catch (error) {

--- a/ui.html
+++ b/ui.html
@@ -2113,7 +2113,7 @@
                     if (state.activeRequests.signal.aborted) return;
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending') {
+                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
                             return this.processFileMetadata(file);
                         }
                         return Promise.resolve();
@@ -2255,8 +2255,12 @@
                     }, { priority: 'animation' });
 
                     if (currentFile.metadataStatus === 'pending') {
-                        currentFile.metadataStatus = 'loading';
-                        Utils.defer(() => App.processFileMetadata(currentFile), { priority: 'background', timeout: 300 });
+                        currentFile.metadataStatus = 'queued';
+                        Utils.defer(() => {
+                            if (currentFile.metadataStatus === 'pending' || currentFile.metadataStatus === 'queued') {
+                                App.processFileMetadata(currentFile);
+                            }
+                        }, { priority: 'background', timeout: 300 });
                     }
 
                 } catch (error) {


### PR DESCRIPTION
## Summary
- mark metadata requests as queued when scheduling deferred work so the UI does not jump to a loading state prematurely
- update every UI build to check for pending or queued metadata before invoking the extractor
- keep processFileMetadata as the single point that flips queued items into loading before fetching metadata

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df8d6e098c832d89c64e6c87224571