### PR TITLE
Fix favorite toggle normalization across HTML variants

### DIFF
--- a/index+holdj.html
+++ b/index+holdj.html
@@ -868,6 +868,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2193,7 +2218,7 @@
                 // 1. Pass: Modifiers
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -3103,8 +3128,10 @@
                 Utils.elements.focusFavoriteBtn.addEventListener('click', async () => {
                     const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                     if (!currentFile) return;
-                    const isFavorite = !currentFile.favorite;
-                    await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                    const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                    await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                     Core.updateFavoriteButton();
                 });
             },

--- a/index.html
+++ b/index.html
@@ -1071,6 +1071,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2499,7 +2524,7 @@
                 const flags = [];
                 const stack = file.stack || file.appProperties?.slideboxStack;
                 if (stack === 'trash') flags.push('trash');
-                if (file.favorite === true || file.appProperties?.favorite === 'true') flags.push('fav');
+                if (Utils.isFavorite(file)) flags.push('fav');
                 return flags.join(',');
             }
             hashString(value) {
@@ -3068,7 +3093,7 @@
                     qualityRating: payload.qualityRating ?? 0,
                     contentRating: payload.contentRating ?? 0,
                     stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
+                    favorite: Utils.normalizeFavorite(payload.favorite),
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
@@ -4789,7 +4814,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -5176,7 +5201,7 @@
                 const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -6498,8 +6523,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/performance-v1 (1).html
+++ b/performance-v1 (1).html
@@ -860,6 +860,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2309,7 +2334,7 @@
                 // 1. Pass: Modifiers
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -3288,8 +3313,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/performance-v1.html
+++ b/performance-v1.html
@@ -1002,6 +1002,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2399,7 +2424,7 @@
                 const flags = [];
                 const stack = file.stack || file.appProperties?.slideboxStack;
                 if (stack === 'trash') flags.push('trash');
-                if (file.favorite === true || file.appProperties?.favorite === 'true') flags.push('fav');
+                if (Utils.isFavorite(file)) flags.push('fav');
                 return flags.join(',');
             }
             hashString(value) {
@@ -2968,7 +2993,7 @@
                     qualityRating: payload.qualityRating ?? 0,
                     contentRating: payload.contentRating ?? 0,
                     stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
+                    favorite: Utils.normalizeFavorite(payload.favorite),
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
@@ -4674,7 +4699,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -5056,7 +5081,7 @@
                 const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -6378,8 +6403,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/performance-v2.html
+++ b/performance-v2.html
@@ -1028,6 +1028,31 @@
         }
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2627,7 +2652,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -2898,7 +2923,7 @@
                 // 1. Pass: Modifiers
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -4069,8 +4094,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/performance.html
+++ b/performance.html
@@ -1071,6 +1071,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2467,7 +2492,7 @@
                 const flags = [];
                 const stack = file.stack || file.appProperties?.slideboxStack;
                 if (stack === 'trash') flags.push('trash');
-                if (file.favorite === true || file.appProperties?.favorite === 'true') flags.push('fav');
+                if (Utils.isFavorite(file)) flags.push('fav');
                 return flags.join(',');
             }
             hashString(value) {
@@ -3036,7 +3061,7 @@
                     qualityRating: payload.qualityRating ?? 0,
                     contentRating: payload.contentRating ?? 0,
                     stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
+                    favorite: Utils.normalizeFavorite(payload.favorite),
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
@@ -4749,7 +4774,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -5136,7 +5161,7 @@
                 const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -6458,8 +6483,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/poc-hold.html
+++ b/poc-hold.html
@@ -955,6 +955,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -3571,7 +3596,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -3822,7 +3847,7 @@
                 // 1. Pass: Modifiers
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -4988,7 +5013,8 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
                         await App.updateUserMetadataImmediate(currentFile.id, { favorite: isFavorite });
                         Core.updateFavoriteButton();
                     } catch (error) {

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -1071,6 +1071,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2499,7 +2524,7 @@
                 const flags = [];
                 const stack = file.stack || file.appProperties?.slideboxStack;
                 if (stack === 'trash') flags.push('trash');
-                if (file.favorite === true || file.appProperties?.favorite === 'true') flags.push('fav');
+                if (Utils.isFavorite(file)) flags.push('fav');
                 return flags.join(',');
             }
             hashString(value) {
@@ -3068,7 +3093,7 @@
                     qualityRating: payload.qualityRating ?? 0,
                     contentRating: payload.contentRating ?? 0,
                     stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
+                    favorite: Utils.normalizeFavorite(payload.favorite),
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
@@ -4789,7 +4814,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -5176,7 +5201,7 @@
                 const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -6509,8 +6534,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -1002,6 +1002,30 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
             
             init() {
                 this.elements = {
@@ -2424,7 +2448,7 @@
                 const flags = [];
                 const stack = file.stack || file.appProperties?.slideboxStack;
                 if (stack === 'trash') flags.push('trash');
-                if (file.favorite === true || file.appProperties?.favorite === 'true') flags.push('fav');
+                if (Utils.isFavorite(file)) flags.push('fav');
                 return flags.join(',');
             }
             hashString(value) {
@@ -2993,7 +3017,7 @@
                     qualityRating: payload.qualityRating ?? 0,
                     contentRating: payload.contentRating ?? 0,
                     stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
+                    favorite: Utils.normalizeFavorite(payload.favorite),
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
@@ -4629,7 +4653,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -5011,7 +5035,7 @@
                 const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -6344,8 +6368,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -1002,6 +1002,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2424,7 +2449,7 @@
                 const flags = [];
                 const stack = file.stack || file.appProperties?.slideboxStack;
                 if (stack === 'trash') flags.push('trash');
-                if (file.favorite === true || file.appProperties?.favorite === 'true') flags.push('fav');
+                if (Utils.isFavorite(file)) flags.push('fav');
                 return flags.join(',');
             }
             hashString(value) {
@@ -2993,7 +3018,7 @@
                     qualityRating: payload.qualityRating ?? 0,
                     contentRating: payload.contentRating ?? 0,
                     stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
+                    favorite: Utils.normalizeFavorite(payload.favorite),
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
@@ -4629,7 +4654,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -5011,7 +5036,7 @@
                 const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -6414,8 +6439,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/ui-v2-old.html
+++ b/ui-v2-old.html
@@ -986,6 +986,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2761,7 +2786,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -3064,7 +3089,7 @@
                 // 1. Pass: Modifiers
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -4256,8 +4281,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -1071,6 +1071,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2499,7 +2524,7 @@
                 const flags = [];
                 const stack = file.stack || file.appProperties?.slideboxStack;
                 if (stack === 'trash') flags.push('trash');
-                if (file.favorite === true || file.appProperties?.favorite === 'true') flags.push('fav');
+                if (Utils.isFavorite(file)) flags.push('fav');
                 return flags.join(',');
             }
             hashString(value) {
@@ -3068,7 +3093,7 @@
                     qualityRating: payload.qualityRating ?? 0,
                     contentRating: payload.contentRating ?? 0,
                     stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
+                    favorite: Utils.normalizeFavorite(payload.favorite),
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
@@ -4789,7 +4814,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -5176,7 +5201,7 @@
                 const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -6509,8 +6534,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -1071,6 +1071,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2499,7 +2524,7 @@
                 const flags = [];
                 const stack = file.stack || file.appProperties?.slideboxStack;
                 if (stack === 'trash') flags.push('trash');
-                if (file.favorite === true || file.appProperties?.favorite === 'true') flags.push('fav');
+                if (Utils.isFavorite(file)) flags.push('fav');
                 return flags.join(',');
             }
             hashString(value) {
@@ -3068,7 +3093,7 @@
                     qualityRating: payload.qualityRating ?? 0,
                     contentRating: payload.contentRating ?? 0,
                     stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
+                    favorite: Utils.normalizeFavorite(payload.favorite),
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
@@ -4789,7 +4814,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -5176,7 +5201,7 @@
                 const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -6509,8 +6534,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -1071,6 +1071,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2499,7 +2524,7 @@
                 const flags = [];
                 const stack = file.stack || file.appProperties?.slideboxStack;
                 if (stack === 'trash') flags.push('trash');
-                if (file.favorite === true || file.appProperties?.favorite === 'true') flags.push('fav');
+                if (Utils.isFavorite(file)) flags.push('fav');
                 return flags.join(',');
             }
             hashString(value) {
@@ -3068,7 +3093,7 @@
                     qualityRating: payload.qualityRating ?? 0,
                     contentRating: payload.contentRating ?? 0,
                     stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
+                    favorite: Utils.normalizeFavorite(payload.favorite),
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
@@ -4789,7 +4814,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -5176,7 +5201,7 @@
                 const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -6509,8 +6534,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -1071,6 +1071,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2499,7 +2524,7 @@
                 const flags = [];
                 const stack = file.stack || file.appProperties?.slideboxStack;
                 if (stack === 'trash') flags.push('trash');
-                if (file.favorite === true || file.appProperties?.favorite === 'true') flags.push('fav');
+                if (Utils.isFavorite(file)) flags.push('fav');
                 return flags.join(',');
             }
             hashString(value) {
@@ -3068,7 +3093,7 @@
                     qualityRating: payload.qualityRating ?? 0,
                     contentRating: payload.contentRating ?? 0,
                     stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
+                    favorite: Utils.normalizeFavorite(payload.favorite),
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
@@ -4789,7 +4814,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -5176,7 +5201,7 @@
                 const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -6509,8 +6534,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -1071,6 +1071,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2499,7 +2524,7 @@
                 const flags = [];
                 const stack = file.stack || file.appProperties?.slideboxStack;
                 if (stack === 'trash') flags.push('trash');
-                if (file.favorite === true || file.appProperties?.favorite === 'true') flags.push('fav');
+                if (Utils.isFavorite(file)) flags.push('fav');
                 return flags.join(',');
             }
             hashString(value) {
@@ -3068,7 +3093,7 @@
                     qualityRating: payload.qualityRating ?? 0,
                     contentRating: payload.contentRating ?? 0,
                     stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
+                    favorite: Utils.normalizeFavorite(payload.favorite),
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
@@ -4789,7 +4814,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -5176,7 +5201,7 @@
                 const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -6509,8 +6534,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -1071,6 +1071,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2499,7 +2524,7 @@
                 const flags = [];
                 const stack = file.stack || file.appProperties?.slideboxStack;
                 if (stack === 'trash') flags.push('trash');
-                if (file.favorite === true || file.appProperties?.favorite === 'true') flags.push('fav');
+                if (Utils.isFavorite(file)) flags.push('fav');
                 return flags.join(',');
             }
             hashString(value) {
@@ -3068,7 +3093,7 @@
                     qualityRating: payload.qualityRating ?? 0,
                     contentRating: payload.contentRating ?? 0,
                     stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
+                    favorite: Utils.normalizeFavorite(payload.favorite),
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
@@ -4789,7 +4814,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -5176,7 +5201,7 @@
                 const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -6509,8 +6534,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -1071,6 +1071,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2499,7 +2524,7 @@
                 const flags = [];
                 const stack = file.stack || file.appProperties?.slideboxStack;
                 if (stack === 'trash') flags.push('trash');
-                if (file.favorite === true || file.appProperties?.favorite === 'true') flags.push('fav');
+                if (Utils.isFavorite(file)) flags.push('fav');
                 return flags.join(',');
             }
             hashString(value) {
@@ -3068,7 +3093,7 @@
                     qualityRating: payload.qualityRating ?? 0,
                     contentRating: payload.contentRating ?? 0,
                     stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
+                    favorite: Utils.normalizeFavorite(payload.favorite),
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
@@ -4789,7 +4814,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -5176,7 +5201,7 @@
                 const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -6509,8 +6534,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -1071,6 +1071,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2499,7 +2524,7 @@
                 const flags = [];
                 const stack = file.stack || file.appProperties?.slideboxStack;
                 if (stack === 'trash') flags.push('trash');
-                if (file.favorite === true || file.appProperties?.favorite === 'true') flags.push('fav');
+                if (Utils.isFavorite(file)) flags.push('fav');
                 return flags.join(',');
             }
             hashString(value) {
@@ -3068,7 +3093,7 @@
                     qualityRating: payload.qualityRating ?? 0,
                     contentRating: payload.contentRating ?? 0,
                     stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
+                    favorite: Utils.normalizeFavorite(payload.favorite),
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
@@ -4789,7 +4814,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -5176,7 +5201,7 @@
                 const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -6520,8 +6545,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -1071,6 +1071,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2499,7 +2524,7 @@
                 const flags = [];
                 const stack = file.stack || file.appProperties?.slideboxStack;
                 if (stack === 'trash') flags.push('trash');
-                if (file.favorite === true || file.appProperties?.favorite === 'true') flags.push('fav');
+                if (Utils.isFavorite(file)) flags.push('fav');
                 return flags.join(',');
             }
             hashString(value) {
@@ -3068,7 +3093,7 @@
                     qualityRating: payload.qualityRating ?? 0,
                     contentRating: payload.contentRating ?? 0,
                     stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
+                    favorite: Utils.normalizeFavorite(payload.favorite),
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
@@ -4789,7 +4814,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -5176,7 +5201,7 @@
                 const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -6520,8 +6545,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -1071,6 +1071,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2499,7 +2524,7 @@
                 const flags = [];
                 const stack = file.stack || file.appProperties?.slideboxStack;
                 if (stack === 'trash') flags.push('trash');
-                if (file.favorite === true || file.appProperties?.favorite === 'true') flags.push('fav');
+                if (Utils.isFavorite(file)) flags.push('fav');
                 return flags.join(',');
             }
             hashString(value) {
@@ -3068,7 +3093,7 @@
                     qualityRating: payload.qualityRating ?? 0,
                     contentRating: payload.contentRating ?? 0,
                     stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
+                    favorite: Utils.normalizeFavorite(payload.favorite),
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
@@ -4789,7 +4814,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -5176,7 +5201,7 @@
                 const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -6509,8 +6534,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -1071,6 +1071,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2499,7 +2524,7 @@
                 const flags = [];
                 const stack = file.stack || file.appProperties?.slideboxStack;
                 if (stack === 'trash') flags.push('trash');
-                if (file.favorite === true || file.appProperties?.favorite === 'true') flags.push('fav');
+                if (Utils.isFavorite(file)) flags.push('fav');
                 return flags.join(',');
             }
             hashString(value) {
@@ -3068,7 +3093,7 @@
                     qualityRating: payload.qualityRating ?? 0,
                     contentRating: payload.contentRating ?? 0,
                     stackSequence: payload.stackSequence ?? 0,
-                    favorite: Boolean(payload.favorite),
+                    favorite: Utils.normalizeFavorite(payload.favorite),
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
@@ -4789,7 +4814,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -5176,7 +5201,7 @@
                 const tagFilters = [];
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -6509,8 +6534,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);

--- a/ui.html
+++ b/ui.html
@@ -981,6 +981,31 @@
         };
         const Utils = {
             elements: {},
+
+            normalizeFavorite(value) {
+                if (value === true || value === false) {
+                    return value;
+                }
+                if (typeof value === 'string') {
+                    const normalized = value.trim().toLowerCase();
+                    if (normalized === 'true') return true;
+                    if (normalized === 'false') return false;
+                }
+                return Boolean(value);
+            },
+
+            isFavorite(input) {
+                if (input && typeof input === 'object') {
+                    if ('favorite' in input && input.favorite != null) {
+                        return this.normalizeFavorite(input.favorite);
+                    }
+                    if (input.appProperties && 'favorite' in input.appProperties) {
+                        return this.normalizeFavorite(input.appProperties.favorite);
+                    }
+                }
+                return this.normalizeFavorite(input);
+            },
+
             
             init() {
                 this.elements = {
@@ -2297,7 +2322,7 @@
                     }
                     return;
                 }
-                const isFavorite = Boolean(currentFile.favorite);
+                const isFavorite = Utils.isFavorite(currentFile);
                 if (Utils.elements.focusFavoriteBtn) {
                     Utils.elements.focusFavoriteBtn.classList.toggle('favorited', isFavorite);
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-pressed', isFavorite ? 'true' : 'false');
@@ -2725,7 +2750,7 @@
                 // 1. Pass: Modifiers
                 modifiers.forEach(mod => {
                     if (mod === '#favorite') {
-                        results = results.filter(file => file.favorite === true);
+                        results = results.filter(file => Utils.isFavorite(file));
                     } else if (mod.startsWith('#quality:')) {
                         const rating = parseInt(mod.split(':')[1]);
                         if (!isNaN(rating)) {
@@ -3989,8 +4014,10 @@
                     try {
                         const currentFile = state.stacks[state.currentStack]?.[state.currentStackPosition];
                         if (!currentFile) return;
-                        const isFavorite = !currentFile.favorite;
-                        await App.updateUserMetadata(currentFile.id, { favorite: isFavorite });
+                        const currentlyFavorite = Utils.isFavorite(currentFile);
+                        const nextFavorite = !currentlyFavorite;
+                        await App.updateUserMetadata(currentFile.id, { favorite: nextFavorite });
+                        currentFile.favorite = nextFavorite;
                         Core.updateFavoriteButton();
                     } catch (error) {
                          Utils.showToast(`Favorite failed: ${error.message}`, 'error', true);


### PR DESCRIPTION
## Summary
- add shared favorite normalization helpers to each UI HTML variant so string flags from metadata are interpreted consistently
- update the focus favorite button, metadata serialization, and #favorite search filtering to rely on the normalized value and persist local state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfb38d402c832d8fd70e44edec1705