### PR TITLE
Restore baseline Google Drive and OneDrive auth in alpha UI

### DIFF
--- a/ui-alpha-v1.html
+++ b/ui-alpha-v1.html
@@ -1,0 +1,1196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Goji Reviewer – Alpha v1</title>
+    <script src="https://alcdn.msauth.net/browser/2.28.1/js/msal-browser.min.js" defer></script>
+    <style>
+        :root {
+            color-scheme: light dark;
+            --bg: #0f172a;
+            --bg-alt: #111d36;
+            --surface: #ffffff;
+            --surface-alt: rgba(255, 255, 255, 0.08);
+            --border: rgba(148, 163, 184, 0.25);
+            --text: #0f172a;
+            --text-inverse: #f8fafc;
+            --text-muted: rgba(248, 250, 252, 0.72);
+            --primary: #6366f1;
+            --primary-dark: #4f46e5;
+            --success: #22c55e;
+            --danger: #ef4444;
+            --radius-lg: 24px;
+            --radius-md: 16px;
+            font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+        }
+
+        *, *::before, *::after {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            background: radial-gradient(circle at top, #1f2937 0%, #0f172a 45%, #020617 100%);
+            color: var(--text-inverse);
+            display: flex;
+            justify-content: center;
+            align-items: stretch;
+        }
+
+        .shell {
+            width: min(1200px, 100%);
+            display: flex;
+            flex-direction: column;
+            padding: clamp(20px, 5vw, 48px);
+            gap: clamp(24px, 4vw, 48px);
+        }
+
+        header {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        header h1 {
+            font-size: clamp(1.5rem, 3.5vw, 2.8rem);
+            font-weight: 700;
+            letter-spacing: -0.02em;
+        }
+
+        header p {
+            margin: 0;
+            color: var(--text-muted);
+            max-width: 48rem;
+            line-height: 1.6;
+        }
+
+        .progress {
+            display: flex;
+            gap: 12px;
+            align-items: center;
+        }
+
+        .progress-step {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 12px 20px;
+            border-radius: 999px;
+            background: var(--surface-alt);
+            border: 1px solid transparent;
+            color: rgba(248, 250, 252, 0.6);
+            font-weight: 500;
+            transition: all 0.3s ease;
+        }
+
+        .progress-step.active {
+            border-color: rgba(99, 102, 241, 0.35);
+            color: white;
+            background: rgba(99, 102, 241, 0.18);
+        }
+
+        .progress-step.complete {
+            border-color: rgba(34, 197, 94, 0.35);
+            color: rgba(34, 197, 94, 0.9);
+            background: rgba(34, 197, 94, 0.15);
+        }
+
+        .stage-wrapper {
+            position: relative;
+            flex: 1;
+            display: grid;
+        }
+
+        .stage {
+            display: none;
+            grid-template-columns: 1fr;
+            align-items: start;
+            gap: clamp(20px, 4vw, 36px);
+            background: linear-gradient(145deg, rgba(255, 255, 255, 0.06) 0%, rgba(15, 23, 42, 0.65) 60%, rgba(2, 6, 23, 0.95) 100%);
+            border: 1px solid rgba(148, 163, 184, 0.15);
+            border-radius: var(--radius-lg);
+            padding: clamp(24px, 5vw, 48px);
+            box-shadow: 0 40px 120px rgba(15, 23, 42, 0.5);
+            animation: fadeIn 0.4s ease;
+        }
+
+        .stage.active {
+            display: grid;
+        }
+
+        .stage header {
+            gap: 6px;
+        }
+
+        .stage header h2 {
+            font-size: clamp(1.4rem, 3vw, 2.1rem);
+            margin: 0;
+        }
+
+        .stage header p {
+            color: rgba(248, 250, 252, 0.7);
+        }
+
+        .card-grid {
+            display: grid;
+            gap: 18px;
+        }
+
+        .provider-card {
+            position: relative;
+            border-radius: var(--radius-md);
+            padding: 20px 22px;
+            border: 1px solid rgba(148, 163, 184, 0.22);
+            background: rgba(15, 23, 42, 0.65);
+            backdrop-filter: blur(16px);
+            cursor: pointer;
+            transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+            display: grid;
+            gap: 8px;
+        }
+
+        .provider-card strong {
+            font-size: 1.05rem;
+        }
+
+        .provider-card span {
+            color: rgba(248, 250, 252, 0.65);
+            font-size: 0.9rem;
+        }
+
+        .provider-card:hover {
+            transform: translateY(-4px);
+            border-color: rgba(99, 102, 241, 0.5);
+            box-shadow: 0 24px 60px rgba(99, 102, 241, 0.25);
+        }
+
+        .provider-card.selected {
+            border-color: rgba(99, 102, 241, 0.65);
+            box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.4);
+        }
+
+        .stage section {
+            display: grid;
+            gap: 20px;
+        }
+
+        .input-stack {
+            display: grid;
+            gap: 12px;
+        }
+
+        label {
+            font-weight: 600;
+            font-size: 0.95rem;
+        }
+
+        input[type="text"],
+        input[type="password"],
+        input[type="search"] {
+            width: 100%;
+            border-radius: 14px;
+            border: 1px solid rgba(148, 163, 184, 0.3);
+            padding: 14px 16px;
+            font-size: 1rem;
+            background: rgba(15, 23, 42, 0.85);
+            color: white;
+        }
+
+        input::placeholder {
+            color: rgba(148, 163, 184, 0.6);
+        }
+
+        .helper-text {
+            color: rgba(148, 163, 184, 0.78);
+            font-size: 0.9rem;
+        }
+
+        .status-line {
+            min-height: 1.4em;
+            font-size: 0.95rem;
+        }
+
+        .status-line.success { color: var(--success); }
+        .status-line.error { color: var(--danger); }
+        .status-line.muted { color: rgba(148, 163, 184, 0.75); }
+
+        .actions {
+            display: flex;
+            gap: 12px;
+        }
+
+        button {
+            font: inherit;
+        }
+
+        .btn {
+            border-radius: 14px;
+            padding: 14px 22px;
+            font-weight: 600;
+            cursor: pointer;
+            border: none;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .btn.primary {
+            background: linear-gradient(135deg, #6366f1, #8b5cf6);
+            color: white;
+            box-shadow: 0 20px 60px rgba(99, 102, 241, 0.35);
+        }
+
+        .btn.primary:hover:not(:disabled) {
+            transform: translateY(-2px);
+            box-shadow: 0 26px 70px rgba(99, 102, 241, 0.4);
+        }
+
+        .btn.secondary {
+            background: rgba(15, 23, 42, 0.6);
+            color: rgba(248, 250, 252, 0.9);
+            border: 1px solid rgba(148, 163, 184, 0.25);
+        }
+
+        .btn:disabled {
+            opacity: 0.55;
+            cursor: not-allowed;
+        }
+
+        .folder-list {
+            display: grid;
+            gap: 12px;
+            max-height: 320px;
+            overflow-y: auto;
+            padding-right: 6px;
+        }
+
+        .folder-pill {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 12px;
+            padding: 14px 18px;
+            border-radius: 16px;
+            background: rgba(15, 23, 42, 0.7);
+            border: 1px solid rgba(148, 163, 184, 0.24);
+            cursor: pointer;
+            transition: border-color 0.2s ease, background 0.2s ease;
+        }
+
+        .folder-pill:hover {
+            border-color: rgba(99, 102, 241, 0.45);
+        }
+
+        .folder-pill.selected {
+            border-color: rgba(99, 102, 241, 0.7);
+            background: rgba(99, 102, 241, 0.18);
+        }
+
+        .folder-pill small {
+            color: rgba(148, 163, 184, 0.75);
+        }
+
+        .workspace {
+            display: none;
+            grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+            gap: clamp(24px, 4vw, 40px);
+        }
+
+        .workspace.active {
+            display: grid;
+        }
+
+        .workspace-card {
+            background: rgba(15, 23, 42, 0.65);
+            border-radius: var(--radius-lg);
+            border: 1px solid rgba(148, 163, 184, 0.18);
+            padding: clamp(24px, 4vw, 40px);
+            display: grid;
+            gap: 24px;
+            box-shadow: 0 40px 120px rgba(15, 23, 42, 0.45);
+        }
+
+        .workspace-headline {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .workspace-headline h2 {
+            margin: 0;
+            font-size: clamp(1.4rem, 3vw, 2.2rem);
+        }
+
+        .hud {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+        }
+
+        .hud span {
+            border-radius: 999px;
+            padding: 10px 18px;
+            border: 1px solid rgba(148, 163, 184, 0.24);
+            background: rgba(15, 23, 42, 0.55);
+            color: rgba(248, 250, 252, 0.75);
+            font-weight: 500;
+        }
+
+        .image-stage {
+            position: relative;
+            border-radius: var(--radius-md);
+            border: 1px solid rgba(148, 163, 184, 0.18);
+            background: rgba(2, 6, 23, 0.85);
+            min-height: 320px;
+            display: grid;
+            place-items: center;
+        }
+
+        .image-stage img {
+            max-width: 100%;
+            border-radius: var(--radius-md);
+            box-shadow: 0 20px 60px rgba(15, 23, 42, 0.4);
+        }
+
+        .image-stage .ghost {
+            color: rgba(148, 163, 184, 0.65);
+        }
+
+        .mode-switch {
+            display: inline-flex;
+            border-radius: 999px;
+            border: 1px solid rgba(148, 163, 184, 0.26);
+            background: rgba(15, 23, 42, 0.6);
+            padding: 6px;
+            gap: 6px;
+        }
+
+        .mode-switch button {
+            border: none;
+            border-radius: 999px;
+            padding: 10px 18px;
+            background: transparent;
+            color: rgba(148, 163, 184, 0.8);
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        .mode-switch button.active {
+            background: rgba(99, 102, 241, 0.18);
+            color: white;
+            box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.4);
+        }
+
+        .tray {
+            display: grid;
+            gap: 14px;
+            background: rgba(15, 23, 42, 0.55);
+            border: 1px solid rgba(148, 163, 184, 0.22);
+            border-radius: var(--radius-md);
+            padding: 18px 20px;
+        }
+
+        .tray-actions {
+            display: flex;
+            gap: 12px;
+        }
+
+        .tray-actions button {
+            flex: 1;
+        }
+
+        .activity-log {
+            background: rgba(15, 23, 42, 0.55);
+            border: 1px solid rgba(148, 163, 184, 0.18);
+            border-radius: var(--radius-md);
+            padding: 20px;
+            display: grid;
+            gap: 12px;
+        }
+
+        .activity-log h3 {
+            margin: 0;
+            font-size: 1.05rem;
+        }
+
+        .activity-log ul {
+            margin: 0;
+            padding-left: 20px;
+            color: rgba(148, 163, 184, 0.75);
+            max-height: 220px;
+            overflow-y: auto;
+        }
+
+        .loading-screen {
+            display: none;
+            align-items: center;
+            justify-content: center;
+            border-radius: var(--radius-lg);
+            border: 1px solid rgba(148, 163, 184, 0.18);
+            padding: 48px;
+            background: rgba(15, 23, 42, 0.65);
+            gap: 18px;
+        }
+
+        .loading-screen.active {
+            display: flex;
+        }
+
+        .spinner {
+            width: 20px;
+            height: 20px;
+            border-radius: 50%;
+            border: 3px solid rgba(148, 163, 184, 0.35);
+            border-top-color: #818cf8;
+            animation: spin 0.9s linear infinite;
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+
+        @keyframes fadeIn {
+            from { opacity: 0; transform: translateY(8px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+
+        @media (max-width: 960px) {
+            .workspace {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="shell">
+        <header>
+            <h1>Goji Reviewer Alpha</h1>
+            <p>Reconnect your Google Drive or OneDrive library using the trusted baseline flow, then review collections with a refined, focus-first canvas.</p>
+        </header>
+
+        <div class="progress" id="progress">
+            <div class="progress-step active" data-step="0">Choose provider</div>
+            <div class="progress-step" data-step="1">Authenticate</div>
+            <div class="progress-step" data-step="2">Pick a folder</div>
+        </div>
+
+        <div class="stage-wrapper">
+            <section class="stage active" id="provider-stage" data-step-content="0">
+                <header>
+                    <h2>Select a storage provider</h2>
+                    <p>We support the same connections as the baseline reviewer. Your credentials remain on this device.</p>
+                </header>
+                <section>
+                    <div class="card-grid">
+                        <button class="provider-card" data-provider="googledrive">
+                            <strong>Google Drive</strong>
+                            <span>Use the Goji reviewer OAuth client to access your shared project folders.</span>
+                        </button>
+                        <button class="provider-card" data-provider="onedrive">
+                            <strong>Microsoft OneDrive</strong>
+                            <span>Authorize with MSAL to reach the same enterprise drive listings as before.</span>
+                        </button>
+                    </div>
+                </section>
+                <footer class="actions">
+                    <button class="btn primary" id="to-auth" disabled>Continue</button>
+                </footer>
+            </section>
+
+            <section class="stage" id="auth-stage" data-step-content="1">
+                <header>
+                    <h2>Authenticate <span id="selected-provider">Google Drive</span></h2>
+                    <p id="auth-intro">Enter the Google Drive client secret we store locally to refresh your access token.</p>
+                </header>
+                <section>
+                    <div class="input-stack" id="auth-body"></div>
+                    <p class="helper-text status-line muted" id="auth-status"></p>
+                </section>
+                <footer class="actions">
+                    <button class="btn secondary" id="back-to-provider">Back</button>
+                    <button class="btn primary" id="auth-action" disabled>Connect</button>
+                </footer>
+            </section>
+
+            <section class="stage" id="folder-stage" data-step-content="2">
+                <header>
+                    <h2>Choose a folder to review</h2>
+                    <p>Search your available folders and pick where to begin. You can swap providers later.</p>
+                </header>
+                <section>
+                    <div class="input-stack">
+                        <label for="folder-search">Search folders</label>
+                        <input type="search" id="folder-search" placeholder="Start typing a folder name" />
+                    </div>
+                    <div class="folder-list" id="folder-list"></div>
+                    <p class="status-line muted" id="folder-status"></p>
+                    <p class="status-line muted" id="folder-empty" hidden>No folders yet. Authenticate first to load your library.</p>
+                </section>
+                <footer class="actions">
+                    <button class="btn secondary" id="back-to-auth">Back</button>
+                    <button class="btn primary" id="start-review" disabled>Start reviewing</button>
+                </footer>
+            </section>
+
+            <section class="loading-screen" id="loading-stage">
+                <div class="spinner" aria-hidden="true"></div>
+                <div>
+                    <strong>Preparing your workspace…</strong>
+                    <p style="margin: 6px 0 0; color: rgba(248, 250, 252, 0.7);">We’re syncing metadata and arranging the first asset.</p>
+                </div>
+            </section>
+        </div>
+
+        <main class="workspace" id="workspace">
+            <section class="workspace-card">
+                <div class="workspace-headline">
+                    <h2 id="workspace-title">Focus review</h2>
+                    <div class="hud" id="hud-status">
+                        <span>0 pri</span>
+                        <span>0 keep</span>
+                        <span>0 out</span>
+                        <span>0 trash</span>
+                    </div>
+                </div>
+                <div class="image-stage">
+                    <div class="ghost">Load a folder to begin reviewing.</div>
+                </div>
+                <div class="tray">
+                    <div>
+                        <strong id="tray-title">Need guidance?</strong>
+                        <p id="tray-description" style="margin: 6px 0 0; color: rgba(148, 163, 184, 0.78);">Use arrow keys or tap the quick actions below to classify each asset.</p>
+                    </div>
+                    <div class="tray-actions">
+                        <button class="btn secondary" id="tray-undo">Undo</button>
+                        <button class="btn primary" id="tray-next">Next</button>
+                    </div>
+                </div>
+            </section>
+            <aside class="workspace-card">
+                <div class="mode-switch">
+                    <button type="button" class="active" data-mode="focus">Focus mode</button>
+                    <button type="button" data-mode="sort">Sort grid</button>
+                </div>
+                <div class="activity-log">
+                    <h3>Activity stream</h3>
+                    <ul id="activity-log">
+                        <li>Connect to begin logging decisions.</li>
+                    </ul>
+                </div>
+            </aside>
+        </main>
+    </div>
+
+    <script>
+        (function handlePopupResponse() {
+            const params = new URLSearchParams(window.location.search);
+            const oauthCode = params.get('code');
+            const oauthError = params.get('error');
+            if ((oauthCode || oauthError) && window.opener && window.opener !== window) {
+                if (oauthError) {
+                    window.opener.postMessage({ type: 'GOOGLE_AUTH_ERROR', error: oauthError }, window.location.origin);
+                } else {
+                    window.opener.postMessage({ type: 'GOOGLE_AUTH_SUCCESS', code: oauthCode }, window.location.origin);
+                }
+                window.close();
+            }
+        })();
+
+        class BaseProvider {
+            constructor(type) {
+                this.type = type;
+                this.isAuthenticated = false;
+            }
+
+            async authenticate() {
+                throw new Error('authenticate() must be implemented');
+            }
+
+            async getFolders() {
+                throw new Error('getFolders() must be implemented');
+            }
+        }
+
+        class GoogleDriveProvider extends BaseProvider {
+            constructor() {
+                super('googledrive');
+                this.clientId = '567988062464-fa6c1ovesqeudqs5398vv4mbo6q068p9.apps.googleusercontent.com';
+                this.redirectUri = window.location.origin + window.location.pathname;
+                this.scope = 'https://www.googleapis.com/auth/drive';
+                this.apiBase = 'https://www.googleapis.com/drive/v3';
+                this.accessToken = null;
+                this.refreshToken = null;
+                this.clientSecret = null;
+                this.loadStoredCredentials();
+            }
+
+            loadStoredCredentials() {
+                this.accessToken = localStorage.getItem('google_access_token');
+                this.refreshToken = localStorage.getItem('google_refresh_token');
+                this.clientSecret = localStorage.getItem('google_client_secret');
+                this.isAuthenticated = Boolean(this.accessToken && this.refreshToken && this.clientSecret);
+            }
+
+            storeCredentials() {
+                if (this.accessToken) localStorage.setItem('google_access_token', this.accessToken);
+                if (this.refreshToken) localStorage.setItem('google_refresh_token', this.refreshToken);
+                if (this.clientSecret) localStorage.setItem('google_client_secret', this.clientSecret);
+            }
+
+            clearStoredCredentials() {
+                localStorage.removeItem('google_access_token');
+                localStorage.removeItem('google_refresh_token');
+                localStorage.removeItem('google_client_secret');
+                this.isAuthenticated = false;
+            }
+
+            buildAuthUrl() {
+                const params = new URLSearchParams({
+                    client_id: this.clientId,
+                    redirect_uri: this.redirectUri,
+                    response_type: 'code',
+                    scope: this.scope,
+                    access_type: 'offline',
+                    prompt: 'consent',
+                });
+                return `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+            }
+
+            async authenticate(clientSecret) {
+                if (clientSecret) {
+                    this.clientSecret = clientSecret;
+                    this.storeCredentials();
+                }
+                if (!this.clientSecret) {
+                    throw new Error('Client secret required to authenticate with Google Drive.');
+                }
+
+                if (this.accessToken && this.refreshToken) {
+                    try {
+                        await this.makeApiCall('/files?pageSize=1');
+                        this.isAuthenticated = true;
+                        return true;
+                    } catch (error) {
+                        // continue to OAuth flow
+                    }
+                }
+
+                return new Promise((resolve, reject) => {
+                    const popup = window.open(this.buildAuthUrl(), 'google-auth', 'width=520,height=640,scrollbars=yes,resizable=yes');
+                    if (!popup) {
+                        reject(new Error('Popup blocked. Allow popups and retry.'));
+                        return;
+                    }
+
+                    const checkClosed = setInterval(() => {
+                        if (popup.closed) {
+                            clearInterval(checkClosed);
+                            window.removeEventListener('message', messageHandler);
+                            reject(new Error('Authentication cancelled.'));
+                        }
+                    }, 800);
+
+                    const messageHandler = async (event) => {
+                        if (event.origin !== window.location.origin) return;
+                        if (event.data?.type === 'GOOGLE_AUTH_SUCCESS') {
+                            clearInterval(checkClosed);
+                            window.removeEventListener('message', messageHandler);
+                            popup.close();
+                            try {
+                                await this.exchangeCodeForTokens(event.data.code);
+                                this.isAuthenticated = true;
+                                resolve(true);
+                            } catch (err) {
+                                reject(err);
+                            }
+                        } else if (event.data?.type === 'GOOGLE_AUTH_ERROR') {
+                            clearInterval(checkClosed);
+                            window.removeEventListener('message', messageHandler);
+                            popup.close();
+                            reject(new Error(event.data.error || 'Google authentication failed.'));
+                        }
+                    };
+
+                    window.addEventListener('message', messageHandler);
+                });
+            }
+
+            async exchangeCodeForTokens(code) {
+                const response = await fetch('https://oauth2.googleapis.com/token', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: new URLSearchParams({
+                        client_id: this.clientId,
+                        client_secret: this.clientSecret,
+                        code,
+                        grant_type: 'authorization_code',
+                        redirect_uri: this.redirectUri,
+                    }),
+                });
+                if (!response.ok) {
+                    throw new Error('Token exchange failed.');
+                }
+                const tokens = await response.json();
+                this.accessToken = tokens.access_token;
+                this.refreshToken = tokens.refresh_token;
+                this.storeCredentials();
+            }
+
+            async refreshAccessToken() {
+                if (!this.refreshToken || !this.clientSecret) {
+                    throw new Error('Missing refresh token; reconnect Google Drive.');
+                }
+                const response = await fetch('https://oauth2.googleapis.com/token', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: new URLSearchParams({
+                        client_id: this.clientId,
+                        client_secret: this.clientSecret,
+                        refresh_token: this.refreshToken,
+                        grant_type: 'refresh_token',
+                    }),
+                });
+                if (!response.ok) {
+                    this.clearStoredCredentials();
+                    throw new Error('Failed to refresh Google Drive credentials.');
+                }
+                const tokens = await response.json();
+                this.accessToken = tokens.access_token;
+                this.storeCredentials();
+                return this.accessToken;
+            }
+
+            async makeApiCall(endpoint, options = {}, asJson = true) {
+                if (!this.accessToken) {
+                    throw new Error('Google Drive not authenticated.');
+                }
+                let url = endpoint;
+                if (!endpoint.startsWith('https://')) {
+                    if (endpoint.startsWith('/upload/drive/')) {
+                        url = `https://www.googleapis.com${endpoint}`;
+                    } else {
+                        url = `${this.apiBase}${endpoint}`;
+                    }
+                }
+                const headers = { 'Authorization': `Bearer ${this.accessToken}`, ...options.headers };
+                if (asJson && !('Content-Type' in headers)) {
+                    headers['Content-Type'] = 'application/json';
+                }
+                let response = await fetch(url, { ...options, headers });
+                if (response.status === 401 && this.refreshToken) {
+                    await this.refreshAccessToken();
+                    headers['Authorization'] = `Bearer ${this.accessToken}`;
+                    response = await fetch(url, { ...options, headers });
+                }
+                if (!response.ok) {
+                    const text = await response.text();
+                    throw new Error(`Google API error: ${response.status} ${response.statusText} - ${text}`);
+                }
+                return asJson ? response.json() : response;
+            }
+
+            async getFolders() {
+                const query = "mimeType='application/vnd.google-apps.folder' and trashed=false";
+                const response = await this.makeApiCall(`/files?q=${encodeURIComponent(query)}&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime desc&pageSize=200`);
+                return (response.files || []).map((folder) => ({
+                    id: folder.id,
+                    name: folder.name,
+                    modifiedTime: folder.modifiedTime,
+                    createdTime: folder.createdTime,
+                }));
+            }
+        }
+
+        class OneDriveProvider extends BaseProvider {
+            constructor() {
+                super('onedrive');
+                if (typeof msal === 'undefined') {
+                    throw new Error('Microsoft authentication library is unavailable.');
+                }
+                this.apiBase = 'https://graph.microsoft.com/v1.0';
+                this.scopes = ['Files.ReadWrite.All', 'User.Read'];
+                this.msalInstance = new msal.PublicClientApplication({
+                    auth: {
+                        clientId: 'b407fd45-c551-4dbb-9da5-cab3a2c5a949',
+                        authority: 'https://login.microsoftonline.com/common',
+                        redirectUri: window.location.origin + window.location.pathname,
+                    },
+                    cache: { cacheLocation: 'localStorage' },
+                });
+                const accounts = this.msalInstance.getAllAccounts();
+                if (accounts.length > 0) {
+                    this.msalInstance.setActiveAccount(accounts[0]);
+                    this.activeAccount = accounts[0];
+                    this.isAuthenticated = true;
+                } else {
+                    this.activeAccount = null;
+                }
+            }
+
+            async authenticate() {
+                try {
+                    const accounts = this.msalInstance.getAllAccounts();
+                    if (accounts.length > 0) {
+                        this.msalInstance.setActiveAccount(accounts[0]);
+                        this.activeAccount = accounts[0];
+                    } else {
+                        const loginResponse = await this.msalInstance.loginPopup({ scopes: this.scopes });
+                        this.activeAccount = loginResponse.account;
+                        this.msalInstance.setActiveAccount(this.activeAccount);
+                    }
+                    this.isAuthenticated = true;
+                    return true;
+                } catch (error) {
+                    this.isAuthenticated = false;
+                    throw new Error(`Authentication failed: ${error.message}`);
+                }
+            }
+
+            async getAccessToken() {
+                if (!this.activeAccount) {
+                    throw new Error('No active Microsoft account.');
+                }
+                try {
+                    const response = await this.msalInstance.acquireTokenSilent({ scopes: this.scopes, account: this.activeAccount });
+                    return response.accessToken;
+                } catch (silentError) {
+                    if (silentError instanceof msal.InteractionRequiredAuthError) {
+                        const response = await this.msalInstance.acquireTokenPopup({ scopes: this.scopes, account: this.activeAccount });
+                        return response.accessToken;
+                    }
+                    throw silentError;
+                }
+            }
+
+            async makeApiCall(endpoint, options = {}) {
+                const token = await this.getAccessToken();
+                const url = endpoint.startsWith('https://') ? endpoint : `${this.apiBase}${endpoint}`;
+                const headers = { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json', ...options.headers };
+                const response = await fetch(url, { ...options, headers });
+                if (!response.ok) {
+                    const text = await response.text();
+                    throw new Error(`Microsoft Graph error: ${response.status} ${response.statusText} - ${text}`);
+                }
+                return response;
+            }
+
+            async getFolders() {
+                const response = await this.makeApiCall('/me/drive/root/children');
+                const data = await response.json();
+                return (data.value || [])
+                    .filter((item) => item.folder)
+                    .map((folder) => ({
+                        id: folder.id,
+                        name: folder.name,
+                        modifiedTime: folder.lastModifiedDateTime,
+                        createdTime: folder.createdDateTime,
+                        itemCount: folder.folder?.childCount ?? null,
+                    }))
+                    .sort((a, b) => a.name.localeCompare(b.name));
+            }
+        }
+
+        const dom = {
+            progressSteps: Array.from(document.querySelectorAll('.progress-step')),
+            providerStage: document.getElementById('provider-stage'),
+            authStage: document.getElementById('auth-stage'),
+            folderStage: document.getElementById('folder-stage'),
+            loadingStage: document.getElementById('loading-stage'),
+            workspace: document.getElementById('workspace'),
+            providerButtons: Array.from(document.querySelectorAll('.provider-card')),
+            toAuth: document.getElementById('to-auth'),
+            backToProvider: document.getElementById('back-to-provider'),
+            backToAuth: document.getElementById('back-to-auth'),
+            authBody: document.getElementById('auth-body'),
+            authStatus: document.getElementById('auth-status'),
+            authIntro: document.getElementById('auth-intro'),
+            authAction: document.getElementById('auth-action'),
+            selectedProviderText: document.getElementById('selected-provider'),
+            folderSearch: document.getElementById('folder-search'),
+            folderList: document.getElementById('folder-list'),
+            folderStatus: document.getElementById('folder-status'),
+            folderEmpty: document.getElementById('folder-empty'),
+            startReview: document.getElementById('start-review'),
+            workspaceTitle: document.getElementById('workspace-title'),
+            hudStatus: document.getElementById('hud-status'),
+            trayTitle: document.getElementById('tray-title'),
+            trayDescription: document.getElementById('tray-description'),
+            trayNext: document.getElementById('tray-next'),
+            trayUndo: document.getElementById('tray-undo'),
+            activityLog: document.getElementById('activity-log'),
+            modeButtons: Array.from(document.querySelectorAll('.mode-switch button')),
+        };
+
+        const state = {
+            activeStep: 0,
+            providerKey: null,
+            provider: null,
+            folders: [],
+            selectedFolder: null,
+            isAuthenticating: false,
+        };
+
+        function showStage(index) {
+            state.activeStep = index;
+            const stages = [dom.providerStage, dom.authStage, dom.folderStage];
+            stages.forEach((stage, idx) => stage.classList.toggle('active', idx === index));
+            dom.loadingStage.classList.remove('active');
+            dom.workspace.classList.toggle('active', index === 3);
+            dom.progressSteps.forEach((step, idx) => {
+                step.classList.toggle('active', idx === index);
+                step.classList.toggle('complete', idx < index);
+            });
+        }
+
+        function formatDate(iso) {
+            if (!iso) return '';
+            const date = new Date(iso);
+            if (Number.isNaN(date.getTime())) return '';
+            return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric', year: 'numeric' }).format(date);
+        }
+
+        function formatFolderMeta(folder) {
+            if (typeof folder.itemCount === 'number') {
+                return `${folder.itemCount} item${folder.itemCount === 1 ? '' : 's'}`;
+            }
+            const timestamp = folder.modifiedTime || folder.createdTime;
+            return timestamp ? `Updated ${formatDate(timestamp)}` : 'Folder';
+        }
+
+        function resetFolders() {
+            dom.folderList.innerHTML = '';
+            dom.folderStatus.textContent = '';
+            dom.folderEmpty.hidden = false;
+            dom.startReview.disabled = true;
+            state.selectedFolder = null;
+        }
+
+        function renderAuth() {
+            dom.authBody.innerHTML = '';
+            dom.authStatus.textContent = '';
+            dom.authStatus.className = 'helper-text status-line muted';
+            dom.authAction.disabled = true;
+            dom.authAction.textContent = 'Connect';
+
+            const providerLabel = state.providerKey === 'onedrive' ? 'OneDrive' : 'Google Drive';
+            dom.selectedProviderText.textContent = providerLabel;
+
+            if (state.providerKey === 'googledrive') {
+                dom.authIntro.textContent = 'Enter the Google OAuth client secret from the baseline app. We keep it in local storage so refresh tokens continue working.';
+                const field = document.createElement('div');
+                field.className = 'input-stack';
+                const label = document.createElement('label');
+                label.setAttribute('for', 'google-client-secret');
+                label.textContent = 'Google OAuth client secret';
+                const input = document.createElement('input');
+                input.type = 'password';
+                input.id = 'google-client-secret';
+                input.placeholder = 'Paste your client secret';
+                input.value = state.provider?.clientSecret || '';
+                field.appendChild(label);
+                field.appendChild(input);
+                dom.authBody.appendChild(field);
+
+                const helper = document.createElement('p');
+                helper.className = 'helper-text';
+                helper.textContent = 'We never transmit this value to our servers. It only lives in this browser.';
+                dom.authBody.appendChild(helper);
+
+                const updateButton = () => {
+                    const hasSecret = input.value.trim().length > 0;
+                    dom.authAction.disabled = state.isAuthenticating || (!state.provider.isAuthenticated && !hasSecret);
+                };
+                input.addEventListener('input', updateButton);
+                updateButton();
+                dom.authAction.dataset.secretField = '#google-client-secret';
+                dom.authAction.textContent = state.provider.isAuthenticated ? 'Continue to folders' : 'Connect Google Drive';
+                if (state.provider.isAuthenticated) {
+                    dom.authStatus.textContent = 'Reusing stored Google session. Continue to refresh folders.';
+                    dom.authStatus.classList.add('success');
+                }
+            } else {
+                dom.authIntro.textContent = 'We use Microsoft\'s MSAL flow exactly like the baseline reviewer. Sign in with your enterprise account.';
+                const copy = document.createElement('p');
+                copy.className = 'helper-text';
+                copy.textContent = 'Cached sessions are reused when available. Popups stay in-browser for continuity.';
+                dom.authBody.appendChild(copy);
+                dom.authAction.disabled = state.isAuthenticating;
+                dom.authAction.textContent = state.provider.isAuthenticated ? 'Continue to folders' : 'Sign in with Microsoft';
+                delete dom.authAction.dataset.secretField;
+                if (state.provider.isAuthenticated) {
+                    dom.authStatus.textContent = 'Microsoft account already connected. Continue to load folders.';
+                    dom.authStatus.classList.add('success');
+                }
+            }
+        }
+
+        function renderFolders() {
+            dom.folderList.innerHTML = '';
+            const query = dom.folderSearch.value.trim().toLowerCase();
+            const filtered = state.folders.filter((folder) => folder.name.toLowerCase().includes(query));
+            dom.folderEmpty.hidden = filtered.length > 0;
+            if (filtered.length === 0) {
+                dom.folderStatus.textContent = state.folders.length === 0 ? 'No folders available. Try refreshing the connection.' : 'No matches for your search.';
+                dom.startReview.disabled = true;
+                return;
+            }
+            dom.folderStatus.textContent = filtered.length === state.folders.length ? `Showing ${filtered.length} folders` : `Showing ${filtered.length} of ${state.folders.length} folders`;
+            filtered.forEach((folder) => {
+                const button = document.createElement('button');
+                button.type = 'button';
+                button.className = 'folder-pill';
+                button.innerHTML = `<span>${folder.name}</span><small>${formatFolderMeta(folder)}</small>`;
+                if (state.selectedFolder && state.selectedFolder.id === folder.id) {
+                    button.classList.add('selected');
+                }
+                button.addEventListener('click', () => {
+                    state.selectedFolder = folder;
+                    dom.workspaceTitle.textContent = `Reviewing: ${folder.name}`;
+                    dom.startReview.disabled = false;
+                    renderFolders();
+                });
+                dom.folderList.appendChild(button);
+            });
+        }
+
+        async function loadFolders() {
+            if (!state.provider) return;
+            dom.folderStatus.textContent = 'Fetching folders…';
+            dom.folderStatus.className = 'status-line muted';
+            dom.folderEmpty.hidden = true;
+            dom.folderList.innerHTML = '';
+            dom.startReview.disabled = true;
+            try {
+                state.folders = await state.provider.getFolders();
+                if (state.folders.length === 0) {
+                    dom.folderStatus.textContent = 'No folders returned. Check your permissions.';
+                    dom.folderEmpty.hidden = false;
+                } else {
+                    dom.folderStatus.textContent = `Showing ${state.folders.length} folders`;
+                    dom.folderStatus.className = 'status-line muted';
+                    renderFolders();
+                }
+            } catch (error) {
+                dom.folderStatus.textContent = error.message || 'Failed to load folders.';
+                dom.folderStatus.className = 'status-line error';
+                dom.folderEmpty.hidden = false;
+            }
+        }
+
+        async function handleAuth() {
+            if (!state.provider) return;
+            state.isAuthenticating = true;
+            dom.authAction.disabled = true;
+            const providerLabel = state.providerKey === 'onedrive' ? 'OneDrive' : 'Google Drive';
+            const loadingText = `Connecting to ${providerLabel}…`;
+            dom.authStatus.textContent = loadingText;
+            dom.authStatus.className = 'status-line muted';
+            const defaultText = dom.authAction.textContent;
+            dom.authAction.textContent = loadingText;
+            try {
+                if (state.providerKey === 'googledrive') {
+                    const selector = dom.authAction.dataset.secretField;
+                    const input = selector ? document.querySelector(selector) : null;
+                    const secret = input ? input.value.trim() : '';
+                    await state.provider.authenticate(secret);
+                } else {
+                    await state.provider.authenticate();
+                }
+                dom.authStatus.textContent = `Connected to ${providerLabel}.`;
+                dom.authStatus.classList.add('success');
+                dom.authAction.textContent = 'Continue to folders';
+                state.isAuthenticating = false;
+                dom.authAction.disabled = false;
+                showStage(2);
+                await loadFolders();
+            } catch (error) {
+                dom.authStatus.textContent = error.message || `Failed to connect to ${providerLabel}.`;
+                dom.authStatus.classList.add('error');
+                dom.authAction.textContent = defaultText;
+                state.isAuthenticating = false;
+                dom.authAction.disabled = false;
+                const selector = dom.authAction.dataset.secretField;
+                if (selector) {
+                    const input = document.querySelector(selector);
+                    if (input) input.focus();
+                }
+            }
+        }
+
+        function hydrateWorkspace() {
+            dom.hudStatus.innerHTML = '';
+            ['Priority', 'Keep', 'Out', 'Trash'].forEach((label) => {
+                const pill = document.createElement('span');
+                pill.textContent = `0 ${label.toLowerCase()}`;
+                dom.hudStatus.appendChild(pill);
+            });
+            dom.trayTitle.textContent = 'Workspace ready';
+            dom.trayDescription.textContent = 'Assets will appear here once syncing completes. Use shortcuts or the controls to classify quickly.';
+            dom.activityLog.innerHTML = '';
+            const entry = document.createElement('li');
+            entry.textContent = `Connected ${state.providerKey === 'onedrive' ? 'OneDrive' : 'Google Drive'} folder “${state.selectedFolder.name}”.`;
+            dom.activityLog.appendChild(entry);
+        }
+
+        dom.providerButtons.forEach((button) => {
+            button.addEventListener('click', () => {
+                dom.providerButtons.forEach((btn) => btn.classList.remove('selected'));
+                button.classList.add('selected');
+                state.providerKey = button.dataset.provider;
+                state.provider = state.providerKey === 'onedrive' ? new OneDriveProvider() : new GoogleDriveProvider();
+                dom.toAuth.disabled = false;
+            });
+        });
+
+        dom.toAuth.addEventListener('click', () => {
+            if (!state.provider) return;
+            showStage(1);
+            renderAuth();
+        });
+
+        dom.backToProvider.addEventListener('click', () => {
+            showStage(0);
+        });
+
+        dom.backToAuth.addEventListener('click', () => {
+            showStage(1);
+            renderAuth();
+        });
+
+        dom.authAction.addEventListener('click', () => {
+            if (state.provider?.isAuthenticated) {
+                showStage(2);
+                loadFolders();
+            } else {
+                handleAuth();
+            }
+        });
+
+        dom.startReview.addEventListener('click', async () => {
+            if (!state.selectedFolder) return;
+            showStage(3);
+            dom.loadingStage.classList.add('active');
+            dom.progressSteps.forEach((step) => step.classList.remove('active'));
+            dom.progressSteps.forEach((step) => step.classList.add('complete'));
+            await new Promise((resolve) => setTimeout(resolve, 800));
+            dom.loadingStage.classList.remove('active');
+            dom.workspace.classList.add('active');
+            hydrateWorkspace();
+        });
+
+        dom.folderSearch.addEventListener('input', renderFolders);
+
+        dom.modeButtons.forEach((button) => {
+            button.addEventListener('click', () => {
+                dom.modeButtons.forEach((btn) => btn.classList.remove('active'));
+                button.classList.add('active');
+                const mode = button.dataset.mode;
+                dom.trayTitle.textContent = mode === 'focus' ? 'Focus review' : 'Sort grid';
+                dom.trayDescription.textContent = mode === 'focus'
+                    ? 'Use the keyboard or tap Next to advance through assets one at a time.'
+                    : 'Switch to the grid to bulk organize, then return to focus mode to fine-tune.';
+            });
+        });
+    </script>
+</body>
+</html>

--- a/ui-alpha.html
+++ b/ui-alpha.html
@@ -1,0 +1,1371 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Goji Reviewer – Alpha</title>
+    <script src="https://alcdn.msauth.net/browser/2.28.1/js/msal-browser.min.js" defer></script>
+    <style>
+        :root {
+            color-scheme: light dark;
+            --bg: #f3f4f6;
+            --surface: #ffffff;
+            --surface-muted: #f9fafb;
+            --text: #111827;
+            --text-muted: #6b7280;
+            --primary: #2563eb;
+            --primary-dark: #1d4ed8;
+            --border: #e5e7eb;
+            --success: #059669;
+            --warning: #f59e0b;
+            --radius: 16px;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: "Inter", "Segoe UI", sans-serif;
+            background: linear-gradient(180deg, #e0e7ff 0%, var(--bg) 30%);
+            color: var(--text);
+            line-height: 1.5;
+        }
+
+        h1, h2, h3, h4, h5 {
+            margin: 0;
+            font-weight: 600;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        button {
+            font: inherit;
+        }
+
+        .page {
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        header {
+            padding: 20px clamp(16px, 6vw, 64px) 0;
+        }
+
+        header h1 {
+            font-size: clamp(1.5rem, 2vw, 2rem);
+        }
+
+        header p {
+            color: var(--text-muted);
+            margin-top: 8px;
+            max-width: 48rem;
+        }
+
+        main {
+            flex: 1;
+            padding: 24px clamp(16px, 6vw, 64px) 64px;
+            display: grid;
+            gap: 32px;
+        }
+
+        .onboarding {
+            display: grid;
+            grid-template-columns: minmax(240px, 320px) 1fr;
+            gap: 32px;
+            align-items: start;
+        }
+
+        .card {
+            background: var(--surface);
+            border-radius: var(--radius);
+            box-shadow: 0 20px 50px -35px rgba(15, 23, 42, 0.6);
+            border: 1px solid var(--border);
+        }
+
+        .stepper {
+            padding: 24px;
+        }
+
+        .stepper ul {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .step {
+            display: grid;
+            grid-template-columns: auto 1fr;
+            gap: 12px;
+            align-items: start;
+        }
+
+        .step-index {
+            width: 32px;
+            height: 32px;
+            border-radius: 50%;
+            display: grid;
+            place-items: center;
+            border: 2px solid var(--border);
+            font-weight: 600;
+            color: var(--text-muted);
+            background: var(--surface-muted);
+        }
+
+        .step.active .step-index {
+            background: var(--primary);
+            border-color: var(--primary);
+            color: white;
+        }
+
+        .step.complete .step-index {
+            background: var(--success);
+            border-color: var(--success);
+            color: white;
+        }
+
+        .step h3 {
+            font-size: 1rem;
+            margin-bottom: 4px;
+        }
+
+        .step p {
+            font-size: 0.9rem;
+            color: var(--text-muted);
+        }
+
+        .step-content {
+            padding: 32px;
+            display: none;
+        }
+
+        .step-content.active {
+            display: block;
+        }
+
+        .provider-grid {
+            display: grid;
+            gap: 12px;
+        }
+
+        .provider {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 16px;
+            border-radius: 12px;
+            border: 1px solid var(--border);
+            background: var(--surface-muted);
+            transition: border-color 0.2s ease;
+            cursor: pointer;
+        }
+
+        .provider:hover,
+        .provider.selected {
+            border-color: var(--primary);
+        }
+
+        .provider strong {
+            font-size: 0.95rem;
+        }
+
+        .provider span {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .auth-form,
+        .folder-form {
+            display: grid;
+            gap: 16px;
+        }
+
+        label {
+            font-weight: 500;
+            font-size: 0.9rem;
+        }
+
+        input[type="email"],
+        input[type="password"],
+        input[type="text"],
+        select {
+            width: 100%;
+            padding: 12px 14px;
+            border-radius: 10px;
+            border: 1px solid var(--border);
+            font-size: 0.95rem;
+            background: white;
+        }
+
+        .helper-text {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .auth-status {
+            min-height: 1.2em;
+        }
+
+        .auth-status.success {
+            color: var(--success);
+        }
+
+        .auth-status.error {
+            color: #dc2626;
+        }
+
+        .actions {
+            display: flex;
+            gap: 12px;
+            margin-top: 8px;
+        }
+
+        .primary-btn {
+            background: var(--primary);
+            border: none;
+            color: white;
+            border-radius: 10px;
+            padding: 12px 20px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background 0.2s ease;
+        }
+
+        .primary-btn:hover {
+            background: var(--primary-dark);
+        }
+
+        .secondary-btn {
+            background: transparent;
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 12px 20px;
+            font-weight: 600;
+            color: var(--text);
+            cursor: pointer;
+        }
+
+        .workspace {
+            display: none;
+            gap: 24px;
+            grid-template-columns: 1.5fr 1fr;
+        }
+
+        .workspace.active {
+            display: grid;
+        }
+
+        .workspace-left {
+            display: grid;
+            gap: 24px;
+        }
+
+        .workspace-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .workspace-header h2 {
+            font-size: 1.25rem;
+        }
+
+        .hud {
+            display: flex;
+            gap: 12px;
+        }
+
+        .hud-pill {
+            padding: 10px 16px;
+            border-radius: 999px;
+            background: var(--surface-muted);
+            border: 1px solid var(--border);
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .canvas {
+            background: var(--surface);
+            border-radius: var(--radius);
+            border: 1px solid var(--border);
+            padding: 24px;
+            display: grid;
+            gap: 16px;
+        }
+
+        .image-stage {
+            position: relative;
+            border-radius: 12px;
+            overflow: hidden;
+            background: #111827;
+            aspect-ratio: 3 / 2;
+            display: grid;
+            place-items: center;
+        }
+
+        .image-stage img {
+            max-width: 100%;
+            max-height: 100%;
+            object-fit: cover;
+        }
+
+        .image-stage button {
+            position: absolute;
+            right: 16px;
+            bottom: 16px;
+            background: rgba(17, 24, 39, 0.85);
+            color: white;
+            padding: 10px 16px;
+            border-radius: 999px;
+            border: none;
+            cursor: pointer;
+        }
+
+        .canvas-footer {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .mode-toggle {
+            display: inline-flex;
+            background: var(--surface-muted);
+            border-radius: 999px;
+            border: 1px solid var(--border);
+            padding: 4px;
+        }
+
+        .mode-toggle button {
+            border: none;
+            background: transparent;
+            padding: 8px 16px;
+            border-radius: 999px;
+            font-weight: 600;
+            cursor: pointer;
+            color: var(--text-muted);
+        }
+
+        .mode-toggle button.active {
+            background: white;
+            color: var(--text);
+            box-shadow: 0 4px 12px rgba(79, 70, 229, 0.15);
+        }
+
+        .quick-actions {
+            display: flex;
+            gap: 12px;
+        }
+
+        .quick-actions button {
+            border: 1px solid var(--border);
+            background: white;
+            border-radius: 999px;
+            padding: 8px 14px;
+            cursor: pointer;
+            font-weight: 500;
+            color: var(--text);
+        }
+
+        .workspace-right {
+            display: grid;
+            gap: 20px;
+        }
+
+        .status-card,
+        .queue-card,
+        .notes-card {
+            padding: 24px;
+            border-radius: var(--radius);
+            border: 1px solid var(--border);
+            background: var(--surface);
+        }
+
+        .status-card h3,
+        .queue-card h3,
+        .notes-card h3 {
+            font-size: 1rem;
+            margin-bottom: 12px;
+        }
+
+        .status-list {
+            display: grid;
+            gap: 12px;
+        }
+
+        .status-item {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 12px 16px;
+            border-radius: 12px;
+            background: var(--surface-muted);
+        }
+
+        .queue-list {
+            display: grid;
+            gap: 8px;
+        }
+
+        .queue-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 12px 16px;
+            border-radius: 12px;
+            border: 1px dashed var(--border);
+            background: var(--surface-muted);
+        }
+
+        button.queue-item {
+            cursor: pointer;
+            text-align: left;
+        }
+
+        button.queue-item.selected {
+            border-style: solid;
+            border-color: var(--primary);
+            background: rgba(37, 99, 235, 0.08);
+        }
+
+        textarea {
+            width: 100%;
+            min-height: 120px;
+            resize: vertical;
+            border-radius: 12px;
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            font-family: inherit;
+            font-size: 0.95rem;
+        }
+
+        .tray {
+            position: fixed;
+            bottom: 24px;
+            left: 50%;
+            transform: translateX(-50%);
+            width: min(680px, calc(100% - 48px));
+            background: rgba(255, 255, 255, 0.95);
+            border-radius: 18px;
+            border: 1px solid rgba(148, 163, 184, 0.4);
+            box-shadow: 0 30px 60px -35px rgba(15, 23, 42, 0.35);
+            padding: 16px 20px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+            transition: transform 0.3s ease, opacity 0.3s ease;
+        }
+
+        .tray.hidden {
+            transform: translate(-50%, calc(100% + 24px));
+            opacity: 0;
+        }
+
+        .tray h4 {
+            font-size: 0.95rem;
+        }
+
+        .tray button.primary-btn {
+            padding: 10px 18px;
+            white-space: nowrap;
+        }
+
+        .empty-state {
+            padding: 20px;
+            border-radius: 12px;
+            border: 1px dashed var(--border);
+            background: var(--surface-muted);
+            color: var(--text-muted);
+        }
+
+        @media (max-width: 1024px) {
+            .onboarding,
+            .workspace {
+                grid-template-columns: 1fr;
+            }
+
+            .stepper {
+                position: sticky;
+                top: 0;
+            }
+
+            .tray {
+                width: calc(100% - 32px);
+            }
+        }
+
+        @media (max-width: 720px) {
+            header,
+            main {
+                padding-left: 16px;
+                padding-right: 16px;
+            }
+
+            .canvas-footer {
+                flex-direction: column;
+                align-items: stretch;
+                gap: 16px;
+            }
+
+            .quick-actions {
+                flex-wrap: wrap;
+            }
+
+            .tray {
+                flex-direction: column;
+                align-items: stretch;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="page">
+        <header>
+            <h1>Goji Reviewer Alpha</h1>
+            <p>
+                A streamlined flow for triaging photo and design libraries. Connect to your storage, stay oriented with a
+                simple stepper, and move through decisions with lightweight controls.
+            </p>
+        </header>
+        <main>
+            <section class="onboarding" id="onboarding">
+                <nav class="card stepper" aria-label="Onboarding steps">
+                    <ul>
+                        <li class="step active" data-step="0">
+                            <div class="step-index">1</div>
+                            <div>
+                                <h3>Choose provider</h3>
+                                <p>Select the service where your library lives.</p>
+                            </div>
+                        </li>
+                        <li class="step" data-step="1">
+                            <div class="step-index">2</div>
+                            <div>
+                                <h3>Sign in securely</h3>
+                                <p>Authenticate with your provider credentials.</p>
+                            </div>
+                        </li>
+                        <li class="step" data-step="2">
+                            <div class="step-index">3</div>
+                            <div>
+                                <h3>Pick a collection</h3>
+                                <p>Confirm the folder to review and start sorting.</p>
+                            </div>
+                        </li>
+                    </ul>
+                </nav>
+                <div class="card">
+                    <div class="step-content active" data-step-content="0">
+                        <h2>Connect your library</h2>
+                        <p class="helper-text">
+                            We support the providers our teams use most often. You can change this later from settings.
+                        </p>
+                        <div class="provider-grid" role="list">
+                            <button class="provider" type="button" data-provider="Google Drive" data-provider-id="googledrive">
+                                <div>
+                                    <strong>Google Drive</strong>
+                                    <div class="helper-text">Shared team folders and personal space</div>
+                                </div>
+                                <span>Recommended</span>
+                            </button>
+                            <button class="provider" type="button" data-provider="OneDrive" data-provider-id="onedrive">
+                                <div>
+                                    <strong>OneDrive</strong>
+                                    <div class="helper-text">Enterprise accounts with SSO</div>
+                                </div>
+                                <span>SSO</span>
+                            </button>
+                        </div>
+                        <div class="actions">
+                            <button class="primary-btn" id="to-auth" disabled>Continue</button>
+                        </div>
+                    </div>
+                    <div class="step-content" data-step-content="1">
+                        <h2>Sign in to <span id="selected-provider">your provider</span></h2>
+                        <p class="helper-text" id="auth-intro">We use a secure OAuth flow tailored to each provider.</p>
+                        <div class="auth-form" id="auth-body" aria-live="polite"></div>
+                        <p class="helper-text auth-status" id="auth-status" role="status"></p>
+                        <div class="actions">
+                            <button class="secondary-btn" data-back>Back</button>
+                            <button class="primary-btn" id="auth-action" disabled>Authorize &amp; continue</button>
+                        </div>
+                    </div>
+                    <div class="step-content" data-step-content="2">
+                        <h2>Choose a collection</h2>
+                        <p class="helper-text">Recently opened folders are pinned first. You can search all directories.</p>
+                        <div class="folder-form" role="list">
+                            <label class="helper-text" for="folder-search">Quick search</label>
+                            <input id="folder-search" type="text" placeholder="Search project names or clients" autocomplete="off" />
+                            <p class="helper-text auth-status" id="folder-status" role="status"></p>
+                            <div class="queue-list" id="folder-list" role="group" aria-label="Folder choices"></div>
+                            <div class="empty-state" id="folder-empty" hidden>
+                                Nothing here yet? Create a folder in your drive and refresh to see it instantly.
+                            </div>
+                        </div>
+                        <div class="actions">
+                            <button class="secondary-btn" data-back>Back</button>
+                            <button class="primary-btn" id="start-review" disabled>Start reviewing</button>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="workspace" id="workspace" aria-live="polite">
+                <div class="workspace-left">
+                    <div class="workspace-header">
+                        <h2 id="workspace-title">Reviewing: Launch Campaign / Priority</h2>
+                        <div class="hud">
+                            <div class="hud-pill" id="hud-progress">12 of 42</div>
+                            <div class="hud-pill" id="hud-status">Focus mode</div>
+                        </div>
+                    </div>
+                    <div class="canvas">
+                        <div class="image-stage" role="img" aria-label="Current asset preview">
+                            <img src="https://images.unsplash.com/photo-1526481280695-3c469182a660?auto=format&fit=crop&w=1200&q=80" alt="Moodboard collage" />
+                            <button type="button" id="open-inspect">Inspect details</button>
+                        </div>
+                        <div class="canvas-footer">
+                            <div class="mode-toggle" role="tablist" aria-label="Review mode">
+                                <button type="button" class="active" data-mode="focus" role="tab">Focus</button>
+                                <button type="button" data-mode="sort" role="tab">Sort</button>
+                            </div>
+                            <div class="quick-actions">
+                                <button type="button" data-action="keep">Keep</button>
+                                <button type="button" data-action="needs-work">Needs work</button>
+                                <button type="button" data-action="discard">Discard</button>
+                                <button type="button" data-action="compare">Compare</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <aside class="workspace-right">
+                    <div class="status-card" aria-live="polite">
+                        <h3>Session status</h3>
+                        <div class="status-list">
+                            <div class="status-item">
+                                <span>Provider</span>
+                                <strong id="status-provider">Google Drive</strong>
+                            </div>
+                            <div class="status-item">
+                                <span>Sync</span>
+                                <strong>Up to date</strong>
+                            </div>
+                            <div class="status-item">
+                                <span>Next review</span>
+                                <strong>Tomorrow, 9:00am</strong>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="queue-card">
+                        <h3>Upcoming assets</h3>
+                        <div class="queue-list" id="upcoming-list">
+                            <div class="queue-item">
+                                <span>Hero banner iteration</span>
+                                <span>Due today</span>
+                            </div>
+                            <div class="queue-item">
+                                <span>Carousel v3</span>
+                                <span>Needs rating</span>
+                            </div>
+                            <div class="queue-item">
+                                <span>Story set – motion</span>
+                                <span>New upload</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="notes-card">
+                        <h3>Notes &amp; tags</h3>
+                        <textarea placeholder="Add quick feedback for collaborators"></textarea>
+                        <div class="helper-text">Use #hashtags to auto-tag assets and @mention teammates.</div>
+                    </div>
+                </aside>
+            </section>
+        </main>
+    </div>
+
+    <div class="tray hidden" id="tray" role="dialog" aria-live="assertive">
+        <div>
+            <h4 id="tray-title">Marked as Keep</h4>
+            <p class="helper-text" id="tray-description">We’ll move this asset to the Approved bucket.</p>
+        </div>
+        <div class="quick-actions">
+            <button type="button" class="secondary-btn" id="tray-undo">Undo</button>
+            <button type="button" class="primary-btn" id="tray-next">Next asset</button>
+        </div>
+    </div>
+
+    <script>
+        (function () {
+            const params = new URLSearchParams(window.location.search);
+            const oauthCode = params.get('code');
+            const oauthError = params.get('error');
+            if ((oauthCode || oauthError) && window.opener && window.opener !== window) {
+                if (oauthError) {
+                    window.opener.postMessage({ type: 'GOOGLE_AUTH_ERROR', error: oauthError }, window.location.origin);
+                } else if (oauthCode) {
+                    window.opener.postMessage({ type: 'GOOGLE_AUTH_SUCCESS', code: oauthCode }, window.location.origin);
+                }
+                window.close();
+                return;
+            }
+
+            class BaseProvider {
+                constructor(name) {
+                    this.name = name;
+                    this.isAuthenticated = false;
+                }
+                async authenticate() {
+                    throw new Error("Method 'authenticate()' must be implemented.");
+                }
+                async getFolders() {
+                    throw new Error("Method 'getFolders()' must be implemented.");
+                }
+            }
+
+            class GoogleDriveProvider extends BaseProvider {
+                constructor() {
+                    super('googledrive');
+                    this.clientId = '567988062464-fa6c1ovesqeudqs5398vv4mbo6q068p9.apps.googleusercontent.com';
+                    this.redirectUri = window.location.origin + window.location.pathname;
+                    this.scope = 'https://www.googleapis.com/auth/drive';
+                    this.apiBase = 'https://www.googleapis.com/drive/v3';
+                    this.accessToken = null;
+                    this.refreshToken = null;
+                    this.clientSecret = null;
+                    this.loadStoredCredentials();
+                }
+
+                loadStoredCredentials() {
+                    this.accessToken = localStorage.getItem('google_access_token');
+                    this.refreshToken = localStorage.getItem('google_refresh_token');
+                    this.clientSecret = localStorage.getItem('google_client_secret');
+                    this.isAuthenticated = Boolean(this.accessToken && this.refreshToken && this.clientSecret);
+                }
+
+                storeCredentials() {
+                    if (this.accessToken) localStorage.setItem('google_access_token', this.accessToken);
+                    if (this.refreshToken) localStorage.setItem('google_refresh_token', this.refreshToken);
+                    if (this.clientSecret) localStorage.setItem('google_client_secret', this.clientSecret);
+                }
+
+                clearStoredCredentials() {
+                    localStorage.removeItem('google_access_token');
+                    localStorage.removeItem('google_refresh_token');
+                    localStorage.removeItem('google_client_secret');
+                }
+
+                async authenticate(clientSecret) {
+                    if (clientSecret) {
+                        this.clientSecret = clientSecret;
+                        this.storeCredentials();
+                    }
+                    if (!this.clientSecret) {
+                        throw new Error('Client secret is required for Google Drive authentication.');
+                    }
+                    if (this.accessToken && this.refreshToken) {
+                        try {
+                            await this.makeApiCall('/files?pageSize=1');
+                            this.isAuthenticated = true;
+                            return true;
+                        } catch (error) {
+                            // continue to popup flow
+                        }
+                    }
+
+                    return new Promise((resolve, reject) => {
+                        const authUrl = this.buildAuthUrl();
+                        const popup = window.open(authUrl, 'google-auth', 'width=500,height=600,scrollbars=yes,resizable=yes');
+                        if (!popup) {
+                            reject(new Error('Popup blocked by browser. Please allow popups and try again.'));
+                            return;
+                        }
+
+                        const checkClosed = setInterval(() => {
+                            if (popup.closed) {
+                                clearInterval(checkClosed);
+                                window.removeEventListener('message', messageHandler);
+                                reject(new Error('Authentication cancelled.'));
+                            }
+                        }, 1000);
+
+                        const messageHandler = async (event) => {
+                            if (event.origin !== window.location.origin) return;
+                            if (event.data?.type === 'GOOGLE_AUTH_SUCCESS') {
+                                clearInterval(checkClosed);
+                                window.removeEventListener('message', messageHandler);
+                                popup.close();
+                                try {
+                                    await this.exchangeCodeForTokens(event.data.code);
+                                    this.isAuthenticated = true;
+                                    resolve(true);
+                                } catch (error) {
+                                    reject(error);
+                                }
+                            } else if (event.data?.type === 'GOOGLE_AUTH_ERROR') {
+                                clearInterval(checkClosed);
+                                window.removeEventListener('message', messageHandler);
+                                popup.close();
+                                reject(new Error(event.data.error || 'Authentication failed.'));
+                            }
+                        };
+
+                        window.addEventListener('message', messageHandler);
+                    });
+                }
+
+                buildAuthUrl() {
+                    const params = new URLSearchParams({
+                        client_id: this.clientId,
+                        redirect_uri: this.redirectUri,
+                        response_type: 'code',
+                        scope: this.scope,
+                        access_type: 'offline',
+                        prompt: 'consent',
+                    });
+                    return `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+                }
+
+                async exchangeCodeForTokens(code) {
+                    const response = await fetch('https://oauth2.googleapis.com/token', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                        body: new URLSearchParams({
+                            client_id: this.clientId,
+                            client_secret: this.clientSecret,
+                            code,
+                            grant_type: 'authorization_code',
+                            redirect_uri: this.redirectUri,
+                        }),
+                    });
+                    if (!response.ok) {
+                        throw new Error('Token exchange failed.');
+                    }
+                    const tokens = await response.json();
+                    this.accessToken = tokens.access_token;
+                    this.refreshToken = tokens.refresh_token;
+                    this.storeCredentials();
+                }
+
+                async refreshAccessToken() {
+                    if (!this.refreshToken || !this.clientSecret) {
+                        throw new Error('Missing refresh token. Please reconnect Google Drive.');
+                    }
+                    const response = await fetch('https://oauth2.googleapis.com/token', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                        body: new URLSearchParams({
+                            client_id: this.clientId,
+                            client_secret: this.clientSecret,
+                            refresh_token: this.refreshToken,
+                            grant_type: 'refresh_token',
+                        }),
+                    });
+                    if (!response.ok) {
+                        this.clearStoredCredentials();
+                        throw new Error('Failed to refresh Google Drive credentials.');
+                    }
+                    const tokens = await response.json();
+                    this.accessToken = tokens.access_token;
+                    this.storeCredentials();
+                    return this.accessToken;
+                }
+
+                async makeApiCall(endpoint, options = {}, asJson = true) {
+                    if (!this.accessToken) {
+                        throw new Error('Not authenticated with Google Drive.');
+                    }
+                    let url;
+                    if (endpoint.startsWith('https://')) {
+                        url = endpoint;
+                    } else if (endpoint.startsWith('/upload/drive/')) {
+                        url = `https://www.googleapis.com${endpoint}`;
+                    } else {
+                        url = `${this.apiBase}${endpoint}`;
+                    }
+
+                    const headers = { 'Authorization': `Bearer ${this.accessToken}`, ...options.headers };
+                    if (asJson && !('Content-Type' in headers)) {
+                        headers['Content-Type'] = 'application/json';
+                    }
+
+                    let response = await fetch(url, { ...options, headers });
+                    if (response.status === 401 && this.refreshToken && this.clientSecret) {
+                        await this.refreshAccessToken();
+                        headers['Authorization'] = `Bearer ${this.accessToken}`;
+                        response = await fetch(url, { ...options, headers });
+                    }
+                    if (!response.ok) {
+                        const errorText = await response.text();
+                        throw new Error(`API call failed: ${response.status} ${response.statusText} - ${errorText}`);
+                    }
+                    return asJson ? response.json() : response;
+                }
+
+                async getFolders() {
+                    const query = "mimeType='application/vnd.google-apps.folder' and trashed=false";
+                    const url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&pageSize=100`;
+                    const response = await this.makeApiCall(url);
+                    return (response.files || []).map((folder) => ({
+                        id: folder.id,
+                        name: folder.name,
+                        modifiedTime: folder.modifiedTime,
+                        createdTime: folder.createdTime,
+                    }));
+                }
+            }
+
+            class OneDriveProvider extends BaseProvider {
+                constructor() {
+                    super('onedrive');
+                    if (typeof msal === 'undefined') {
+                        throw new Error('Microsoft authentication library is unavailable.');
+                    }
+                    this.apiBase = 'https://graph.microsoft.com/v1.0';
+                    this.scopes = ['Files.ReadWrite.AppFolder', 'User.Read'];
+                    this.msalInstance = new msal.PublicClientApplication({
+                        auth: {
+                            clientId: 'b407fd45-c551-4dbb-9da5-cab3a2c5a949',
+                            authority: 'https://login.microsoftonline.com/common',
+                            redirectUri: window.location.origin + window.location.pathname,
+                        },
+                        cache: { cacheLocation: 'localStorage' },
+                    });
+                    const accounts = this.msalInstance.getAllAccounts();
+                    if (accounts.length > 0) {
+                        this.msalInstance.setActiveAccount(accounts[0]);
+                        this.activeAccount = accounts[0];
+                        this.isAuthenticated = true;
+                    } else {
+                        this.activeAccount = null;
+                    }
+                }
+
+                async authenticate() {
+                    try {
+                        const accounts = this.msalInstance.getAllAccounts();
+                        if (accounts.length > 0) {
+                            this.msalInstance.setActiveAccount(accounts[0]);
+                            this.activeAccount = accounts[0];
+                        } else {
+                            const loginResponse = await this.msalInstance.loginPopup({ scopes: this.scopes });
+                            this.activeAccount = loginResponse.account;
+                            this.msalInstance.setActiveAccount(this.activeAccount);
+                        }
+                        this.isAuthenticated = true;
+                        return true;
+                    } catch (error) {
+                        this.isAuthenticated = false;
+                        throw new Error(`Authentication failed: ${error.message}`);
+                    }
+                }
+
+                async getAccessToken() {
+                    if (!this.activeAccount) {
+                        throw new Error('No active Microsoft account.');
+                    }
+                    try {
+                        const response = await this.msalInstance.acquireTokenSilent({ scopes: this.scopes, account: this.activeAccount });
+                        return response.accessToken;
+                    } catch (silentError) {
+                        if (silentError instanceof msal.InteractionRequiredAuthError) {
+                            const response = await this.msalInstance.acquireTokenPopup({ scopes: this.scopes, account: this.activeAccount });
+                            return response.accessToken;
+                        }
+                        throw silentError;
+                    }
+                }
+
+                async makeApiCall(endpoint, options = {}) {
+                    const accessToken = await this.getAccessToken();
+                    const url = endpoint.startsWith('https://') ? endpoint : `${this.apiBase}${endpoint}`;
+                    const headers = { 'Authorization': `Bearer ${accessToken}`, 'Content-Type': 'application/json', ...options.headers };
+                    const response = await fetch(url, { ...options, headers });
+                    if (!response.ok) {
+                        const errorText = await response.text();
+                        throw new Error(`API call failed: ${response.status} ${response.statusText} - ${errorText}`);
+                    }
+                    return response;
+                }
+
+                async getFolders() {
+                    const response = await this.makeApiCall('/me/drive/root/children');
+                    const data = await response.json();
+                    return (data.value || [])
+                        .filter((item) => item.folder)
+                        .map((folder) => ({
+                            id: folder.id,
+                            name: folder.name,
+                            modifiedTime: folder.lastModifiedDateTime,
+                            createdTime: folder.createdDateTime,
+                            itemCount: folder.folder?.childCount ?? null,
+                        }))
+                        .sort((a, b) => a.name.localeCompare(b.name));
+                }
+            }
+
+            const dom = {
+                steps: Array.from(document.querySelectorAll('.step')),
+                contents: Array.from(document.querySelectorAll('[data-step-content]')),
+                toAuthButton: document.getElementById('to-auth'),
+                authActionButton: document.getElementById('auth-action'),
+                startReviewButton: document.getElementById('start-review'),
+                onboarding: document.getElementById('onboarding'),
+                workspace: document.getElementById('workspace'),
+                providerButtons: Array.from(document.querySelectorAll('.provider')),
+                selectedProviderText: document.getElementById('selected-provider'),
+                statusProvider: document.getElementById('status-provider'),
+                workspaceTitle: document.getElementById('workspace-title'),
+                authBody: document.getElementById('auth-body'),
+                authStatus: document.getElementById('auth-status'),
+                authIntro: document.getElementById('auth-intro'),
+                folderSearch: document.getElementById('folder-search'),
+                folderList: document.getElementById('folder-list'),
+                folderStatus: document.getElementById('folder-status'),
+                folderEmpty: document.getElementById('folder-empty'),
+                tray: document.getElementById('tray'),
+                trayTitle: document.getElementById('tray-title'),
+                trayDescription: document.getElementById('tray-description'),
+                trayNext: document.getElementById('tray-next'),
+                trayUndo: document.getElementById('tray-undo'),
+                hudStatus: document.getElementById('hud-status'),
+                modeButtons: Array.from(document.querySelectorAll('.mode-toggle button')),
+            };
+
+            const state = {
+                activeStep: 0,
+                providerType: null,
+                provider: null,
+                folders: [],
+                selectedFolder: null,
+                isAuthenticating: false,
+            };
+
+            function setStep(index) {
+                state.activeStep = index;
+                dom.steps.forEach((step, i) => {
+                    step.classList.toggle('active', i === index);
+                    step.classList.toggle('complete', i < index);
+                });
+                dom.contents.forEach((content) => {
+                    const contentIndex = Number(content.dataset.stepContent);
+                    content.classList.toggle('active', contentIndex === index);
+                });
+            }
+
+            function showStatus(element, message, tone = '') {
+                if (!element) return;
+                element.textContent = message;
+                element.classList.remove('success', 'error');
+                if (tone) {
+                    element.classList.add(tone);
+                }
+            }
+
+            function formatDate(isoString) {
+                if (!isoString) return '';
+                const date = new Date(isoString);
+                if (Number.isNaN(date.getTime())) return '';
+                return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric', year: 'numeric' }).format(date);
+            }
+
+            function formatFolderMeta(folder) {
+                if (typeof folder.itemCount === 'number') {
+                    return `${folder.itemCount} item${folder.itemCount === 1 ? '' : 's'}`;
+                }
+                const timestamp = folder.modifiedTime || folder.createdTime;
+                if (timestamp) {
+                    return `Updated ${formatDate(timestamp)}`;
+                }
+                return 'Folder';
+            }
+
+            function resetFolderSelection() {
+                state.selectedFolder = null;
+                dom.startReviewButton.disabled = true;
+            }
+
+            function renderFolderList() {
+                if (!dom.folderList) return;
+                const query = dom.folderSearch.value.trim().toLowerCase();
+                const filtered = state.folders.filter((folder) => folder.name.toLowerCase().includes(query));
+                dom.folderList.innerHTML = '';
+                dom.folderEmpty.hidden = filtered.length !== 0;
+
+                if (filtered.length === 0) {
+                    showStatus(dom.folderStatus, state.folders.length === 0 ? 'No folders found for this provider.' : 'No matches for your search.', '');
+                    resetFolderSelection();
+                    return;
+                }
+
+                showStatus(dom.folderStatus, filtered.length === state.folders.length ? `Showing ${filtered.length} folders` : `Showing ${filtered.length} of ${state.folders.length} folders`, '');
+
+                filtered.forEach((folder) => {
+                    const button = document.createElement('button');
+                    button.type = 'button';
+                    button.className = 'queue-item';
+                    button.dataset.folderId = folder.id;
+                    button.dataset.folderName = folder.name;
+                    button.innerHTML = `<span>${folder.name}</span><span>${formatFolderMeta(folder)}</span>`;
+                    if (state.selectedFolder && state.selectedFolder.id === folder.id) {
+                        button.classList.add('selected');
+                    }
+                    button.addEventListener('click', () => selectFolder(folder));
+                    dom.folderList.appendChild(button);
+                });
+            }
+
+            function selectFolder(folder) {
+                state.selectedFolder = folder;
+                dom.workspaceTitle.textContent = `Reviewing: ${folder.name}`;
+                dom.startReviewButton.disabled = false;
+                Array.from(dom.folderList.querySelectorAll('button.queue-item')).forEach((button) => {
+                    button.classList.toggle('selected', button.dataset.folderId === folder.id);
+                });
+            }
+
+            function renderAuthStep() {
+                if (!state.providerType || !dom.authBody) return;
+                dom.authBody.innerHTML = '';
+                dom.authActionButton.disabled = true;
+                dom.authActionButton.classList.remove('loading');
+                showStatus(dom.authStatus, '', '');
+
+                const providerLabel = state.providerType === 'googledrive' ? 'Google Drive' : 'OneDrive';
+                dom.selectedProviderText.textContent = providerLabel;
+                dom.statusProvider.textContent = providerLabel;
+
+                if (state.providerType === 'googledrive') {
+                    dom.authIntro.textContent = 'Enter the Google Drive OAuth client secret. It is stored locally and used to securely refresh your session.';
+                    const field = document.createElement('div');
+                    const label = document.createElement('label');
+                    label.setAttribute('for', 'google-client-secret');
+                    label.textContent = 'Google OAuth client secret';
+                    const input = document.createElement('input');
+                    input.id = 'google-client-secret';
+                    input.name = 'google-client-secret';
+                    input.type = 'password';
+                    input.placeholder = 'Enter client secret';
+                    input.autocomplete = 'current-password';
+                    input.value = state.provider?.clientSecret || '';
+                    field.appendChild(label);
+                    field.appendChild(input);
+                    dom.authBody.appendChild(field);
+
+                    const helper = document.createElement('p');
+                    helper.className = 'helper-text';
+                    helper.textContent = 'Use the same credentials as the baseline reviewer app. We only persist them in this browser.';
+                    dom.authBody.appendChild(helper);
+
+                    const updateButtonState = () => {
+                        const hasSecret = input.value.trim().length > 0;
+                        dom.authActionButton.disabled = state.isAuthenticating || (!state.provider.isAuthenticated && !hasSecret);
+                    };
+                    input.addEventListener('input', updateButtonState);
+                    updateButtonState();
+
+                    if (state.provider.isAuthenticated) {
+                        showStatus(dom.authStatus, 'Using saved Google Drive session. Continue to refresh folders.', 'success');
+                        dom.authActionButton.disabled = state.isAuthenticating;
+                        dom.authActionButton.textContent = 'Continue to folders';
+                    } else {
+                        dom.authActionButton.textContent = 'Connect Google Drive';
+                    }
+
+                    dom.authActionButton.dataset.clientSecretField = '#google-client-secret';
+                } else {
+                    dom.authIntro.textContent = 'We use Microsoft’s MSAL library to mirror the baseline OneDrive OAuth flow. You\'ll sign in with your organization credentials in a popup.';
+                    const copy = document.createElement('p');
+                    copy.className = 'helper-text';
+                    copy.textContent = 'When prompted, choose the same account you use in the baseline tool. We reuse cached sessions when available.';
+                    dom.authBody.appendChild(copy);
+
+                    dom.authActionButton.disabled = state.isAuthenticating;
+                    dom.authActionButton.textContent = state.provider.isAuthenticated ? 'Continue to folders' : 'Sign in with Microsoft';
+                    delete dom.authActionButton.dataset.clientSecretField;
+
+                    if (state.provider.isAuthenticated) {
+                        showStatus(dom.authStatus, 'Microsoft account already connected. Continue to open your folders.', 'success');
+                    }
+                }
+            }
+
+            async function handleAuthAction() {
+                if (!state.provider) return;
+                state.isAuthenticating = true;
+                dom.authActionButton.disabled = true;
+                const defaultText = state.providerType === 'googledrive' ? 'Connect Google Drive' : 'Sign in with Microsoft';
+                const loadingText = state.providerType === 'googledrive' ? 'Connecting to Google Drive…' : 'Connecting to OneDrive…';
+                const successText = state.providerType === 'googledrive' ? 'Connected to Google Drive.' : 'Connected to OneDrive.';
+                dom.authActionButton.textContent = loadingText;
+                showStatus(dom.authStatus, loadingText, '');
+
+                try {
+                    if (state.providerType === 'googledrive') {
+                        const selector = dom.authActionButton.dataset.clientSecretField;
+                        const input = selector ? document.querySelector(selector) : null;
+                        const secret = input ? input.value.trim() : '';
+                        await state.provider.authenticate(secret);
+                    } else {
+                        await state.provider.authenticate();
+                    }
+                    showStatus(dom.authStatus, successText, 'success');
+                    dom.authActionButton.textContent = 'Continue to folders';
+                    state.isAuthenticating = false;
+                    dom.authActionButton.disabled = false;
+                    setStep(2);
+                    await loadFolders();
+                } catch (error) {
+                    showStatus(dom.authStatus, error.message || 'Authentication failed.', 'error');
+                    dom.authActionButton.textContent = defaultText;
+                    state.isAuthenticating = false;
+                    const selector = dom.authActionButton.dataset.clientSecretField;
+                    if (selector) {
+                        const input = document.querySelector(selector);
+                        if (input) input.focus();
+                    }
+                    dom.authActionButton.disabled = false;
+                }
+            }
+
+            async function loadFolders() {
+                if (!state.provider) return;
+                resetFolderSelection();
+                dom.folderList.innerHTML = '';
+                dom.folderEmpty.hidden = true;
+                dom.folderSearch.value = '';
+                showStatus(dom.folderStatus, 'Loading folders…', '');
+
+                try {
+                    const folders = await state.provider.getFolders();
+                    state.folders = folders;
+                    if (folders.length === 0) {
+                        showStatus(dom.folderStatus, 'No folders were returned by the provider.', 'error');
+                        dom.folderEmpty.hidden = false;
+                        return;
+                    }
+                    showStatus(dom.folderStatus, `Showing ${folders.length} folders`, 'success');
+                    renderFolderList();
+                } catch (error) {
+                    state.folders = [];
+                    showStatus(dom.folderStatus, error.message || 'Unable to load folders.', 'error');
+                    dom.folderEmpty.hidden = false;
+                }
+            }
+
+            function showTray(action) {
+                const copy = {
+                    keep: {
+                        title: 'Marked as Keep',
+                        description: 'We\'ll move this asset to the Approved bucket.',
+                    },
+                    'needs-work': {
+                        title: 'Marked as Needs Work',
+                        description: 'We\'ve queued this asset for revisions.',
+                    },
+                    discard: {
+                        title: 'Marked as Discard',
+                        description: 'This asset will be archived after confirmation.',
+                    },
+                    compare: {
+                        title: 'Compare queued',
+                        description: 'We\'ll open a side-by-side view with the next candidate.',
+                    },
+                }[action];
+
+                if (!copy) return;
+                dom.trayTitle.textContent = copy.title;
+                dom.trayDescription.textContent = copy.description;
+                dom.tray.classList.remove('hidden');
+                clearTimeout(dom.tray.dataset.timeout);
+                dom.tray.dataset.timeout = setTimeout(() => dom.tray.classList.add('hidden'), 4000);
+            }
+
+            dom.providerButtons.forEach((button) => {
+                button.addEventListener('click', () => {
+                    dom.providerButtons.forEach((btn) => btn.classList.remove('selected'));
+                    button.classList.add('selected');
+                    state.providerType = button.dataset.providerId;
+                    try {
+                        state.provider = state.providerType === 'googledrive' ? new GoogleDriveProvider() : new OneDriveProvider();
+                        dom.selectedProviderText.textContent = button.dataset.provider;
+                        dom.statusProvider.textContent = button.dataset.provider;
+                        dom.toAuthButton.disabled = false;
+                        showStatus(dom.authStatus, '', '');
+                    } catch (error) {
+                        state.provider = null;
+                        state.providerType = null;
+                        dom.selectedProviderText.textContent = 'your provider';
+                        dom.toAuthButton.disabled = true;
+                        showStatus(dom.authStatus, error.message, 'error');
+                    }
+                });
+            });
+
+            dom.toAuthButton.addEventListener('click', () => {
+                if (!state.providerType || !state.provider) return;
+                setStep(1);
+                renderAuthStep();
+            });
+
+            document.querySelectorAll('[data-back]').forEach((button) => {
+                button.addEventListener('click', () => {
+                    const nextStep = Math.max(0, state.activeStep - 1);
+                    setStep(nextStep);
+                    if (nextStep === 1) {
+                        renderAuthStep();
+                    }
+                });
+            });
+
+            dom.authActionButton.addEventListener('click', handleAuthAction);
+            dom.folderSearch.addEventListener('input', () => {
+                renderFolderList();
+            });
+
+            dom.startReviewButton.addEventListener('click', () => {
+                if (!state.selectedFolder) return;
+                dom.onboarding.style.display = 'none';
+                dom.workspace.classList.add('active');
+                dom.tray.classList.add('hidden');
+            });
+
+            document.querySelectorAll('[data-action]').forEach((button) => {
+                button.addEventListener('click', () => {
+                    showTray(button.dataset.action);
+                });
+            });
+
+            dom.trayNext.addEventListener('click', () => {
+                dom.tray.classList.add('hidden');
+                dom.hudStatus.textContent = 'Next asset loaded';
+                setTimeout(() => {
+                    dom.hudStatus.textContent = 'Focus mode';
+                }, 2500);
+            });
+
+            dom.trayUndo.addEventListener('click', () => {
+                dom.tray.classList.add('hidden');
+                dom.hudStatus.textContent = 'Action undone';
+                setTimeout(() => {
+                    dom.hudStatus.textContent = 'Focus mode';
+                }, 2000);
+            });
+
+            dom.modeButtons.forEach((button) => {
+                button.addEventListener('click', () => {
+                    dom.modeButtons.forEach((btn) => btn.classList.remove('active'));
+                    button.classList.add('active');
+                    dom.hudStatus.textContent = `${button.dataset.mode === 'focus' ? 'Focus' : 'Sort'} mode`;
+                });
+            });
+        })();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- integrate the baseline Google Drive OAuth popup, client secret handling, and token refresh flow into the alpha onboarding
- reuse the baseline OneDrive MSAL authentication and folder retrieval pipeline so the alpha stepper can sign in with Microsoft accounts
- render dynamic provider folders and status messaging inside the stepper before entering the review workspace

## Testing
- not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68de4eb11270832d9bc182c6cfefad3b