### PR TITLE
Prefer Drive API download URLs over view URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -3382,7 +3382,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3488,7 +3488,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -3383,7 +3383,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3489,7 +3489,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };


### PR DESCRIPTION
## Summary
- use Google Drive API download links when present and fall back to UC URLs
- keep view URLs untouched while syncing UI HTML variants with the main index template

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfd3757088832da1063974ed94f61b