### PR TITLE
Ensure Drive download fallbacks cover all templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,13 @@ View your app in AI Studio: https://ai.studio/apps/drive/1Rlag5HDS4Wav5vrVq_GIS0
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Verifying Google Drive download URLs
+
+To confirm that every HTML template maps Google Drive downloads through API links (falling back to UC links when needed) instead of the shareable view URLs, run the following search from the repository root:
+
+```bash
+rg "downloadUrl: viewUrl"
+```
+
+The command should produce no matches. Any future regression where a template assigns a `downloadUrl` directly to the `viewUrl` will show up in this search so it can be corrected immediately.

--- a/index.html
+++ b/index.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/performance-v1.html
+++ b/performance-v1.html
@@ -3358,7 +3358,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3464,7 +3464,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/performance.html
+++ b/performance.html
@@ -3426,7 +3426,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3550,7 +3550,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -3382,7 +3382,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3488,7 +3488,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -3383,7 +3383,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3489,7 +3489,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -3458,7 +3458,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: viewUrl,
+                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3582,7 +3582,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: viewUrl,
+                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };


### PR DESCRIPTION
## Summary
- update remaining Drive HTML templates to prefer API download links with UC fallbacks
- document a repository-wide ripgrep check to ensure downloadUrl never reverts to viewUrl

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfd3757088832da1063974ed94f61b