### PR TITLE
Restore filename overlay across UI variants

### DIFF
--- a/index+holdj.html
+++ b/index+holdj.html
@@ -174,8 +174,36 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
-        .filename-overlay { display: none !important; }
+        #focus-image-count { display: none !important; }
 
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -456,10 +484,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -482,7 +506,8 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #normal-image-count,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -661,6 +686,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -672,7 +699,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -938,7 +964,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1957,9 +1983,15 @@
                 Utils.elements.detailsButton.style.display = 'flex';
                 await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                 
-                const folderName = state.currentFolder.name;
-                const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                Utils.elements.focusFilenameDisplay.textContent = `${truncatedFolder} / ${currentFile.name.replace(/\.[^/.]+$/, "")}`;
+                const folderName = state.currentFolder?.name || '';
+                const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                    const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                    Utils.elements.filenameOverlay.href = directUrl || '#';
+                    Utils.elements.filenameOverlay.classList.add('visible');
+                }
 
                 state.currentScale = 1;
                 state.panOffset = { x: 0, y: 0 };
@@ -2039,6 +2071,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';

--- a/index.html
+++ b/index.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -372,7 +400,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,7 +415,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -512,10 +540,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -541,13 +565,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -785,6 +809,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -796,7 +822,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1136,7 +1161,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -4759,9 +4784,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4970,6 +5002,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
@@ -5072,7 +5107,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/performance-v1 (1).html
+++ b/performance-v1 (1).html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -354,7 +382,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -369,7 +397,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -473,10 +501,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -499,7 +523,8 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #normal-image-count,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -653,6 +678,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -664,7 +691,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -925,7 +951,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -2057,9 +2083,15 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    Utils.elements.focusFilenameDisplay.textContent = `${truncatedFolder} / ${currentFile.name.replace(/\.[^/.]+$/, "")}`;
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
@@ -2146,6 +2178,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -2240,7 +2275,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/performance-v1.html
+++ b/performance-v1.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -372,7 +400,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,7 +415,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -512,10 +540,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -541,13 +565,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -785,6 +809,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -796,7 +822,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1067,7 +1092,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -4652,9 +4677,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4855,6 +4887,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -4952,7 +4987,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/performance-v2.html
+++ b/performance-v2.html
@@ -179,6 +179,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -359,7 +387,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -374,7 +402,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -478,10 +506,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -507,13 +531,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -751,6 +775,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -762,7 +788,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1093,7 +1118,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -2605,9 +2630,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -2715,6 +2747,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -2824,7 +2859,7 @@
                         this.toggleSelection(e, file.id);
                     });
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/performance.html
+++ b/performance.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -372,7 +400,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,7 +415,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -512,10 +540,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -541,13 +565,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -785,6 +809,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -796,7 +822,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1136,7 +1161,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -4727,9 +4752,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4930,6 +4962,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
@@ -5032,7 +5067,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/poc-hold.html
+++ b/poc-hold.html
@@ -175,6 +175,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -355,7 +383,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -370,7 +398,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -474,10 +502,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -503,13 +527,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -747,6 +771,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -758,7 +784,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1020,7 +1045,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -3549,9 +3574,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -3659,6 +3691,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -3753,7 +3788,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -372,7 +400,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,7 +415,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -512,10 +540,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -541,13 +565,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -785,6 +809,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -796,7 +822,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1136,7 +1161,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -4759,9 +4784,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4970,6 +5002,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
@@ -5072,7 +5107,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -372,7 +400,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,7 +415,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -512,10 +540,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -541,13 +565,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -785,6 +809,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -796,7 +822,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1066,7 +1091,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -4598,9 +4623,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4809,6 +4841,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -4906,7 +4941,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -372,7 +400,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,7 +415,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -512,10 +540,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -541,13 +565,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -785,6 +809,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -796,7 +822,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1067,7 +1092,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -4599,9 +4624,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4810,6 +4842,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -4907,7 +4942,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/ui-v2-old.html
+++ b/ui-v2-old.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -382,7 +410,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -397,7 +425,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -498,10 +526,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -527,13 +551,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -771,6 +795,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -782,7 +808,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1051,7 +1076,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -2731,9 +2756,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -2849,6 +2881,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -2946,7 +2981,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -372,7 +400,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,7 +415,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -512,10 +540,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -541,13 +565,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -785,6 +809,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -796,7 +822,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1136,7 +1161,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -4759,9 +4784,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4970,6 +5002,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
@@ -5072,7 +5107,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -372,7 +400,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,7 +415,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -512,10 +540,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -541,13 +565,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -785,6 +809,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -796,7 +822,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1136,7 +1161,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -4759,9 +4784,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4970,6 +5002,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
@@ -5072,7 +5107,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -372,7 +400,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,7 +415,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -512,10 +540,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -541,13 +565,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -785,6 +809,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -796,7 +822,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1136,7 +1161,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -4759,9 +4784,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4970,6 +5002,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
@@ -5072,7 +5107,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -372,7 +400,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,7 +415,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -512,10 +540,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -541,13 +565,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -785,6 +809,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -796,7 +822,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1136,7 +1161,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -4759,9 +4784,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4970,6 +5002,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
@@ -5072,7 +5107,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -372,7 +400,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,7 +415,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -512,10 +540,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -541,13 +565,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -785,6 +809,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -796,7 +822,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1136,7 +1161,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -4759,9 +4784,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4970,6 +5002,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
@@ -5072,7 +5107,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -372,7 +400,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,7 +415,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -512,10 +540,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -541,13 +565,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -785,6 +809,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -796,7 +822,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1136,7 +1161,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -4759,9 +4784,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4970,6 +5002,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
@@ -5072,7 +5107,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -372,7 +400,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,7 +415,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -512,10 +540,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -541,13 +565,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -785,6 +809,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -796,7 +822,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1136,7 +1161,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -4759,9 +4784,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4970,6 +5002,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
@@ -5072,7 +5107,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -372,7 +400,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,7 +415,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -512,10 +540,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -541,13 +565,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -785,6 +809,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -796,7 +822,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1136,7 +1161,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -4759,9 +4784,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4970,6 +5002,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
@@ -5072,7 +5107,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -372,7 +400,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,7 +415,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -512,10 +540,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -541,13 +565,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -785,6 +809,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -796,7 +822,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1136,7 +1161,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -4759,9 +4784,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4970,6 +5002,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
@@ -5072,7 +5107,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -372,7 +400,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,7 +415,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -512,10 +540,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -541,13 +565,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -785,6 +809,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -796,7 +822,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1136,7 +1161,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -4759,9 +4784,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4970,6 +5002,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
@@ -5072,7 +5107,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -372,7 +400,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,7 +415,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -512,10 +540,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -541,13 +565,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -785,6 +809,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -796,7 +822,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1136,7 +1161,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -4759,9 +4784,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4970,6 +5002,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
@@ -5072,7 +5107,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);

--- a/ui.html
+++ b/ui.html
@@ -174,6 +174,34 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
+
+        .filename-overlay {
+            position: absolute;
+            bottom: 25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            padding: 6px 14px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            z-index: 5;
+            max-width: 90%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: auto;
+            text-decoration: none;
+        }
+        .filename-overlay:hover {
+            background-color: rgba(0, 0, 0, 0.8);
+            color: var(--app-accent);
+        }
+        .filename-overlay.visible { opacity: 1; }
+
         
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -371,7 +399,7 @@
         }
         .grid-drag-ghost .grid-drag-handle { display: none; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -386,7 +414,7 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
         
@@ -490,10 +518,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -519,13 +543,13 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
+        .app-container.focus-mode .filename-overlay { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
         
@@ -763,6 +787,8 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
+        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
+
         
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
@@ -774,7 +800,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -1046,7 +1071,7 @@
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -2267,9 +2292,16 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+                    const folderName = state.currentFolder?.name || '';
+                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
+                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
+                    if (Utils.elements.filenameOverlay) {
+                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
+                        Utils.elements.filenameOverlay.href = directUrl || '#';
+                        Utils.elements.filenameOverlay.classList.add('visible');
+                    }
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -2385,6 +2417,9 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
+                if (Utils.elements.filenameOverlay) {
+                    Utils.elements.filenameOverlay.classList.remove('visible');
+                }
                 this.updateImageCounters();
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -2483,7 +2518,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);


### PR DESCRIPTION
## Summary
- restore the baseline filename overlay styling and anchor across every UI variant
- update the image display logic to populate the overlay text, deep link, and visibility, and hide it again when stacks are empty
- rename the grid filename overlay helper class so it no longer conflicts with the restored overlay element

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e03149cf54832dbcb1d3222024f134