### PR TITLE
Normalize tag casing across UI variants

### DIFF
--- a/index.html
+++ b/index.html
@@ -1371,7 +1371,14 @@
             normalizeTagValue(tag) {
                 const trimmed = (tag || '').trim();
                 if (!trimmed) return '';
-                return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                let normalized = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                const firstCharIndex = normalized.search(/[^#]/);
+                if (firstCharIndex >= 0) {
+                    normalized = normalized.slice(0, firstCharIndex) +
+                        normalized[firstCharIndex].toLowerCase() +
+                        normalized.slice(firstCharIndex + 1);
+                }
+                return normalized;
             },
             normalizeTagList(tags = []) {
                 const normalized = [];

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -1371,7 +1371,14 @@
             normalizeTagValue(tag) {
                 const trimmed = (tag || '').trim();
                 if (!trimmed) return '';
-                return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                let normalized = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                const firstCharIndex = normalized.search(/[^#]/);
+                if (firstCharIndex >= 0) {
+                    normalized = normalized.slice(0, firstCharIndex) +
+                        normalized[firstCharIndex].toLowerCase() +
+                        normalized.slice(firstCharIndex + 1);
+                }
+                return normalized;
             },
             normalizeTagList(tags = []) {
                 const normalized = [];

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -1302,7 +1302,14 @@
             normalizeTagValue(tag) {
                 const trimmed = (tag || '').trim();
                 if (!trimmed) return '';
-                return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                let normalized = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                const firstCharIndex = normalized.search(/[^#]/);
+                if (firstCharIndex >= 0) {
+                    normalized = normalized.slice(0, firstCharIndex) +
+                        normalized[firstCharIndex].toLowerCase() +
+                        normalized.slice(firstCharIndex + 1);
+                }
+                return normalized;
             },
             normalizeTagList(tags = []) {
                 const normalized = [];

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -1303,7 +1303,14 @@
             normalizeTagValue(tag) {
                 const trimmed = (tag || '').trim();
                 if (!trimmed) return '';
-                return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                let normalized = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                const firstCharIndex = normalized.search(/[^#]/);
+                if (firstCharIndex >= 0) {
+                    normalized = normalized.slice(0, firstCharIndex) +
+                        normalized[firstCharIndex].toLowerCase() +
+                        normalized.slice(firstCharIndex + 1);
+                }
+                return normalized;
             },
             normalizeTagList(tags = []) {
                 const normalized = [];

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -1371,7 +1371,14 @@
             normalizeTagValue(tag) {
                 const trimmed = (tag || '').trim();
                 if (!trimmed) return '';
-                return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                let normalized = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                const firstCharIndex = normalized.search(/[^#]/);
+                if (firstCharIndex >= 0) {
+                    normalized = normalized.slice(0, firstCharIndex) +
+                        normalized[firstCharIndex].toLowerCase() +
+                        normalized.slice(firstCharIndex + 1);
+                }
+                return normalized;
             },
             normalizeTagList(tags = []) {
                 const normalized = [];

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -1371,7 +1371,14 @@
             normalizeTagValue(tag) {
                 const trimmed = (tag || '').trim();
                 if (!trimmed) return '';
-                return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                let normalized = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                const firstCharIndex = normalized.search(/[^#]/);
+                if (firstCharIndex >= 0) {
+                    normalized = normalized.slice(0, firstCharIndex) +
+                        normalized[firstCharIndex].toLowerCase() +
+                        normalized.slice(firstCharIndex + 1);
+                }
+                return normalized;
             },
             normalizeTagList(tags = []) {
                 const normalized = [];

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -1371,7 +1371,14 @@
             normalizeTagValue(tag) {
                 const trimmed = (tag || '').trim();
                 if (!trimmed) return '';
-                return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                let normalized = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                const firstCharIndex = normalized.search(/[^#]/);
+                if (firstCharIndex >= 0) {
+                    normalized = normalized.slice(0, firstCharIndex) +
+                        normalized[firstCharIndex].toLowerCase() +
+                        normalized.slice(firstCharIndex + 1);
+                }
+                return normalized;
             },
             normalizeTagList(tags = []) {
                 const normalized = [];

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -1371,7 +1371,14 @@
             normalizeTagValue(tag) {
                 const trimmed = (tag || '').trim();
                 if (!trimmed) return '';
-                return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                let normalized = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                const firstCharIndex = normalized.search(/[^#]/);
+                if (firstCharIndex >= 0) {
+                    normalized = normalized.slice(0, firstCharIndex) +
+                        normalized[firstCharIndex].toLowerCase() +
+                        normalized.slice(firstCharIndex + 1);
+                }
+                return normalized;
             },
             normalizeTagList(tags = []) {
                 const normalized = [];

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -1371,7 +1371,14 @@
             normalizeTagValue(tag) {
                 const trimmed = (tag || '').trim();
                 if (!trimmed) return '';
-                return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                let normalized = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                const firstCharIndex = normalized.search(/[^#]/);
+                if (firstCharIndex >= 0) {
+                    normalized = normalized.slice(0, firstCharIndex) +
+                        normalized[firstCharIndex].toLowerCase() +
+                        normalized.slice(firstCharIndex + 1);
+                }
+                return normalized;
             },
             normalizeTagList(tags = []) {
                 const normalized = [];

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -1371,7 +1371,14 @@
             normalizeTagValue(tag) {
                 const trimmed = (tag || '').trim();
                 if (!trimmed) return '';
-                return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                let normalized = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                const firstCharIndex = normalized.search(/[^#]/);
+                if (firstCharIndex >= 0) {
+                    normalized = normalized.slice(0, firstCharIndex) +
+                        normalized[firstCharIndex].toLowerCase() +
+                        normalized.slice(firstCharIndex + 1);
+                }
+                return normalized;
             },
             normalizeTagList(tags = []) {
                 const normalized = [];

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -1371,7 +1371,14 @@
             normalizeTagValue(tag) {
                 const trimmed = (tag || '').trim();
                 if (!trimmed) return '';
-                return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                let normalized = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                const firstCharIndex = normalized.search(/[^#]/);
+                if (firstCharIndex >= 0) {
+                    normalized = normalized.slice(0, firstCharIndex) +
+                        normalized[firstCharIndex].toLowerCase() +
+                        normalized.slice(firstCharIndex + 1);
+                }
+                return normalized;
             },
             normalizeTagList(tags = []) {
                 const normalized = [];

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -1371,7 +1371,14 @@
             normalizeTagValue(tag) {
                 const trimmed = (tag || '').trim();
                 if (!trimmed) return '';
-                return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                let normalized = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                const firstCharIndex = normalized.search(/[^#]/);
+                if (firstCharIndex >= 0) {
+                    normalized = normalized.slice(0, firstCharIndex) +
+                        normalized[firstCharIndex].toLowerCase() +
+                        normalized.slice(firstCharIndex + 1);
+                }
+                return normalized;
             },
             normalizeTagList(tags = []) {
                 const normalized = [];

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -1371,7 +1371,14 @@
             normalizeTagValue(tag) {
                 const trimmed = (tag || '').trim();
                 if (!trimmed) return '';
-                return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                let normalized = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                const firstCharIndex = normalized.search(/[^#]/);
+                if (firstCharIndex >= 0) {
+                    normalized = normalized.slice(0, firstCharIndex) +
+                        normalized[firstCharIndex].toLowerCase() +
+                        normalized.slice(firstCharIndex + 1);
+                }
+                return normalized;
             },
             normalizeTagList(tags = []) {
                 const normalized = [];

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -1371,7 +1371,14 @@
             normalizeTagValue(tag) {
                 const trimmed = (tag || '').trim();
                 if (!trimmed) return '';
-                return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                let normalized = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                const firstCharIndex = normalized.search(/[^#]/);
+                if (firstCharIndex >= 0) {
+                    normalized = normalized.slice(0, firstCharIndex) +
+                        normalized[firstCharIndex].toLowerCase() +
+                        normalized.slice(firstCharIndex + 1);
+                }
+                return normalized;
             },
             normalizeTagList(tags = []) {
                 const normalized = [];

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -1371,7 +1371,14 @@
             normalizeTagValue(tag) {
                 const trimmed = (tag || '').trim();
                 if (!trimmed) return '';
-                return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                let normalized = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+                const firstCharIndex = normalized.search(/[^#]/);
+                if (firstCharIndex >= 0) {
+                    normalized = normalized.slice(0, firstCharIndex) +
+                        normalized[firstCharIndex].toLowerCase() +
+                        normalized.slice(firstCharIndex + 1);
+                }
+                return normalized;
             },
             normalizeTagList(tags = []) {
                 const normalized = [];


### PR DESCRIPTION
## Summary
- ensure TagService.normalizeTagValue prepends `#` and lowercases the first non-`#` character in index.html and all ui* variants

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e04562c26c832d9ea68ff1b26be4e6