### PR TITLE
Sync focus-mode exit with baseline stack reorder

### DIFF
--- a/index.html
+++ b/index.html
@@ -6144,6 +6144,23 @@
                 state.isFocusMode = !state.isFocusMode;
                 Utils.elements.appContainer.classList.toggle('focus-mode', state.isFocusMode);
                 this.updateGestureOverlayMode();
+
+                if (!state.isFocusMode) {
+                    const currentStackArray = state.stacks[state.currentStack];
+                    if (currentStackArray && currentStackArray.length > 0) {
+                        const currentFile = currentStackArray[state.currentStackPosition];
+                        if (currentFile) {
+                            const currentIndex = currentStackArray.findIndex(file => file.id === currentFile.id);
+                            if (currentIndex > 0) {
+                                const [item] = currentStackArray.splice(currentIndex, 1);
+                                currentStackArray.unshift(item);
+                            }
+                            state.currentStackPosition = 0;
+                        }
+                    }
+                    Core.displayCurrentImage();
+                }
+
                 Core.updateImageCounters();
                 this.lastHubTap = { time: 0, x: 0, y: 0 };
             },

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -5989,6 +5989,23 @@
                 state.isFocusMode = !state.isFocusMode;
                 Utils.elements.appContainer.classList.toggle('focus-mode', state.isFocusMode);
                 this.updateGestureOverlayMode();
+
+                if (!state.isFocusMode) {
+                    const currentStackArray = state.stacks[state.currentStack];
+                    if (currentStackArray && currentStackArray.length > 0) {
+                        const currentFile = currentStackArray[state.currentStackPosition];
+                        if (currentFile) {
+                            const currentIndex = currentStackArray.findIndex(file => file.id === currentFile.id);
+                            if (currentIndex > 0) {
+                                const [item] = currentStackArray.splice(currentIndex, 1);
+                                currentStackArray.unshift(item);
+                            }
+                            state.currentStackPosition = 0;
+                        }
+                    }
+                    Core.displayCurrentImage();
+                }
+
                 Core.updateImageCounters();
                 this.lastHubTap = { time: 0, x: 0, y: 0 };
             },

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -5990,6 +5990,23 @@
                 state.isFocusMode = !state.isFocusMode;
                 Utils.elements.appContainer.classList.toggle('focus-mode', state.isFocusMode);
                 this.updateGestureOverlayMode();
+
+                if (!state.isFocusMode) {
+                    const currentStackArray = state.stacks[state.currentStack];
+                    if (currentStackArray && currentStackArray.length > 0) {
+                        const currentFile = currentStackArray[state.currentStackPosition];
+                        if (currentFile) {
+                            const currentIndex = currentStackArray.findIndex(file => file.id === currentFile.id);
+                            if (currentIndex > 0) {
+                                const [item] = currentStackArray.splice(currentIndex, 1);
+                                currentStackArray.unshift(item);
+                            }
+                            state.currentStackPosition = 0;
+                        }
+                    }
+                    Core.displayCurrentImage();
+                }
+
                 Core.updateImageCounters();
                 this.lastHubTap = { time: 0, x: 0, y: 0 };
             },

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -6166,6 +6166,23 @@
                 state.isFocusMode = !state.isFocusMode;
                 Utils.elements.appContainer.classList.toggle('focus-mode', state.isFocusMode);
                 this.updateGestureOverlayMode();
+
+                if (!state.isFocusMode) {
+                    const currentStackArray = state.stacks[state.currentStack];
+                    if (currentStackArray && currentStackArray.length > 0) {
+                        const currentFile = currentStackArray[state.currentStackPosition];
+                        if (currentFile) {
+                            const currentIndex = currentStackArray.findIndex(file => file.id === currentFile.id);
+                            if (currentIndex > 0) {
+                                const [item] = currentStackArray.splice(currentIndex, 1);
+                                currentStackArray.unshift(item);
+                            }
+                            state.currentStackPosition = 0;
+                        }
+                    }
+                    Core.displayCurrentImage();
+                }
+
                 Core.updateImageCounters();
                 this.lastHubTap = { time: 0, x: 0, y: 0 };
             },

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -6166,6 +6166,23 @@
                 state.isFocusMode = !state.isFocusMode;
                 Utils.elements.appContainer.classList.toggle('focus-mode', state.isFocusMode);
                 this.updateGestureOverlayMode();
+
+                if (!state.isFocusMode) {
+                    const currentStackArray = state.stacks[state.currentStack];
+                    if (currentStackArray && currentStackArray.length > 0) {
+                        const currentFile = currentStackArray[state.currentStackPosition];
+                        if (currentFile) {
+                            const currentIndex = currentStackArray.findIndex(file => file.id === currentFile.id);
+                            if (currentIndex > 0) {
+                                const [item] = currentStackArray.splice(currentIndex, 1);
+                                currentStackArray.unshift(item);
+                            }
+                            state.currentStackPosition = 0;
+                        }
+                    }
+                    Core.displayCurrentImage();
+                }
+
                 Core.updateImageCounters();
                 this.lastHubTap = { time: 0, x: 0, y: 0 };
             },

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -6155,6 +6155,23 @@
                 state.isFocusMode = !state.isFocusMode;
                 Utils.elements.appContainer.classList.toggle('focus-mode', state.isFocusMode);
                 this.updateGestureOverlayMode();
+
+                if (!state.isFocusMode) {
+                    const currentStackArray = state.stacks[state.currentStack];
+                    if (currentStackArray && currentStackArray.length > 0) {
+                        const currentFile = currentStackArray[state.currentStackPosition];
+                        if (currentFile) {
+                            const currentIndex = currentStackArray.findIndex(file => file.id === currentFile.id);
+                            if (currentIndex > 0) {
+                                const [item] = currentStackArray.splice(currentIndex, 1);
+                                currentStackArray.unshift(item);
+                            }
+                            state.currentStackPosition = 0;
+                        }
+                    }
+                    Core.displayCurrentImage();
+                }
+
                 Core.updateImageCounters();
                 this.lastHubTap = { time: 0, x: 0, y: 0 };
             },

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -6155,6 +6155,23 @@
                 state.isFocusMode = !state.isFocusMode;
                 Utils.elements.appContainer.classList.toggle('focus-mode', state.isFocusMode);
                 this.updateGestureOverlayMode();
+
+                if (!state.isFocusMode) {
+                    const currentStackArray = state.stacks[state.currentStack];
+                    if (currentStackArray && currentStackArray.length > 0) {
+                        const currentFile = currentStackArray[state.currentStackPosition];
+                        if (currentFile) {
+                            const currentIndex = currentStackArray.findIndex(file => file.id === currentFile.id);
+                            if (currentIndex > 0) {
+                                const [item] = currentStackArray.splice(currentIndex, 1);
+                                currentStackArray.unshift(item);
+                            }
+                            state.currentStackPosition = 0;
+                        }
+                    }
+                    Core.displayCurrentImage();
+                }
+
                 Core.updateImageCounters();
                 this.lastHubTap = { time: 0, x: 0, y: 0 };
             },

--- a/ui.html
+++ b/ui.html
@@ -3677,6 +3677,23 @@
                 state.isFocusMode = !state.isFocusMode;
                 Utils.elements.appContainer.classList.toggle('focus-mode', state.isFocusMode);
                 this.updateGestureOverlayMode();
+
+                if (!state.isFocusMode) {
+                    const currentStackArray = state.stacks[state.currentStack];
+                    if (currentStackArray && currentStackArray.length > 0) {
+                        const currentFile = currentStackArray[state.currentStackPosition];
+                        if (currentFile) {
+                            const currentIndex = currentStackArray.findIndex(file => file.id === currentFile.id);
+                            if (currentIndex > 0) {
+                                const [item] = currentStackArray.splice(currentIndex, 1);
+                                currentStackArray.unshift(item);
+                            }
+                            state.currentStackPosition = 0;
+                        }
+                    }
+                    Core.displayCurrentImage();
+                }
+
                 Core.updateImageCounters();
                 this.lastHubTap = { time: 0, x: 0, y: 0 };
             },


### PR DESCRIPTION
## Summary
- align the modern UI shells’ `Gestures.toggleFocusMode` handlers with the baseline focus-mode toggle logic so exiting focus mode reorders the stack head and refreshes the main image

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e022df06b0832da78913a06c80eb63