### PR TITLE
Retire filename overlay and toaster from UI variants

### DIFF
--- a/index+holdj.html
+++ b/index+holdj.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,8 +164,6 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
-        .filename-overlay { display: none !important; }
 
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
@@ -187,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -201,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -212,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -235,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -248,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -261,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -284,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -299,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -315,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; }
         .search-helper-icon { color: #9ca3af; cursor: pointer; display: flex; align-items: center; }
@@ -333,16 +321,15 @@
         }
         .search-helper-popup a:hover { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -355,7 +342,7 @@
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -375,7 +362,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; min-height: 40px; }
         .tag-item { display: inline-flex; align-items: center; background: #dbeafe; color: #1e40af; padding: 4px 8px; border-radius: 12px; font-size: 12px; gap: 6px; }
         .tag-remove {
@@ -388,7 +375,7 @@
             font-size: 12px; color: #6b7280; cursor: pointer; transition: all 0.2s;
         }
         .add-tag-btn:hover { background: #e5e7eb; color: #374151; }
-        
+
         /* NEW: Action Modal Tag Chips */
         #tag-chip-container { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
         .tag-chip {
@@ -402,11 +389,10 @@
         }
         .tag-chip-remove:hover { background: rgba(99, 102, 241, 0.1); }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -421,12 +407,16 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -456,10 +446,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -477,17 +463,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-        
+
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #normal-image-count,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -513,7 +499,7 @@
         #focus-tap-left { left: 0; width: 40%; }
         #focus-tap-center { left: 40%; width: 20%; }
         #focus-tap-right { right: 0; width: 40%; }
-        
+
         .app-container.focus-mode .focus-tap-zone {
             display: block;
         }
@@ -554,7 +540,7 @@
         </div>
         <div class="app-footer">Orbital8-J-2025-09-16 03:29 AM</div>
     </div>
-    
+
     <!-- Google Drive Auth Screen -->
     <div class="screen hidden" id="gdrive-auth-screen">
         <div class="card">
@@ -567,7 +553,7 @@
         </div>
         <div class="app-footer">Orbital8-J-2025-09-16 03:29 AM</div>
     </div>
-    
+
     <!-- OneDrive Auth Screen -->
     <div class="screen hidden" id="onedrive-auth-screen">
         <div class="card">
@@ -579,7 +565,7 @@
         </div>
         <div class="app-footer">Orbital8-J-2025-09-16 03:29 AM</div>
     </div>
-    
+
     <!-- Google Drive Folder Screen -->
     <div class="screen hidden" id="gdrive-folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -594,7 +580,7 @@
         </div>
         <div class="app-footer">Orbital8-J-2025-09-16 03:29 AM</div>
     </div>
-    
+
     <!-- OneDrive Folder Screen -->
     <div class="screen hidden" id="onedrive-folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -609,7 +595,7 @@
         </div>
         <div class="app-footer">Orbital8-J-2025-09-16 03:29 AM</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -623,7 +609,7 @@
         </div>
         <div class="app-footer">Orbital8-J-2025-09-16 03:29 AM</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -631,7 +617,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -645,23 +631,23 @@
         <div id="focus-tap-left" class="focus-tap-zone"></div>
         <div id="focus-tap-center" class="focus-tap-zone"></div>
         <div id="focus-tap-right" class="focus-tap-zone"></div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -672,7 +658,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -682,11 +667,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">Orbital8-J-2025-09-16 03:29 AM</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -702,7 +685,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -717,7 +700,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper">
@@ -735,7 +718,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -754,7 +737,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -766,7 +749,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -778,14 +761,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -805,19 +788,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating">
@@ -828,7 +811,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating">
@@ -840,7 +823,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -850,7 +833,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root & Web Worker =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -893,7 +876,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -903,11 +885,11 @@
                     onedriveFolderScreen: document.getElementById('onedrive-folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     gdriveClientSecret: document.getElementById('gdrive-client-secret'),
                     gdriveAuthButton: document.getElementById('gdrive-auth-button'),
                     gdriveBackButton: document.getElementById('gdrive-back-button'),
@@ -916,7 +898,7 @@
                     gdriveRefreshFolders: document.getElementById('gdrive-refresh-folders'),
                     gdriveBackToProvider: document.getElementById('gdrive-back-to-provider'),
                     gdriveLogout: document.getElementById('gdrive-logout'),
-                    
+
                     onedriveAuthButton: document.getElementById('onedrive-auth-button'),
                     onedriveBackButton: document.getElementById('onedrive-back-button'),
                     onedriveAuthStatus: document.getElementById('onedrive-auth-status'),
@@ -925,7 +907,7 @@
                     onedriveRefreshFolders: document.getElementById('onedrive-refresh-folders'),
                     onedriveBackToProvider: document.getElementById('onedrive-back-to-provider'),
                     onedriveLogout: document.getElementById('onedrive-logout'),
-                    
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -934,11 +916,11 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -949,17 +931,17 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
                     edgeRight: document.getElementById('edge-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -971,22 +953,22 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1002,7 +984,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'gdrive-auth-screen', 'onedrive-auth-screen', 
                                'gdrive-folder-screen', 'onedrive-folder-screen', 'loading-screen', 'app-container'];
@@ -1010,22 +992,47 @@
                     document.getElementById(id).classList.toggle('hidden', id !== screenId);
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1038,7 +1045,7 @@
                     img.onerror = () => {
                         if (state.currentImageLoadId !== loadId) return;
                         let fallbackUrl = this.getFallbackImageUrl(file);
-                        
+
                         img.onerror = () => {
                             if (state.currentImageLoadId !== loadId) return;
                             img.src = 'data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'150\' height=\'150\' viewBox=\'0 0 150 150\' fill=\'none\'%3E%3Crect width=\'150\' height=\'150\' fill=\'%23E5E7EB\'/%3E%3Cpath d=\'M65 60H85V90H65V60Z\' fill=\'%239CA3AF\'/%3E%3Ccircle cx=\'75\' cy=\'45\' r=\'10\' fill=\'%239CA3AF\'/%3E%3C/svg%3E';
@@ -1050,7 +1057,7 @@
                     img.alt = file.name || 'Image';
                 });
             },
-            
+
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
                     if (file.thumbnailLink) {
@@ -1072,7 +1079,7 @@
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -1080,7 +1087,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -1262,7 +1269,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -1628,7 +1635,7 @@
                     Utils.elements.onedriveAuthStatus.textContent = 'Click to sign in with your Microsoft account';
                 }
             },
-            
+
             backToProviderSelection() {
                 if(state.syncManager) state.syncManager.stop();
                 state.provider = null;
@@ -1642,7 +1649,7 @@
                 state.currentFolder.id = folderId;
                 state.currentFolder.name = folderName;
                 state.activeRequests = new AbortController();
-                
+
                 await this.loadImages();
                 this.switchToCommonUI();
                 if(state.syncManager) state.syncManager.start();
@@ -1663,24 +1670,24 @@
 
                 Utils.showScreen('loading-screen');
                 Utils.updateLoadingProgress(0, 0, 'Fetching from cloud...');
-                
+
                 try {
                     const result = await state.provider.getFilesAndMetadata(state.currentFolder.id);
                     const files = result.files || [];
-                    
+
                     if (files.length === 0) {
                         Utils.showToast('No images found in this folder', 'info', true);
                         this.returnToFolderSelection();
                         return;
                     }
-                    
+
                     state.imageFiles = files;
                     await this.processAllMetadata(state.imageFiles, true);
                     await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
-                    
+
                     Core.initializeStacks();
                     Core.initializeImageDisplay();
-                    
+
                 } catch (error) {
                     if (error.name !== 'AbortError') {
                         Utils.showToast(`Error loading images: ${error.message}`, 'error', true);
@@ -1694,11 +1701,11 @@
                     const result = await state.provider.getFilesAndMetadata(state.currentFolder.id);
                     const cloudFiles = result.files || [];
                     const localFiles = await state.dbManager.getFolderCache(state.currentFolder.id) || [];
-            
+
                     const cloudFileMap = new Map(cloudFiles.map(f => [f.id, f]));
                     const localFileMap = new Map(localFiles.map(f => [f.id, f]));
                     let hasChanges = false;
-            
+
                     for (const cloudFile of cloudFiles) {
                         const localFile = localFileMap.get(cloudFile.id);
                         if (!localFile || new Date(cloudFile.modifiedTime) > new Date(localFile.modifiedTime)) {
@@ -1706,14 +1713,14 @@
                             localFileMap.set(cloudFile.id, cloudFile);
                         }
                     }
-            
+
                     for (const localId of localFileMap.keys()) {
                         if (!cloudFileMap.has(localId)) {
                             hasChanges = true;
                             localFileMap.delete(localId);
                         }
                     }
-            
+
                     if (hasChanges) {
                         const newMergedFiles = Array.from(localFileMap.values());
                         await this.processAllMetadata(newMergedFiles);
@@ -1729,7 +1736,7 @@
                     console.warn("Background refresh failed:", error.message);
                 }
             },
-            
+
             async processAllMetadata(files, isFirstLoad = false) {
                  if (isFirstLoad) Utils.updateLoadingProgress(0, files.length, 'Processing files...');
                  for (let i = 0; i < files.length; i++) {
@@ -1771,11 +1778,11 @@
                  }
                  return baseMetadata;
             },
-            
+
             switchToCommonUI() {
                 Utils.showScreen('app-container');
             },
-            
+
             returnToFolderSelection() {
                 if (state.syncManager) {
                     state.syncManager.requestSync();
@@ -1797,7 +1804,7 @@
                 Core.showEmptyState();
                 Utils.elements.emptyState.classList.add('hidden');
             },
-            
+
             async updateUserMetadata(fileId, updates) {
                 const file = state.imageFiles.find(f => f.id === fileId);
                 if (!file) return;
@@ -1805,7 +1812,7 @@
                 await state.dbManager.saveMetadata(file.id, file);
                 await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
             },
-            
+
             async deleteFile(fileId) {
                 const fileIndex = state.imageFiles.findIndex(f => f.id === fileId);
                 if (fileIndex > -1) {
@@ -1813,16 +1820,16 @@
                     const stackIndex = state.stacks[file.stack].findIndex(f => f.id === fileId);
                     if (stackIndex > -1) { state.stacks[file.stack].splice(stackIndex, 1); }
                 }
-                
+
                 await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
-                
+
                 try {
                     await state.provider.deleteFile(fileId);
                 } catch (e) {
                     Utils.showToast(`Failed to delete from cloud: ${e.message}`, 'error', true);
                 }
             },
-            
+
             async extractMetadataInBackground(pngFiles) {
                 const BATCH_SIZE = 5;
                 for (let i = 0; i < pngFiles.length; i += BATCH_SIZE) {
@@ -1837,14 +1844,14 @@
                     await Promise.allSettled(promises);
                 }
             },
-            
+
             async processFileMetadata(file) {
                 if (file.metadataStatus === 'loaded' || file.metadataStatus === 'loading' || file.metadataStatus === 'error') return;
                 file.metadataStatus = 'loading';
                 try {
                     const metadata = await state.metadataExtractor.fetchMetadata(file);
                     let finalMetadata = { ...file };
-                    
+
                     if (metadata.error) {
                         finalMetadata.metadataStatus = 'error';
                         finalMetadata.extractedMetadata = { 'Error': metadata.error };
@@ -1853,7 +1860,7 @@
                         finalMetadata.metadataStatus = 'loaded';
                         finalMetadata.extractedMetadata = metadata;
                     }
-                    
+
                     await state.dbManager.saveMetadata(file.id, finalMetadata);
                     Object.assign(file, finalMetadata);
 
@@ -1883,7 +1890,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -1894,7 +1901,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -1905,7 +1912,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -1913,34 +1920,34 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 const stack = state.stacks[stackName];
                 if (!stack || stack.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 Utils.elements.emptyState.classList.add('hidden');
                 state.currentStack = stackName;
                 state.currentStackPosition = 0;
-                
+
                 await this.displayCurrentImage();
                 this.updateActiveProxTab();
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -1956,10 +1963,6 @@
 
                 Utils.elements.detailsButton.style.display = 'flex';
                 await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                
-                const folderName = state.currentFolder.name;
-                const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                Utils.elements.focusFilenameDisplay.textContent = `${truncatedFolder} / ${currentFile.name.replace(/\.[^/.]+$/, "")}`;
 
                 state.currentScale = 1;
                 state.panOffset = { x: 0, y: 0 };
@@ -1968,7 +1971,7 @@
                 if (currentFile.metadataStatus === 'pending') {
                     App.processFileMetadata(currentFile);
                 }
-                
+
                 this.updateImageCounters();
                 this.updateFavoriteButton();
             },
@@ -1988,26 +1991,26 @@
                 if (!currentFile) return;
                 Utils.elements.focusFavoriteBtn.classList.toggle('favorited', !!currentFile.favorite);
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack) {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                
+
                 const currentImage = currentStackArray[state.currentStackPosition];
                 if (!currentImage) return;
 
@@ -2029,12 +2032,12 @@
                     state.stacks[targetStack].unshift(item);
                     state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                 }
-                
+
                 this.updateStackCounts();
                 this.updateActiveProxTab();
                 await this.displayCurrentImage();
             },
-            
+
             showEmptyState() {
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
@@ -2063,7 +2066,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 if (state.grid.isDirty) {
                     await this.reorderStackOnClose();
@@ -2140,7 +2143,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -2149,7 +2152,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.moveSelected, Utils.elements.deleteSelected, 
@@ -2157,7 +2160,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -2167,20 +2170,20 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
                 state.grid.selected = [];
                 if (!query) { this.resetSearch(); return; }
                 state.grid.filtered = this.searchImages(query);
-                
+
                 Utils.elements.gridContainer.innerHTML = '';
                 if (state.grid.filtered.length === 0) {
                     Utils.elements.gridEmptyState.classList.remove('hidden');
@@ -2204,7 +2207,7 @@
                 Core.updateStackCounts();
                 this.deselectAll();
             },
-            
+
             searchImages(query) {
                 const lowerCaseQuery = query.toLowerCase();
                 const terms = lowerCaseQuery.split(/\s+/).filter(t => t);
@@ -2276,10 +2279,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -2535,7 +2538,7 @@
             addTagChip(tag) {
                 if (this.taggingState.tags.has(tag)) return;
                 this.taggingState.tags.add(tag);
-                
+
                 const container = document.getElementById('tag-chip-container');
                 const chip = document.createElement('div');
                 chip.className = 'tag-chip';
@@ -2617,7 +2620,7 @@
             async executeTag() {
                 const tagsToAdd = Array.from(this.taggingState.tags);
                 if (tagsToAdd.length === 0) return;
-                
+
                 await this.executeBulkAction(async (fileId) => {
                     const file = state.imageFiles.find(f => f.id === fileId);
                     if (file) {
@@ -2731,7 +2734,7 @@
                 const currentTime = Date.now();
                 if (currentTime - this.lastTapTime < 300) { e.preventDefault(); this.toggleFocusMode(); this.lastTapTime = 0; return; }
                 this.lastTapTime = currentTime;
-                
+
                 if (state.stacks[state.currentStack].length === 0) return;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
@@ -2769,11 +2772,11 @@
                 if (!state.isDragging) return;
                 state.isDragging = false; Utils.elements.centerImage.classList.remove('dragging');
                 if (!this.gestureStarted) { this.hideAllEdgeGlows(); return; }
-                
+
                 const deltaX = this.currentPos.x - this.startPos.x;
                 const deltaY = this.currentPos.y - this.startPos.y;
                 const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
-                
+
                 if (distance > 80) {
                     if(state.isFocusMode){
                          if (deltaX < 0) { this.nextImage(); } 
@@ -2975,7 +2978,7 @@
             init(modal, header) {
                 let pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
                 let isDragging = false;
-                
+
                 header.onmousedown = dragMouseDown;
 
                 function dragMouseDown(e) {
@@ -2996,7 +2999,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 

--- a/index.html
+++ b/index.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -349,16 +339,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -372,7 +361,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,10 +376,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -410,7 +399,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tag-section { display: flex; flex-direction: column; gap: 6px; }
@@ -439,11 +428,10 @@
         .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -458,7 +446,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
@@ -483,6 +471,10 @@
         }
         .app-footer .footer-link:focus-visible {
             outline: none;
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -512,10 +504,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -540,19 +528,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -696,7 +682,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -711,7 +697,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -740,7 +726,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -748,7 +734,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -769,23 +755,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -796,7 +782,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -806,11 +791,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -826,7 +809,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -841,7 +824,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -864,7 +847,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -884,7 +867,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -896,7 +879,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -908,14 +891,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -935,19 +918,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -958,7 +941,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -970,7 +953,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -980,7 +963,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1096,7 +1079,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1104,11 +1086,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1123,7 +1105,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1132,11 +1115,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1147,7 +1129,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1162,12 +1144,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1179,27 +1161,27 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1215,7 +1197,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1225,22 +1207,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1325,7 +1332,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3290,7 +3297,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -3994,7 +4001,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if (state.syncManager) {
@@ -4679,7 +4686,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -4690,7 +4697,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -4701,7 +4708,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -4709,12 +4716,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -4726,21 +4733,21 @@
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -4758,10 +4765,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4822,22 +4826,22 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack, options = {}) {
                 const { source = 'ui:direct' } = options;
                 if (state.isImageTransitioning) return;
@@ -4999,7 +5003,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -5072,7 +5076,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -5088,7 +5092,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -5097,7 +5101,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -5105,7 +5109,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -5115,13 +5119,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
@@ -5270,10 +5274,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6370,7 +6374,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -6719,7 +6723,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/performance-v1 (1).html
+++ b/performance-v1 (1).html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; }
         .search-helper-icon { color: #9ca3af; cursor: pointer; display: flex; align-items: center; }
@@ -331,16 +321,15 @@
         }
         .search-helper-popup a:hover { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -354,7 +343,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -369,10 +358,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -392,7 +381,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; min-height: 40px; }
         .tag-item { display: inline-flex; align-items: center; background: #dbeafe; color: #1e40af; padding: 4px 8px; border-radius: 12px; font-size: 12px; gap: 6px; }
         .tag-remove {
@@ -405,7 +394,7 @@
             font-size: 12px; color: #6b7280; cursor: pointer; transition: all 0.2s;
         }
         .add-tag-btn:hover { background: #e5e7eb; color: #374151; }
-        
+
         /* NEW: Action Modal Tag Chips */
         #tag-chip-container { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
         .tag-chip {
@@ -419,11 +408,10 @@
         }
         .tag-chip-remove:hover { background: rgba(99, 102, 241, 0.1); }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -438,12 +426,16 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -473,10 +465,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -494,7 +482,7 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-        
+
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
@@ -502,9 +490,9 @@
         .app-container.focus-mode #center-trash-btn { display: none; }
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -530,7 +518,7 @@
         #focus-tap-left { left: 0; width: 40%; }
         #focus-tap-center { left: 40%; width: 20%; }
         #focus-tap-right { right: 0; width: 40%; }
-        
+
         .app-container.focus-mode .focus-tap-zone {
             display: block;
         }
@@ -571,7 +559,7 @@
         </div>
         <div class="app-footer">Orbital8-K-2025-09-18 02:08 AM</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -586,7 +574,7 @@
         </div>
         <div class="app-footer">Orbital8-K-2025-09-18 02:08 AM</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -601,7 +589,7 @@
         </div>
         <div class="app-footer">Orbital8-K-2025-09-18 02:08 AM</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -615,7 +603,7 @@
         </div>
         <div class="app-footer">Orbital8-K-2025-09-18 02:08 AM</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -623,7 +611,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -637,23 +625,23 @@
         <div id="focus-tap-left" class="focus-tap-zone"></div>
         <div id="focus-tap-center" class="focus-tap-zone"></div>
         <div id="focus-tap-right" class="focus-tap-zone"></div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -664,7 +652,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -674,11 +661,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">Orbital8-K-2025-09-18 02:08 AM</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -694,7 +679,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -709,7 +694,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper">
@@ -727,7 +712,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -746,7 +731,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -758,7 +743,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -770,14 +755,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -797,19 +782,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating">
@@ -820,7 +805,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating">
@@ -832,7 +817,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -842,7 +827,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root & Web Worker =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -885,7 +870,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -893,11 +877,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -912,7 +896,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -921,11 +906,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -936,17 +920,17 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
                     edgeRight: document.getElementById('edge-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -958,22 +942,22 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -989,7 +973,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -999,22 +983,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1027,7 +1036,7 @@
                     img.onerror = () => {
                         if (state.currentImageLoadId !== loadId) return;
                         let fallbackUrl = this.getFallbackImageUrl(file);
-                        
+
                         img.onerror = () => {
                             if (state.currentImageLoadId !== loadId) return;
                             img.src = 'data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'150\' height=\'150\' viewBox=\'0 0 150 150\' fill=\'none\'%3E%3Crect width=\'150\' height=\'150\' fill=\'%23E5E7EB\'/%3E%3Cpath d=\'M65 60H85V90H65V60Z\' fill=\'%239CA3AF\'/%3E%3Ccircle cx=\'75\' cy=\'45\' r=\'10\' fill=\'%239CA3AF\'/%3E%3C/svg%3E';
@@ -1039,7 +1048,7 @@
                     img.alt = file.name || 'Image';
                 });
             },
-            
+
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
                     return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
@@ -1062,7 +1071,7 @@
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -1070,7 +1079,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -1252,7 +1261,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -1708,7 +1717,7 @@
                     authButton.textContent = `Connect ${isGoogle ? 'Drive' : 'OneDrive'}`;
                 }
             },
-            
+
             backToProviderSelection() {
                 if(state.syncManager) state.syncManager.stop();
                 state.provider = null;
@@ -1723,7 +1732,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if(state.syncManager) state.syncManager.start();
@@ -1748,24 +1757,24 @@
 
                 Utils.showScreen('loading-screen');
                 Utils.updateLoadingProgress(0, 0, 'Fetching from cloud...');
-                
+
                 try {
                     const result = await state.provider.getFilesAndMetadata(state.currentFolder.id);
                     const files = result.files || [];
-                    
+
                     if (files.length === 0) {
                         Utils.showToast('No images found in this folder', 'info', true);
                         this.returnToFolderSelection();
                         return;
                     }
-                    
+
                     state.imageFiles = files;
                     await this.processAllMetadata(state.imageFiles, true);
                     await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
-                    
+
                     Core.initializeStacks();
                     Core.initializeImageDisplay();
-                    
+
                 } catch (error) {
                     if (error.name !== 'AbortError') {
                         Utils.showToast(`Error loading images: ${error.message}`, 'error', true);
@@ -1779,11 +1788,11 @@
                     const result = await state.provider.getFilesAndMetadata(state.currentFolder.id);
                     const cloudFiles = result.files || [];
                     const localFiles = await state.dbManager.getFolderCache(state.currentFolder.id) || [];
-            
+
                     const cloudFileMap = new Map(cloudFiles.map(f => [f.id, f]));
                     const localFileMap = new Map(localFiles.map(f => [f.id, f]));
                     let hasChanges = false;
-            
+
                     for (const cloudFile of cloudFiles) {
                         const localFile = localFileMap.get(cloudFile.id);
                         if (!localFile || new Date(cloudFile.modifiedTime) > new Date(localFile.modifiedTime)) {
@@ -1791,14 +1800,14 @@
                             localFileMap.set(cloudFile.id, cloudFile);
                         }
                     }
-            
+
                     for (const localId of localFileMap.keys()) {
                         if (!cloudFileMap.has(localId)) {
                             hasChanges = true;
                             localFileMap.delete(localId);
                         }
                     }
-            
+
                     if (hasChanges) {
                         const newMergedFiles = Array.from(localFileMap.values());
                         await this.processAllMetadata(newMergedFiles);
@@ -1814,7 +1823,7 @@
                     console.warn("Background refresh failed:", error.message);
                 }
             },
-            
+
             async processAllMetadata(files, isFirstLoad = false) {
                  if (isFirstLoad) Utils.updateLoadingProgress(0, files.length, 'Processing files...');
                  for (let i = 0; i < files.length; i++) {
@@ -1860,11 +1869,11 @@
                  }
                  return baseMetadata;
             },
-            
+
             switchToCommonUI() {
                 Utils.showScreen('app-container');
             },
-            
+
             async returnToFolderSelection() {
                 try {
                     if (state.syncManager) {
@@ -1888,7 +1897,7 @@
                 Core.showEmptyState();
                 Utils.elements.emptyState.classList.add('hidden');
             },
-            
+
             async updateUserMetadata(fileId, updates) {
                 try {
                     const file = state.imageFiles.find(f => f.id === fileId);
@@ -1908,16 +1917,16 @@
                     const stackIndex = state.stacks[file.stack].findIndex(f => f.id === fileId);
                     if (stackIndex > -1) { state.stacks[file.stack].splice(stackIndex, 1); }
                 }
-                
+
                 await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
-                
+
                 try {
                     await state.provider.deleteFile(fileId);
                 } catch (e) {
                     Utils.showToast(`Failed to delete from cloud: ${e.message}`, 'error', true);
                 }
             },
-            
+
             async extractMetadataInBackground(pngFiles) {
                 const BATCH_SIZE = 5;
                 for (let i = 0; i < pngFiles.length; i += BATCH_SIZE) {
@@ -1932,14 +1941,14 @@
                     await Promise.allSettled(promises);
                 }
             },
-            
+
             async processFileMetadata(file) {
                 if (file.metadataStatus === 'loaded' || file.metadataStatus === 'loading' || file.metadataStatus === 'error') return;
                 file.metadataStatus = 'loading';
                 try {
                     const metadata = await state.metadataExtractor.fetchMetadata(file);
                     let finalMetadata = { ...file };
-                    
+
                     if (metadata.error) {
                         finalMetadata.metadataStatus = 'error';
                         finalMetadata.extractedMetadata = { 'Error': metadata.error };
@@ -1948,7 +1957,7 @@
                         finalMetadata.metadataStatus = 'loaded';
                         finalMetadata.extractedMetadata = metadata;
                     }
-                    
+
                     await state.dbManager.saveMetadata(file.id, finalMetadata);
                     Object.assign(file, finalMetadata);
 
@@ -1978,7 +1987,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -1989,7 +1998,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -2000,7 +2009,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -2008,12 +2017,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -2021,25 +2030,25 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -2052,14 +2061,10 @@
                     this.showEmptyState();
                     return;
                 }
-                
+
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    Utils.elements.focusFilenameDisplay.textContent = `${truncatedFolder} / ${currentFile.name.replace(/\.[^/.]+$/, "")}`;
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
@@ -2068,7 +2073,7 @@
                     if (currentFile.metadataStatus === 'pending') {
                         App.processFileMetadata(currentFile);
                     }
-                    
+
                     this.updateImageCounters();
                     this.updateFavoriteButton();
                 } catch (error) {
@@ -2091,26 +2096,26 @@
                 if (!currentFile) return;
                 Utils.elements.focusFavoriteBtn.classList.toggle('favorited', !!currentFile.favorite);
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack) {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                
+
                 const currentImage = currentStackArray[state.currentStackPosition];
                 if (!currentImage) return;
 
@@ -2133,7 +2138,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();
@@ -2141,7 +2146,7 @@
                     Utils.showToast(`Error moving image: ${error.message}`, 'error', true);
                 }
             },
-            
+
             showEmptyState() {
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
@@ -2170,7 +2175,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -2240,7 +2245,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -2256,7 +2261,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -2265,7 +2270,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.moveSelected, Utils.elements.deleteSelected, 
@@ -2273,7 +2278,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -2283,20 +2288,20 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
                 state.grid.selected = [];
                 if (!query) { this.resetSearch(); return; }
                 state.grid.filtered = this.searchImages(query);
-                
+
                 Utils.elements.gridContainer.innerHTML = '';
                 if (state.grid.filtered.length === 0) {
                     Utils.elements.gridEmptyState.classList.remove('hidden');
@@ -2320,7 +2325,7 @@
                 Core.updateStackCounts();
                 this.deselectAll();
             },
-            
+
             searchImages(query) {
                 const lowerCaseQuery = query.toLowerCase();
                 const terms = lowerCaseQuery.split(/\s+/).filter(t => t);
@@ -2392,10 +2397,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -2655,7 +2660,7 @@
             addTagChip(tag) {
                 if (this.taggingState.tags.has(tag)) return;
                 this.taggingState.tags.add(tag);
-                
+
                 const container = document.getElementById('tag-chip-container');
                 const chip = document.createElement('div');
                 chip.className = 'tag-chip';
@@ -2760,7 +2765,7 @@
                     this.hide();
                     return;
                 }
-                
+
                 await this.executeBulkAction({
                     action: async (fileId) => {
                         const file = state.imageFiles.find(f => f.id === fileId);
@@ -2885,7 +2890,7 @@
                 const currentTime = Date.now();
                 if (currentTime - this.lastTapTime < 300) { e.preventDefault(); this.toggleFocusMode(); this.lastTapTime = 0; return; }
                 this.lastTapTime = currentTime;
-                
+
                 if (state.stacks[state.currentStack].length === 0) return;
                 if (e.touches && (e.touches.length > 1 || state.isPinching)) return;
                 if (state.currentScale > 1.1) return;
@@ -2923,11 +2928,11 @@
                 if (!state.isDragging) return;
                 state.isDragging = false; Utils.elements.centerImage.classList.remove('dragging');
                 if (!this.gestureStarted) { this.hideAllEdgeGlows(); return; }
-                
+
                 const deltaX = this.currentPos.x - this.startPos.x;
                 const deltaY = this.currentPos.y - this.startPos.y;
                 const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
-                
+
                 if (distance > 80) {
                     if(state.isFocusMode){
                          if (deltaX < 0) { this.nextImage(); } 
@@ -3173,7 +3178,7 @@
             init(modal, header) {
                 let pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
                 let isDragging = false;
-                
+
                 header.onmousedown = dragMouseDown;
 
                 function dragMouseDown(e) {
@@ -3194,7 +3199,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -3413,7 +3418,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/performance-v1.html
+++ b/performance-v1.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -349,16 +339,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -372,7 +361,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,10 +376,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -410,7 +399,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tag-section { display: flex; flex-direction: column; gap: 6px; }
@@ -439,11 +428,10 @@
         .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -458,7 +446,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
@@ -483,6 +471,10 @@
         }
         .app-footer .footer-link:focus-visible {
             outline: none;
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -512,10 +504,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -540,19 +528,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -696,7 +682,7 @@
         </div>
         <div class="app-footer">Synch</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -711,7 +697,7 @@
         </div>
         <div class="app-footer">Synch</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">Synch</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -740,7 +726,7 @@
         </div>
         <div class="app-footer">Synch</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -748,7 +734,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -769,23 +755,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -796,7 +782,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -806,11 +791,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">Synch</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -826,7 +809,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -841,7 +824,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -864,7 +847,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -884,7 +867,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -896,7 +879,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -908,14 +891,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -935,19 +918,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -958,7 +941,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -970,7 +953,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -980,7 +963,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1027,7 +1010,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1035,11 +1017,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1054,7 +1036,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1063,11 +1046,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1078,7 +1060,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1093,12 +1075,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1110,27 +1092,27 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1146,7 +1128,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1156,22 +1138,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1184,7 +1191,7 @@
                     img.onerror = () => {
                         if (state.currentImageLoadId !== loadId) return;
                         let fallbackUrl = this.getFallbackImageUrl(file);
-                        
+
                         img.onerror = () => {
                             if (state.currentImageLoadId !== loadId) return;
                             img.src = 'data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'150\' height=\'150\' viewBox=\'0 0 150 150\' fill=\'none\'%3E%3Crect width=\'150\' height=\'150\' fill=\'%23E5E7EB\'/%3E%3Cpath d=\'M65 60H85V90H65V60Z\' fill=\'%239CA3AF\'/%3E%3Ccircle cx=\'75\' cy=\'45\' r=\'10\' fill=\'%239CA3AF\'/%3E%3C/svg%3E';
@@ -1196,7 +1203,7 @@
                     img.alt = file.name || 'Image';
                 });
             },
-            
+
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
                     if (file.thumbnailLink) {
@@ -1224,7 +1231,7 @@
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -1232,7 +1239,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3190,7 +3197,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -3876,7 +3883,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if (state.syncManager) {
@@ -4572,7 +4579,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -4583,7 +4590,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -4594,7 +4601,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -4602,12 +4609,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -4615,25 +4622,25 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -4651,10 +4658,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4662,7 +4666,7 @@
                     if (currentFile.metadataStatus === 'pending') {
                         App.processFileMetadata(currentFile);
                     }
-                    
+
                     this.updateImageCounters();
                     this.updateFavoriteButton();
                 } catch (error) {
@@ -4707,22 +4711,22 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack, options = {}) {
                 const { source = 'ui:direct' } = options;
                 if (state.isImageTransitioning) return;
@@ -4772,7 +4776,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();
@@ -4879,7 +4883,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -4952,7 +4956,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -4968,7 +4972,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -4977,7 +4981,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -4985,7 +4989,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -4995,13 +4999,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
@@ -5150,10 +5154,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6250,7 +6254,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -6599,7 +6603,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/performance-v2.html
+++ b/performance-v2.html
@@ -24,28 +24,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -59,7 +59,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -69,14 +69,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -84,7 +84,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -96,13 +96,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -110,29 +110,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -146,7 +136,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -158,20 +148,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -179,7 +169,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -190,7 +180,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -204,7 +194,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -215,11 +205,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -238,7 +228,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -251,7 +241,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -264,7 +254,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -287,7 +277,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -302,11 +292,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -318,7 +308,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; }
         .search-helper-icon { color: #9ca3af; cursor: pointer; display: flex; align-items: center; }
@@ -336,16 +326,15 @@
         }
         .search-helper-popup a:hover { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -359,7 +348,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -374,10 +363,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -397,7 +386,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; min-height: 40px; }
         .tag-item { display: inline-flex; align-items: center; background: #dbeafe; color: #1e40af; padding: 4px 8px; border-radius: 12px; font-size: 12px; gap: 6px; }
         .tag-remove {
@@ -410,7 +399,7 @@
             font-size: 12px; color: #6b7280; cursor: pointer; transition: all 0.2s;
         }
         .add-tag-btn:hover { background: #e5e7eb; color: #374151; }
-        
+
         /* NEW: Action Modal Tag Chips */
         #tag-chip-container { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
         .tag-chip {
@@ -424,11 +413,10 @@
         }
         .tag-chip-remove:hover { background: rgba(99, 102, 241, 0.1); }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -443,12 +431,16 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -478,10 +470,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -506,19 +494,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -662,7 +648,7 @@
         </div>
         <div class="app-footer">Version R - Unified, Tier 3 Last Device Wins - UI Optimized</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -677,7 +663,7 @@
         </div>
         <div class="app-footer">Version R - Unified, Tier 3 Last Device Wins - UI Optimized</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -692,7 +678,7 @@
         </div>
         <div class="app-footer">Version R - Unified, Tier 3 Last Device Wins - UI Optimized</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -706,7 +692,7 @@
         </div>
         <div class="app-footer">Version R - Unified, Tier 3 Last Device Wins - UI Optimized</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -714,7 +700,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -735,23 +721,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -762,7 +748,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -772,11 +757,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">Version R - Unified, Tier 3 Last Device Wins - UI Optimized</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -792,7 +775,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -807,7 +790,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper">
@@ -825,7 +808,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -844,7 +827,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -856,7 +839,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -868,14 +851,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -895,19 +878,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating">
@@ -918,7 +901,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating">
@@ -930,7 +913,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -940,7 +923,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1053,7 +1036,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1061,11 +1043,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1080,7 +1062,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1089,11 +1072,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1104,7 +1086,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1119,12 +1101,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1136,22 +1118,22 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1167,7 +1149,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1177,22 +1159,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1236,7 +1243,7 @@
                     img.alt = file.name || 'Image';
                 });
             },
-            
+
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
                     if (file.thumbnailLink) {
@@ -1272,7 +1279,7 @@
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -1280,7 +1287,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -1883,7 +1890,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -2526,7 +2533,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -2537,7 +2544,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -2548,7 +2555,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -2556,12 +2563,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -2569,25 +2576,25 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -2604,10 +2611,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -2615,7 +2619,7 @@
                     if (currentFile.metadataStatus === 'pending') {
                         App.processFileMetadata(currentFile);
                     }
-                    
+
                     this.updateImageCounters();
                     this.updateFavoriteButton();
                 } catch (error) {
@@ -2660,26 +2664,26 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack) {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                
+
                 const currentImage = currentStackArray[state.currentStackPosition];
                 if (!currentImage) return;
 
@@ -2702,7 +2706,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();
@@ -2710,7 +2714,7 @@
                     Utils.showToast(`Error moving image: ${error.message}`, 'error', true);
                 }
             },
-            
+
             showEmptyState() {
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
@@ -2739,7 +2743,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -2824,7 +2828,7 @@
                         this.toggleSelection(e, file.id);
                     });
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -2845,7 +2849,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -2854,7 +2858,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.moveSelected, Utils.elements.deleteSelected, 
@@ -2862,7 +2866,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -2872,20 +2876,20 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
                 state.grid.selected = [];
                 if (!query) { this.resetSearch(); return; }
                 state.grid.filtered = this.searchImages(query);
-                
+
                 Utils.elements.gridContainer.innerHTML = '';
                 if (state.grid.filtered.length === 0) {
                     Utils.elements.gridEmptyState.classList.remove('hidden');
@@ -2909,7 +2913,7 @@
                 Core.updateStackCounts();
                 this.deselectAll();
             },
-            
+
             searchImages(query) {
                 const lowerCaseQuery = query.toLowerCase();
                 const terms = lowerCaseQuery.split(/\s+/).filter(t => t);
@@ -2981,10 +2985,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -3338,7 +3342,7 @@
                     this.hide();
                     return;
                 }
-                
+
                 await this.executeBulkAction({
                     action: async (fileId) => {
                         const file = state.imageFiles.find(f => f.id === fileId);
@@ -3954,7 +3958,7 @@
             init(modal, header) {
                 let pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
                 let isDragging = false;
-                
+
                 header.onmousedown = dragMouseDown;
 
                 function dragMouseDown(e) {
@@ -3975,7 +3979,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -4194,7 +4198,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/performance.html
+++ b/performance.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -349,16 +339,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -372,7 +361,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,10 +376,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -410,7 +399,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tag-section { display: flex; flex-direction: column; gap: 6px; }
@@ -439,11 +428,10 @@
         .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -458,7 +446,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
@@ -483,6 +471,10 @@
         }
         .app-footer .footer-link:focus-visible {
             outline: none;
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -512,10 +504,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -540,19 +528,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -696,7 +682,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -711,7 +697,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -740,7 +726,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -748,7 +734,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -769,23 +755,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -796,7 +782,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -806,11 +791,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -826,7 +809,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -841,7 +824,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -864,7 +847,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -884,7 +867,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -896,7 +879,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -908,14 +891,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -935,19 +918,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -958,7 +941,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -970,7 +953,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -980,7 +963,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1096,7 +1079,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1104,11 +1086,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1123,7 +1105,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1132,11 +1115,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1147,7 +1129,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1162,12 +1144,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1179,27 +1161,27 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1215,7 +1197,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1225,22 +1207,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1285,7 +1292,7 @@
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -1293,7 +1300,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3258,7 +3265,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -3962,7 +3969,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if (state.syncManager) {
@@ -4647,7 +4654,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -4658,7 +4665,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -4669,7 +4676,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -4677,12 +4684,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -4690,25 +4697,25 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -4726,10 +4733,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4737,7 +4741,7 @@
                     if (currentFile.metadataStatus === 'pending') {
                         App.processFileMetadata(currentFile);
                     }
-                    
+
                     this.updateImageCounters();
                     this.updateFavoriteButton();
                 } catch (error) {
@@ -4782,22 +4786,22 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack, options = {}) {
                 const { source = 'ui:direct' } = options;
                 if (state.isImageTransitioning) return;
@@ -4847,7 +4851,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();
@@ -4959,7 +4963,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -5032,7 +5036,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -5048,7 +5052,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -5057,7 +5061,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -5065,7 +5069,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -5075,13 +5079,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
@@ -5230,10 +5234,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6330,7 +6334,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -6679,7 +6683,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/poc-hold.html
+++ b/poc-hold.html
@@ -20,28 +20,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -55,7 +55,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -65,14 +65,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -80,7 +80,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -92,13 +92,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -106,29 +106,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -142,7 +132,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -154,20 +144,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -175,7 +165,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -186,7 +176,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -200,7 +190,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -211,11 +201,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -234,7 +224,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -247,7 +237,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -260,7 +250,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -283,7 +273,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -298,11 +288,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -314,7 +304,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; }
         .search-helper-icon { color: #9ca3af; cursor: pointer; display: flex; align-items: center; }
@@ -332,16 +322,15 @@
         }
         .search-helper-popup a:hover { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -355,7 +344,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -370,10 +359,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -393,7 +382,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; min-height: 40px; }
         .tag-item { display: inline-flex; align-items: center; background: #dbeafe; color: #1e40af; padding: 4px 8px; border-radius: 12px; font-size: 12px; gap: 6px; }
         .tag-remove {
@@ -406,7 +395,7 @@
             font-size: 12px; color: #6b7280; cursor: pointer; transition: all 0.2s;
         }
         .add-tag-btn:hover { background: #e5e7eb; color: #374151; }
-        
+
         /* NEW: Action Modal Tag Chips */
         #tag-chip-container { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
         .tag-chip {
@@ -420,11 +409,10 @@
         }
         .tag-chip-remove:hover { background: rgba(99, 102, 241, 0.1); }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -439,12 +427,16 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -474,10 +466,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -502,19 +490,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -658,7 +644,7 @@
         </div>
         <div class="app-footer">Orbital8-O-2025-09-23 01:04 UTC :: Sync queue + worker overhaul with PNG cache updates</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -673,7 +659,7 @@
         </div>
         <div class="app-footer">Orbital8-O-2025-09-23 01:04 UTC :: Sync queue + worker overhaul with PNG cache updates</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -688,7 +674,7 @@
         </div>
         <div class="app-footer">Orbital8-O-2025-09-23 01:04 UTC :: Sync queue + worker overhaul with PNG cache updates</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -702,7 +688,7 @@
         </div>
         <div class="app-footer">Orbital8-O-2025-09-23 01:04 UTC :: Sync queue + worker overhaul with PNG cache updates</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -710,7 +696,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -731,23 +717,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -758,7 +744,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -768,11 +753,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">Orbital8-O-2025-09-23 01:04 UTC :: Sync queue + worker overhaul with PNG cache updates</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -788,7 +771,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -803,7 +786,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper">
@@ -821,7 +804,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -840,7 +823,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -852,7 +835,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -864,14 +847,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -891,19 +874,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating">
@@ -914,7 +897,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating">
@@ -926,7 +909,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -936,7 +919,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -980,7 +963,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -988,11 +970,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1007,7 +989,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1016,11 +999,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1031,7 +1013,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1046,12 +1028,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1063,22 +1045,22 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1094,7 +1076,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1104,22 +1086,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1132,7 +1139,7 @@
                     img.onerror = () => {
                         if (state.currentImageLoadId !== loadId) return;
                         let fallbackUrl = this.getFallbackImageUrl(file);
-                        
+
                         img.onerror = () => {
                             if (state.currentImageLoadId !== loadId) return;
                             img.src = 'data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'150\' height=\'150\' viewBox=\'0 0 150 150\' fill=\'none\'%3E%3Crect width=\'150\' height=\'150\' fill=\'%23E5E7EB\'/%3E%3Cpath d=\'M65 60H85V90H65V60Z\' fill=\'%239CA3AF\'/%3E%3Ccircle cx=\'75\' cy=\'45\' r=\'10\' fill=\'%239CA3AF\'/%3E%3C/svg%3E';
@@ -1144,7 +1151,7 @@
                     img.alt = file.name || 'Image';
                 });
             },
-            
+
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
                     if (file.thumbnailLink) {
@@ -1166,7 +1173,7 @@
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -1208,7 +1215,7 @@
                     return v.toString(16);
                 });
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3151,7 +3158,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if(state.syncManager) state.syncManager.start();
@@ -3470,7 +3477,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -3481,7 +3488,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -3492,7 +3499,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -3500,12 +3507,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -3513,25 +3520,25 @@
                         this.showEmptyState();
                         return;
                     }
-                    
+
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -3548,10 +3555,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -3559,7 +3563,7 @@
                     if (currentFile.metadataStatus === 'pending') {
                         App.processFileMetadata(currentFile);
                     }
-                    
+
                     this.updateImageCounters();
                     this.updateFavoriteButton();
                 } catch (error) {
@@ -3604,26 +3608,26 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack) {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                
+
                 const currentImage = currentStackArray[state.currentStackPosition];
                 if (!currentImage) return;
 
@@ -3646,7 +3650,7 @@
                         state.stacks[targetStack].unshift(item);
                         state.stacks[targetStack] = this.sortFiles(state.stacks[targetStack]);
                     }
-                    
+
                     this.updateStackCounts();
                     this.updateActiveProxTab();
                     await this.displayCurrentImage();
@@ -3654,7 +3658,7 @@
                     Utils.showToast(`Error moving image: ${error.message}`, 'error', true);
                 }
             },
-            
+
             showEmptyState() {
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
@@ -3683,7 +3687,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -3753,7 +3757,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -3769,7 +3773,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -3778,7 +3782,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.moveSelected, Utils.elements.deleteSelected, 
@@ -3786,7 +3790,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -3796,20 +3800,20 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
                 state.grid.selected = [];
                 if (!query) { this.resetSearch(); return; }
                 state.grid.filtered = this.searchImages(query);
-                
+
                 Utils.elements.gridContainer.innerHTML = '';
                 if (state.grid.filtered.length === 0) {
                     Utils.elements.gridEmptyState.classList.remove('hidden');
@@ -3833,7 +3837,7 @@
                 Core.updateStackCounts();
                 this.deselectAll();
             },
-            
+
             searchImages(query) {
                 const lowerCaseQuery = query.toLowerCase();
                 const terms = lowerCaseQuery.split(/\s+/).filter(t => t);
@@ -3905,10 +3909,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -4257,7 +4261,7 @@
                     this.hide();
                     return;
                 }
-                
+
                 await this.executeBulkAction({
                     action: async (fileId) => {
                         const file = state.imageFiles.find(f => f.id === fileId);
@@ -4873,7 +4877,7 @@
             init(modal, header) {
                 let pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
                 let isDragging = false;
-                
+
                 header.onmousedown = dragMouseDown;
 
                 function dragMouseDown(e) {
@@ -4894,7 +4898,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -5112,7 +5116,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/thebaseline.html
+++ b/thebaseline.html
@@ -25,7 +25,7 @@
            - UI (Folder Button): The "Folders" button text is now static for consistency.
            - UI (Filename Display): The filename overlay is now prepended with the truncated folder name.
         */
-        
+
         :root {
             --app-accent: #f59e0b;
             --glass-bg: rgba(255, 255, 255, 0.1);
@@ -36,30 +36,30 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         /* ===== Screen & Card Styles ===== */
         .screen {
             position: fixed; inset: 0; background: var(--dark-gradient);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass-bg); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         /* ===== Typography ===== */
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         /* ===== Form Elements ===== */
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--glass-border); border-radius: 12px;
@@ -76,7 +76,7 @@
             background: #f3f4f6;
             border-color: #d1d5db;
         }
-        
+
         /* ===== Buttons ===== */
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--app-accent), #d97706); border: none; border-radius: 15px;
@@ -87,14 +87,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--glass-border); background: var(--glass-bg);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -102,7 +102,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         /* ===== Provider Selection Specific ===== */
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
@@ -115,15 +115,15 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--app-accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options {
             display: flex; gap: 8px; justify-content: center; margin-bottom: 16px;
         }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -131,12 +131,12 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--app-accent); background: rgba(245, 158, 11, 0.2); color: var(--app-accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         /* ===== Status & Feedback ===== */
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
@@ -144,17 +144,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 1000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         /* ===== Folder Items ===== */
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
@@ -169,7 +159,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -181,19 +171,19 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         /* ===== Loading & Progress ===== */
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--app-accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--app-accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--app-accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         /* ===== Main App Layout ===== */
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark-gradient); overflow: hidden; }
         .nav-button {
@@ -204,7 +194,7 @@
         .nav-button:hover { opacity: 1; background: rgba(255, 255, 255, 0.2); }
         .nav-button.back { left: 20px; }
         .nav-button.details { right: 20px; }
-        
+
         /* ===== Folder Tooltip ===== */
         .folder-tooltip {
             position: absolute; background: rgba(0,0,0,0.85); color: white;
@@ -212,7 +202,7 @@
             z-index: 1000; pointer-events: none; white-space: nowrap;
             box-shadow: 0 2px 8px rgba(0,0,0,0.3);
         }
-        
+
         /* ===== Image Display ===== */
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
@@ -221,33 +211,6 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
 
         /* ===== Edge Effects ===== */
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; }
@@ -260,7 +223,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow-opacity)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow-opacity)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         /* ===== Pills & Counters ===== */
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
@@ -274,7 +237,7 @@
         .pill-counter.bottom { bottom: 60px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         /* ===== Enhanced Ripple Effects ===== */
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
@@ -286,12 +249,12 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow-opacity)), 0 0 50px rgba(245, 158, 11, calc(var(--glow-opacity) * 0.6)); 
             animation: sustainedGlow 1s ease-out calc(var(--ripple-duration) * 1); 
         }
-        
+
         /* High intensity mode */
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -310,7 +273,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         /* ===== Empty State ===== */
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
@@ -322,7 +285,7 @@
             padding: 12px 24px; color: white; font-size: 16px; cursor: pointer; transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         /* ===== Modal System ===== */
         .modal { position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); display: flex; align-items: center; justify-content: center; z-index: 50; }
         .modal.hidden { display: none !important; }
@@ -331,7 +294,7 @@
             width: 100%; height: 100%; max-width: 1152px; max-height: 90vh; margin: 16px; display: flex; flex-direction: column;
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         /* ===== Enhanced Grid System ===== */
         .modal-header { position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; }
         .modal-header-main { padding: 12px 16px; border-bottom: 1px solid #f3f4f6; display: flex; align-items: center; justify-content: space-between; }
@@ -348,7 +311,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -363,11 +326,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px;
             border-bottom: 1px solid #e5e7eb;
@@ -379,7 +342,7 @@
             flex-grow: 1; padding: 6px 10px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 14px;
         }
         #omni-search-btn { padding: 6px 16px; }
-        
+
         .grid-row-4 {
             padding: 8px 16px;
             border-bottom: 1px solid #e5e7eb;
@@ -389,10 +352,10 @@
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative;
             background-color: #f3f4f6;
@@ -425,7 +388,7 @@
             opacity: 1;
         }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-        
+
         /* ===== Details Modal ===== */
         .details-modal-content { max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; }
         .details-header { display: flex; align-items: center; justify-content: space-between; padding: 16px; border-bottom: 1px solid #e5e7eb; flex-shrink: 0; }
@@ -440,7 +403,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         /* ===== Tags & Ratings ===== */
         .tags-container { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; min-height: 40px; }
         .tag-item { display: inline-flex; align-items: center; background: #dbeafe; color: #1e40af; padding: 4px 8px; border-radius: 12px; font-size: 12px; gap: 6px; }
@@ -454,11 +417,11 @@
             font-size: 12px; color: #6b7280; cursor: pointer; transition: all 0.2s;
         }
         .add-tag-btn:hover { background: #e5e7eb; color: #374151; }
-        
+
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         /* ===== Metadata Table ===== */
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
@@ -473,12 +436,16 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         /* ===== Footer ===== */
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center; padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
         .footer-link {
             color: rgba(255, 255, 255, 0.6);
@@ -488,7 +455,7 @@
         .footer-link:hover {
             color: white;
         }
-        
+
         /* ===== Focus Mode ===== */
         .focus-mode-ui {
             position: absolute;
@@ -513,41 +480,37 @@
         #focus-stack-name { top: 20px; left: 20px; }
         #focus-image-count { bottom: 20px; left: 20px; }
         #focus-delete-btn { bottom: 20px; right: 20px; width: 44px; height: 44px; padding: 0; border-radius: 50%; }
-        
+
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode .nav-button.back,
-        .app-container.focus-mode .filename-overlay {
-            display: none;
-        }
         .app-container.focus-mode .focus-mode-ui {
             display: flex;
         }
         .app-container.focus-mode .nav-button.details {
             background: rgba(0, 0, 0, 0.4);
         }
-        
+
         /* ===== Responsive ===== */
         .hidden { display: none !important; }
-        
+
         @media screen and (min-width: 768px) {
             .pill-counter { font-size: 16px; padding: 8px 16px; min-width: 40px; }
             .nav-button { font-size: 14px; padding: 10px 16px; }
             .focus-mode-ui { font-size: 14px; padding: 10px 16px; }
         }
-        
+
         @media screen and (max-width: 767px) {
             .nav-button { font-size: 16px; padding: 12px 20px; border-radius: 25px; min-width: 80px; }
             .pill-counter.bottom { bottom: 80px; }
-            .filename-overlay { font-size: 11px; padding: 5px 12px; bottom: 35px; }
             .details-modal-content { max-width: 100vw; max-height: 100vh; height: 100vh; margin: 0; border-radius: 0; }
             .metadata-table .key-cell { width: 30%; min-width: 80px; font-size: 12px; }
             .metadata-table .value-cell { font-size: 12px; }
             .copy-button { font-size: 10px; padding: 3px 6px; }
-            
+
             .app-container { height: 100vh; height: 100dvh; }
             .image-viewport { height: 100vh; height: 100dvh; }
         }
-        
+
         @supports (height: 100dvh) {
             .app-container { height: 100dvh; }
             .image-viewport { height: 100dvh; }
@@ -560,21 +523,21 @@
         <div class="card">
             <h1 class="title" style="font-size: 32px;">Orbital8</h1>
             <p class="subtitle">Select your cloud storage provider</p>
-            
+
             <button class="provider-button" id="google-drive-btn">
                 <svg style="width: 20px; height: 20px;" viewBox="0 0 24 24">
                     <path fill="currentColor" d="M6.28 7L9.69 1h4.62l3.41 6zM16.05 7H7.95l4.05 7zM11.76 15h8.58L24 21H7.05z"/>
                 </svg>
                 Google Drive
             </button>
-            
+
             <button class="provider-button" id="onedrive-btn">
                 <svg style="width: 20px; height: 20px;" viewBox="0 0 24 24">
                     <path fill="currentColor" d="M17.75 8C16.82 8 16 8.82 16 9.75S16.82 11.5 17.75 11.5s1.75-.82 1.75-1.75S18.68 8 17.75 8z"/>
                 </svg>
                 OneDrive
             </button>
-            
+
             <div class="settings-section">
                 <div style="margin-bottom: 16px;">
                     <label style="color: rgba(255,255,255,0.9); font-size: 14px; font-weight: 500; display: block; margin-bottom: 8px;">Visual Cue Intensity:</label>
@@ -584,7 +547,7 @@
                         <button class="intensity-btn" data-level="high">High</button>
                     </div>
                 </div>
-                
+
                 <div>
                     <label class="checkbox-label">
                         <input type="checkbox" id="haptic-enabled" checked style="margin: 0;">
@@ -592,14 +555,14 @@
                     </label>
                 </div>
             </div>
-            
+
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
         <div class="app-footer">
             <a href="https://github.com/acmeproducts/stuff/blob/main/orbital8-v14.html" target="_blank" class="footer-link">orbital8-v14-ph12.html</a>
         </div>
     </div>
-    
+
     <!-- Google Drive Auth Screen -->
     <div class="screen hidden" id="gdrive-auth-screen">
         <div class="card">
@@ -614,7 +577,7 @@
             <a href="https://github.com/acmeproducts/stuff/blob/main/orbital8-v14.html" target="_blank" class="footer-link">orbital8-v14-ph12.html</a>
         </div>
     </div>
-    
+
     <!-- OneDrive Auth Screen -->
     <div class="screen hidden" id="onedrive-auth-screen">
         <div class="card">
@@ -628,7 +591,7 @@
             <a href="https://github.com/acmeproducts/stuff/blob/main/orbital8-v14.html" target="_blank" class="footer-link">orbital8-v14-ph12.html</a>
         </div>
     </div>
-    
+
     <!-- Google Drive Folder Screen -->
     <div class="screen hidden" id="gdrive-folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -645,7 +608,7 @@
             <a href="https://github.com/acmeproducts/stuff/blob/main/orbital8-v14.html" target="_blank" class="footer-link">orbital8-v14-ph12.html</a>
         </div>
     </div>
-    
+
     <!-- OneDrive Folder Screen -->
     <div class="screen hidden" id="onedrive-folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -662,7 +625,7 @@
             <a href="https://github.com/acmeproducts/stuff/blob/main/orbital8-v14.html" target="_blank" class="footer-link">orbital8-v14-ph12.html</a>
         </div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -678,33 +641,31 @@
             <a href="https://github.com/acmeproducts/stuff/blob/main/orbital8-v14.html" target="_blank" class="footer-link">orbital8-v14-ph12.html</a>
         </div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <div class="nav-button back" id="back-button">← Folders</div>
         <div class="nav-button details" id="details-button">Details →</div>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
 
         <!-- Focus Mode UI -->
         <div id="focus-stack-name" class="focus-mode-ui"></div>
@@ -714,13 +675,11 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">
             <a href="https://github.com/acmeproducts/stuff/blob/main/orbital8-v14.html" target="_blank" class="footer-link">orbital8-v14-ph12.html</a>
         </div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -737,7 +696,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <!-- Row 2: Selection & Zoom -->
                 <div class="grid-row-2">
                     <span class="selection-count">
@@ -753,13 +712,13 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <!-- Row 3: Omni Search -->
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search tags, notes, and metadata..." style="margin-bottom: 0; flex-grow: 1;">
                     <button id="omni-search-btn" class="btn btn-primary">Go</button>
                 </div>
-                
+
                 <!-- Row 4: Reserved for Bulk Actions -->
                 <div class="grid-row-4">
                     <div class="bulk-actions">
@@ -776,7 +735,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -788,7 +747,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -800,14 +759,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -827,19 +786,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating">
@@ -860,7 +819,7 @@
                             </svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating">
@@ -882,7 +841,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -909,11 +868,11 @@
            - UI (Folder Button): The "Folders" button text is now static for consistency.
            - UI (Filename Display): The filename overlay is now prepended with the truncated folder name.
         */
-        
+
         // ===== Core Constants & State =====
         const STACK_TYPES = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'In', 'out': 'Out', 'priority': 'Priority', 'trash': 'Trash' };
-        
+
         const appState = {
             currentProvider: null,
             currentProviderType: null,
@@ -955,7 +914,7 @@
         // ===== Unified Utilities =====
         const utils = {
             elements: {},
-            
+
             init() {
                 this.elements = {
                     // Screens
@@ -966,12 +925,12 @@
                     onedriveFolderScreen: document.getElementById('onedrive-folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     // Provider selection
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     // Google Drive elements
                     gdriveClientSecret: document.getElementById('gdrive-client-secret'),
                     gdriveAuthButton: document.getElementById('gdrive-auth-button'),
@@ -981,7 +940,7 @@
                     gdriveRefreshFolders: document.getElementById('gdrive-refresh-folders'),
                     gdriveBackToProvider: document.getElementById('gdrive-back-to-provider'),
                     gdriveLogout: document.getElementById('gdrive-logout'),
-                    
+
                     // OneDrive elements
                     onedriveAuthButton: document.getElementById('onedrive-auth-button'),
                     onedriveBackButton: document.getElementById('onedrive-back-button'),
@@ -991,7 +950,7 @@
                     onedriveRefreshFolders: document.getElementById('onedrive-refresh-folders'),
                     onedriveBackToProvider: document.getElementById('onedrive-back-to-provider'),
                     onedriveLogout: document.getElementById('onedrive-logout'),
-                    
+
                     // App elements
                     backButton: document.getElementById('back-button'),
                     detailsButton: document.getElementById('details-button'),
@@ -1000,9 +959,8 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     // Focus Mode elements
                     focusStackName: document.getElementById('focus-stack-name'),
                     focusImageCount: document.getElementById('focus-image-count'),
@@ -1013,19 +971,19 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     // Edge glows
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
                     edgeRight: document.getElementById('edge-right'),
-                    
+
                     // Pill counters
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     // Grid modal
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
@@ -1037,25 +995,25 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     // Search elements
                     omniSearch: document.getElementById('omni-search'),
                     omniSearchBtn: document.getElementById('omni-search-btn'),
-                    
+
                     // Action buttons
                     tagSelected: document.getElementById('tag-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     // Action modal
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     // Details modal
                     detailsModal: document.getElementById('details-modal'),
                     detailsClose: document.getElementById('details-close'),
@@ -1070,7 +1028,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'gdrive-auth-screen', 'onedrive-auth-screen', 
                                'gdrive-folder-screen', 'onedrive-folder-screen', 'loading-screen', 'app-container'];
@@ -1078,23 +1036,48 @@
                     document.getElementById(id).classList.toggle('hidden', id !== screenId);
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
-                
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
+
                 if (important && appState.hapticManager) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     appState.hapticManager.triggerFeedback(hapticType);
                 }
             },
-            
+
             async withErrorHandling(operation, errorMessage = 'Operation failed') {
                 try {
                     return await operation();
@@ -1103,13 +1086,13 @@
                     throw error;
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 appState.currentImageLoadId = loadId;
 
                 let imageUrl = this.generateImageUrl(file);
-                
+
                 return new Promise((resolve) => {
                     img.onload = () => {
                         if (appState.currentImageLoadId !== loadId) return;
@@ -1126,7 +1109,7 @@
                         } else {
                             fallbackUrl = file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                         }
-                        
+
                         img.onerror = () => {
                             if (appState.currentImageLoadId !== loadId) return;
                             img.src = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="150" height="150" viewBox="0 0 150 150" fill="none"%3E%3Crect width="150" height="150" fill="%23E5E7EB"/%3E%3Cpath d="M65 60H85V90H65V60Z" fill="%239CA3AF"/%3E%3Ccircle cx="75" cy="45" r="10" fill="%239CA3AF"/%3E%3C/svg%3E';
@@ -1138,7 +1121,7 @@
                     img.alt = file.name || 'Image';
                 });
             },
-            
+
             generateImageUrl(file) {
                 if (appState.currentProviderType === 'googledrive') {
                     if (file.thumbnailLink) {
@@ -1152,7 +1135,7 @@
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
             },
-            
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -1160,14 +1143,14 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total) {
                 appState.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
                 this.elements.loadingMessage.textContent = total ? 
                     `Processing ${current} of ${total} images...` : 
                     `Found ${current} images`;
-                
+
                 if (total > 0) {
                     const percentage = (current / total) * 100;
                     this.elements.loadingProgressBar.style.width = `${percentage}%`;
@@ -1181,29 +1164,29 @@
                 this.currentIntensity = localStorage.getItem('orbital8_visual_intensity') || 'medium';
                 this.applyIntensity(this.currentIntensity);
             }
-            
+
             setIntensity(level) {
                 this.currentIntensity = level;
                 this.applyIntensity(level);
                 localStorage.setItem('orbital8_visual_intensity', level);
-                
+
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.classList.toggle('active', btn.dataset.level === level);
                 });
             }
-            
+
             applyIntensity(level) {
                 const settings = {
                     low: { glowOpacity: 0.3, rippleDuration: 1000, extraEffects: false },
                     medium: { glowOpacity: 0.6, rippleDuration: 1500, extraEffects: false },
                     high: { glowOpacity: 1.0, rippleDuration: 2000, extraEffects: true }
                 };
-                
+
                 const config = settings[level];
-                
+
                 document.documentElement.style.setProperty('--glow-opacity', config.glowOpacity);
                 document.documentElement.style.setProperty('--ripple-duration', `${config.rippleDuration}ms`);
-                
+
                 if (config.extraEffects) {
                     document.body.classList.add('high-intensity-mode');
                 } else {
@@ -1217,26 +1200,26 @@
             constructor() {
                 this.isEnabled = localStorage.getItem('orbital8_haptic_enabled') !== 'false';
                 this.isSupported = 'vibrate' in navigator;
-                
+
                 const checkbox = document.getElementById('haptic-enabled');
                 if (checkbox) checkbox.checked = this.isEnabled;
             }
-            
+
             setEnabled(enabled) {
                 this.isEnabled = enabled;
                 localStorage.setItem('orbital8_haptic_enabled', enabled);
             }
-            
+
             triggerFeedback(type) {
                 if (!this.isEnabled || !this.isSupported) return;
-                
+
                 const patterns = {
                     swipe: [20, 40],
                     pillTap: [35],
                     buttonPress: [25],
                     error: [100, 50, 100]
                 };
-                
+
                 const pattern = patterns[type];
                 if (pattern && navigator.vibrate) {
                     navigator.vibrate(pattern);
@@ -1249,7 +1232,7 @@
             constructor() {
                 this.db = null;
             }
-            
+
             async init() {
                 return new Promise((resolve, reject) => {
                     const request = indexedDB.open('Orbital8UnifiedCache', 3);
@@ -1270,7 +1253,7 @@
                     };
                 });
             }
-            
+
             async getCachedFiles(folderId) {
                 if (!this.db) return null;
                 try {
@@ -1281,7 +1264,7 @@
                         request.onsuccess = () => resolve(request.result);
                         request.onerror = () => reject(request.error);
                     });
-                    
+
                     if (result && this.isCacheValid(result.cached)) {
                         return result.files;
                     }
@@ -1290,7 +1273,7 @@
                 }
                 return null;
             }
-            
+
             async setCachedFiles(folderId, files) {
                 if (!this.db) return;
                 try {
@@ -1309,7 +1292,7 @@
                     console.warn('Failed to cache files:', error);
                 }
             }
-            
+
             async getMetadata(fileId) { // NOTE: Removed modifiedTime check for Google Drive fix
                 if (!this.db) return null;
                 try {
@@ -1320,7 +1303,7 @@
                         request.onsuccess = () => resolve(request.result);
                         request.onerror = () => reject(request.error);
                     });
-                    
+
                     // For Google Drive, we can't trust modifiedTime.
                     // For OneDrive, it's safe. We accept the cached data if it exists.
                     if (result) {
@@ -1332,7 +1315,7 @@
                 }
                 return null;
             }
-            
+
             async setMetadata(fileId, metadata) { // NOTE: Removed modifiedTime
                 if (!this.db) return;
                 try {
@@ -1351,12 +1334,12 @@
                     console.warn('Failed to cache metadata:', error);
                 }
             }
-            
+
             isCacheValid(cachedTime) {
                 const CACHE_DURATION = 60 * 60 * 1000; // 1 hour
                 return (Date.now() - cachedTime) < CACHE_DURATION;
             }
-            
+
             async clearCacheForFolder(folderId) {
                 if (!this.db) return;
                 try {
@@ -1378,43 +1361,43 @@
             constructor() {
                 this.abortController = null;
             }
-            
+
             abort() {
                 if (this.abortController) {
                     this.abortController.abort();
                     this.abortController = null;
                 }
             }
-            
+
             async extract(buffer) {
                 if (!buffer) return {};
-                
+
                 const metadata = {};
                 const view = new DataView(buffer);
-                
+
                 if (buffer.byteLength < 8) return {};
-                
+
                 let pos = 8; // Skip PNG header
-                
+
                 try {
                     while (pos < buffer.byteLength - 12) {
                         const chunkLength = view.getUint32(pos, false);
                         pos += 4;
-                        
+
                         let chunkType = '';
                         for (let i = 0; i < 4; i++) {
                             chunkType += String.fromCharCode(view.getUint8(pos + i));
                         }
                         pos += 4;
-                        
+
                         if (chunkType === 'tEXt') {
                             let keyword = '';
                             let value = '';
                             let nullFound = false;
-                            
+
                             for (let i = 0; i < chunkLength; i++) {
                                 const byte = view.getUint8(pos + i);
-                                
+
                                 if (!nullFound) {
                                     if (byte === 0) {
                                         nullFound = true;
@@ -1425,7 +1408,7 @@
                                     value += String.fromCharCode(byte);
                                 }
                             }
-                            
+
                             metadata[keyword] = value;
                         } else if (chunkType === 'IHDR') {
                             const width = view.getUint32(pos, false);
@@ -1434,9 +1417,9 @@
                         } else if (chunkType === 'IEND') {
                             break;
                         }
-                        
+
                         pos += chunkLength + 4;
-                        
+
                         if (chunkLength > buffer.byteLength || pos > buffer.byteLength) {
                             break;
                         }
@@ -1444,16 +1427,16 @@
                 } catch (error) {
                     // Return what we have so far
                 }
-                
+
                 return metadata;
             }
-            
+
             async fetchMetadata(file, isForExport = false) {
                 if (file.mimeType !== 'image/png') {
                     if (!isForExport) file.metadataStatus = 'loaded';
                     return { error: 'Not a PNG file' };
                 }
-                
+
                 try {
                     this.abortController = new AbortController();
                     let response;
@@ -1474,11 +1457,11 @@
                             signal: this.abortController.signal
                         });
                     }
-                    
+
                     if (!response.ok) {
                         throw new Error(`HTTP ${response.status} ${response.statusText}`);
                     }
-                    
+
                     const buffer = await response.arrayBuffer();
                     return await this.extract(buffer);
                 } catch (error) {
@@ -1504,36 +1487,36 @@
                 this.isAuthenticated = false;
                 this.loadStoredCredentials();
             }
-            
+
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
                 this.clientSecret = localStorage.getItem('google_client_secret');
                 this.isAuthenticated = !!(this.accessToken && this.refreshToken && this.clientSecret);
             }
-            
+
             storeCredentials() {
                 if (this.accessToken) localStorage.setItem('google_access_token', this.accessToken);
                 if (this.refreshToken) localStorage.setItem('google_refresh_token', this.refreshToken);
                 if (this.clientSecret) localStorage.setItem('google_client_secret', this.clientSecret);
             }
-            
+
             clearStoredCredentials() {
                 localStorage.removeItem('google_access_token');
                 localStorage.removeItem('google_refresh_token');
                 localStorage.removeItem('google_client_secret');
             }
-            
+
             async authenticate(clientSecret) {
                 if (clientSecret) {
                     this.clientSecret = clientSecret;
                     this.storeCredentials();
                 }
-                
+
                 if (!this.clientSecret) {
                     throw new Error('Client secret is required for Google Drive authentication');
                 }
-                
+
                 if (this.accessToken && this.refreshToken) {
                     try {
                         await this.makeApiCall('/files?pageSize=1');
@@ -1543,31 +1526,31 @@
                         // Token invalid, continue with fresh auth
                     }
                 }
-                
+
                 return new Promise((resolve, reject) => {
                     const authUrl = this.buildAuthUrl();
                     const popup = window.open(authUrl, 'google-auth', 'width=500,height=600,scrollbars=yes,resizable=yes');
-                    
+
                     if (!popup) {
                         reject(new Error('Popup blocked by browser'));
                         return;
                     }
-                    
+
                     const checkClosed = setInterval(() => {
                         if (popup.closed) {
                             clearInterval(checkClosed);
                             reject(new Error('Authentication cancelled'));
                         }
                     }, 1000);
-                    
+
                     const messageHandler = async (event) => {
                         if (event.origin !== window.location.origin) return;
-                        
+
                         if (event.data.type === 'GOOGLE_AUTH_SUCCESS') {
                             clearInterval(checkClosed);
                             window.removeEventListener('message', messageHandler);
                             popup.close();
-                            
+
                             try {
                                 await this.exchangeCodeForTokens(event.data.code);
                                 this.isAuthenticated = true;
@@ -1582,11 +1565,11 @@
                             reject(new Error(event.data.error));
                         }
                     };
-                    
+
                     window.addEventListener('message', messageHandler);
                 });
             }
-            
+
             buildAuthUrl() {
                 const params = new URLSearchParams({
                     client_id: this.clientId,
@@ -1598,7 +1581,7 @@
                 });
                 return `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
             }
-            
+
             async exchangeCodeForTokens(code) {
                 const response = await fetch('https://oauth2.googleapis.com/token', {
                     method: 'POST',
@@ -1611,22 +1594,22 @@
                         redirect_uri: this.redirectUri
                     })
                 });
-                
+
                 if (!response.ok) {
                     throw new Error('Token exchange failed');
                 }
-                
+
                 const tokens = await response.json();
                 this.accessToken = tokens.access_token;
                 this.refreshToken = tokens.refresh_token;
                 this.storeCredentials();
             }
-            
+
             async refreshAccessToken() {
                 if (!this.refreshToken || !this.clientSecret) {
                     throw new Error('No refresh token or client secret available');
                 }
-                
+
                 const response = await fetch('https://oauth2.googleapis.com/token', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -1637,22 +1620,22 @@
                         grant_type: 'refresh_token'
                     })
                 });
-                
+
                 if (!response.ok) {
                     throw new Error('Failed to refresh access token');
                 }
-                
+
                 const tokens = await response.json();
                 this.accessToken = tokens.access_token;
                 this.storeCredentials();
                 return this.accessToken;
             }
-            
+
             async makeApiCall(endpoint, options = {}, isJson = true) {
                 if (!this.accessToken) {
                     throw new Error('Not authenticated');
                 }
-                
+
                 const url = endpoint.startsWith('https://') ? endpoint : `${this.apiBase}${endpoint}`;
                 const headers = {
                     'Authorization': `Bearer ${this.accessToken}`,
@@ -1661,9 +1644,9 @@
                 if(isJson) {
                     headers['Content-Type'] = 'application/json';
                 }
-                
+
                 let response = await fetch(url, { ...options, headers });
-                
+
                 if (response.status === 401 && this.refreshToken && this.clientSecret) {
                     try {
                         await this.refreshAccessToken();
@@ -1675,18 +1658,18 @@
                         throw new Error('Authentication expired. Please reconnect.');
                     }
                 }
-                
+
                 if (!response.ok) {
                     const errorText = await response.text();
                     throw new Error(`API call failed: ${response.status} ${response.statusText} - ${errorText}`);
                 }
-                
+
                 if (isJson) {
                     return await response.json();
                 }
                 return response;
             }
-            
+
             async getFolders() {
                 const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
                 return response.files.map(folder => ({
@@ -1697,21 +1680,21 @@
                     modifiedTime: folder.modifiedTime
                 }));
             }
-            
+
             async getFiles(folderId = 'root') {
                 const allFiles = [];
                 let nextPageToken = null;
-                
+
                 do {
                     const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
                     let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,appProperties,parents),nextPageToken&pageSize=100`;
-                    
+
                     if (nextPageToken) {
                         url += `&pageToken=${nextPageToken}`;
                     }
-                    
+
                     const response = await this.makeApiCall(url);
-                    
+
                     const files = response.files
                         .filter(file => file.mimeType && file.mimeType.startsWith('image/'))
                         .map(file => ({
@@ -1727,19 +1710,19 @@
                             appProperties: file.appProperties || {},
                             parents: file.parents
                         }));
-                    
+
                     allFiles.push(...files);
                     nextPageToken = response.nextPageToken;
-                    
+
                     if (this.onProgressCallback) {
                         this.onProgressCallback(allFiles.length);
                     }
-                    
+
                 } while (nextPageToken);
-                
+
                 return { folders: [], files: allFiles };
             }
-            
+
             async moveFileToStack(fileId, targetStack, sequence) {
                 await this.makeApiCall(`/files/${fileId}`, {
                     method: 'PATCH',
@@ -1765,7 +1748,7 @@
                 });
                 return true;
             }
-            
+
             async updateFileProperties(fileId, properties) {
                 await this.makeApiCall(`/files/${fileId}`, {
                     method: 'PATCH',
@@ -1775,7 +1758,7 @@
                 });
                 return true;
             }
-            
+
             async deleteFile(fileId) {
                 await this.makeApiCall(`/files/${fileId}`, {
                     method: 'PATCH',
@@ -1783,7 +1766,7 @@
                 });
                 return true;
             }
-            
+
             async disconnect() {
                 this.isAuthenticated = false;
                 this.accessToken = null;
@@ -1807,7 +1790,7 @@
                 this.metadataManager = null;
                 this.initMSAL();
             }
-            
+
             initMSAL() {
                 const msalConfig = {
                     auth: {
@@ -1819,7 +1802,7 @@
                 };
                 this.msalInstance = new msal.PublicClientApplication(msalConfig);
             }
-            
+
             async authenticate() {
                 try {
                     const accounts = this.msalInstance.getAllAccounts();
@@ -1836,19 +1819,19 @@
 
                     this.isAuthenticated = true;
                     this.metadataManager = new OneDriveMetadataManager(this);
-                    
+
                     return true;
                 } catch (error) {
                     this.isAuthenticated = false;
                     throw new Error(`Authentication failed: ${error.message}`);
                 }
             }
-            
+
             async getAccessToken() {
                 if (!this.activeAccount) {
                     throw new Error('No active account');
                 }
-                
+
                 try {
                     const response = await this.msalInstance.acquireTokenSilent({
                         scopes: ['Files.ReadWrite.AppFolder'],
@@ -1866,7 +1849,7 @@
                     throw silentError;
                 }
             }
-            
+
             async makeApiCall(endpoint, options = {}) {
                 const accessToken = await this.getAccessToken();
                 const url = `${this.apiBase}${endpoint}`;
@@ -1875,31 +1858,31 @@
                     'Content-Type': 'application/json',
                     ...options.headers
                 };
-                
+
                 const response = await fetch(url, { ...options, headers });
-                
+
                 if (!response.ok) {
                     const errorText = await response.text();
                     throw new Error(`API call failed: ${response.status} ${response.statusText} - ${errorText}`);
                 }
-                
+
                 return response;
             }
-            
+
             async getDownloadsFolder() {
                 try {
                     const response = await this.makeApiCall('/me/drive/root/children');
                     const data = await response.json();
-                    
+
                     const downloadsFolder = data.value.find(item => 
                         item.folder && 
                         (item.name.toLowerCase() === 'downloads' || item.name.toLowerCase() === 'download')
                     );
-                    
+
                     if (downloadsFolder) {
                         return downloadsFolder;
                     }
-                    
+
                     return {
                         id: 'root',
                         name: 'Root',
@@ -1914,39 +1897,39 @@
                     };
                 }
             }
-            
+
             async getFolders() {
                 try {
                     const downloadsFolder = await this.getDownloadsFolder();
-                    
+
                     this.currentParentId = downloadsFolder.id;
                     this.currentParentPath = downloadsFolder.name;
                     this.breadcrumb = [{ id: downloadsFolder.id, name: downloadsFolder.name }];
-                    
+
                     return await this.loadFoldersInParent(downloadsFolder.id);
                 } catch (error) {
                     console.warn('Failed to load initial folders:', error);
                     return [];
                 }
             }
-            
+
             async loadFoldersInParent(parentId) {
                 try {
                     const folders = [];
                     let nextLink = null;
-                    
+
                     const endpoint = parentId === 'root' ? 
                         '/me/drive/root/children' : 
                         `/me/drive/items/${parentId}/children`;
-                    
+
                     do {
                         const url = nextLink || endpoint;
                         const response = nextLink ? 
                             await this.makeApiCall(nextLink.replace(this.apiBase, '')) :
                             await this.makeApiCall(url);
-                        
+
                         const data = await response.json();
-                        
+
                         const folderItems = data.value
                             .filter(item => item.folder)
                             .map(folder => ({
@@ -1958,70 +1941,70 @@
                                 itemCount: folder.folder.childCount || 0,
                                 hasChildren: (folder.folder.childCount || 0) > 0
                             }));
-                        
+
                         folders.push(...folderItems);
                         nextLink = data['@odata.nextLink'];
-                        
+
                     } while (nextLink);
-                    
+
                     return folders.sort((a, b) => a.name.localeCompare(b.name));
-                    
+
                 } catch (error) {
                     console.warn('Failed to load folders:', error);
                     return [];
                 }
             }
-            
+
             async drillIntoFolder(folder) {
                 try {
                     this.breadcrumb.push({ id: folder.id, name: folder.name });
                     this.currentParentId = folder.id;
                     this.currentParentPath = this.breadcrumb.map(b => b.name).join(' / ');
-                    
+
                     return await this.loadFoldersInParent(folder.id);
                 } catch (error) {
                     console.warn('Failed to drill into folder:', error);
                     return [];
                 }
             }
-            
+
             async navigateToParent() {
                 if (this.breadcrumb.length <= 1) {
                     return await this.getFolders();
                 }
-                
+
                 this.breadcrumb.pop();
                 const parentFolder = this.breadcrumb[this.breadcrumb.length - 1];
-                
+
                 this.currentParentId = parentFolder.id;
                 this.currentParentPath = this.breadcrumb.map(b => b.name).join(' / ');
-                
+
                 return await this.loadFoldersInParent(parentFolder.id);
             }
-            
+
             getCurrentPath() {
                 return this.currentParentPath;
             }
-            
+
             canGoUp() {
                 return this.breadcrumb.length > 1;
             }
-            
+
             async getFiles(folderId = 'root') {
                 const allFiles = [];
                 let nextLink = null;
                 let endpoint = folderId === 'root' ? 
                     '/me/drive/root/children' : 
                     `/me/drive/items/${folderId}/children`;
-                
+
                 do {
                     const url = nextLink || endpoint;
                     const response = nextLink ? 
                         await this.makeApiCall(nextLink.replace(this.apiBase, '')) :
                         await this.makeApiCall(url);
-                    
+
                     const data = await response.json();
-                    
+
                     const files = data.value
                         .filter(item => item.file && item.file.mimeType && item.file.mimeType.startsWith('image/'))
                         .map(item => ({
@@ -2037,16 +2020,16 @@
                             } : null,
                             downloadUrl: item['@microsoft.graph.downloadUrl']
                         }));
-                    
+
                     allFiles.push(...files);
                     nextLink = data['@odata.nextLink'];
-                    
+
                     if (this.onProgressCallback) {
                         this.onProgressCallback(allFiles.length);
                     }
-                    
+
                 } while (nextLink);
-                
+
                 return { folders: [], files: allFiles };
             }
 
@@ -2063,14 +2046,14 @@
                 });
                 return true;
             }
-            
+
             async deleteFile(fileId) {
                 await this.makeApiCall(`/me/drive/items/${fileId}`, {
                     method: 'DELETE'
                 });
                 return true;
             }
-            
+
             async disconnect() {
                 this.isAuthenticated = false;
                 this.activeAccount = null;
@@ -2094,17 +2077,17 @@
                 this.cacheTimestamp = 0;
                 this.cacheExpiry = 5 * 60 * 1000; // 5 minutes
             }
-            
+
             async loadMetadata() {
                 try {
                     const now = Date.now();
                     if (this.cache.size > 0 && (now - this.cacheTimestamp) < this.cacheExpiry) {
                         return this.cache;
                     }
-                    
+
                     const response = await this.provider.makeApiCall('/me/drive/special/approot:/tags.json:/content');
                     const data = await response.json();
-                    
+
                     if (data && data.files) {
                         this.cache.clear();
                         Object.entries(data.files).forEach(([fileId, metadata]) => {
@@ -2112,7 +2095,7 @@
                         });
                         this.cacheTimestamp = now;
                     }
-                    
+
                     return this.cache;
                 } catch (error) {
                     if (error.message.includes('404')) {
@@ -2123,7 +2106,7 @@
                     return this.cache;
                 }
             }
-            
+
             async saveMetadata() {
                 try {
                     const data = {
@@ -2131,20 +2114,20 @@
                         lastModified: new Date().toISOString(),
                         files: Object.fromEntries(this.cache)
                     };
-                    
+
                     await this.provider.makeApiCall('/me/drive/special/approot:/tags.json:/content', {
                         method: 'PUT',
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify(data, null, 2)
                     });
-                    
+
                     this.cacheTimestamp = Date.now();
                 } catch (error) {
                     console.warn('Failed to save user metadata:', error);
                     throw error;
                 }
             }
-            
+
             getUserMetadata(fileId) {
                 return this.cache.get(fileId) || {
                     stack: 'in',
@@ -2155,18 +2138,18 @@
                     stackSequence: 0
                 };
             }
-            
+
             async setUserMetadata(fileId, metadata) {
                 const updated = {
                     ...metadata,
                     lastUpdated: new Date().toISOString()
                 };
-                
+
                 this.cache.set(fileId, updated);
                 await this.saveMetadata();
                 return updated;
             }
-            
+
             async updateUserMetadata(fileId, updates) {
                 const current = this.getUserMetadata(fileId);
                 const updated = { ...current, ...updates };
@@ -2178,17 +2161,17 @@
         class ExportSystem {
             // NOTE: The primary logic for fetching data has been moved to the new Live Export Process.
             // This class is now only responsible for formatting and downloading the final data.
-            
+
             async exportData(imagesWithMetadata) {
                 if (imagesWithMetadata.length === 0) {
                     utils.showToast('No images to export', 'info', true);
                     return;
                 }
-                
+
                 const csvData = this.formatForCSV(imagesWithMetadata);
                 this.downloadCSV(csvData);
             }
-            
+
             formatForCSV(images) {
                 const headers = [
                     'Filename', 'Direct Image URL', 'Prompt', 'Negative Prompt', 'Model', 
@@ -2196,7 +2179,7 @@
                     'Created Date', 'Modified Date', 'Tags', 'Notes', 
                     'Quality Rating', 'Content Rating', 'Provider', 'Metadata (JSON)'
                 ];
-                
+
                 const rows = images.map(image => {
                     const meta = image.extractedMetadata || {};
                     const dims = meta._dimensions || {};
@@ -2222,7 +2205,7 @@
                         JSON.stringify(meta)
                     ];
                 });
-                
+
                 return [headers, ...rows];
             }
 
@@ -2238,7 +2221,7 @@
                 }
                 return '';
             }
-            
+
             getDirectImageURL(image) {
                 if (appState.currentProviderType === 'googledrive') {
                     return `https://drive.google.com/uc?id=${image.id}&export=view`;
@@ -2247,7 +2230,7 @@
                 }
                 return '';
             }
-            
+
             formatFileSize(bytes) {
                 if (bytes === 0) return '0 Bytes';
                 const k = 1024;
@@ -2255,7 +2238,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             }
-            
+
             downloadCSV(data) {
                 const folderName = appState.currentFolder.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
                 const stackName = appState.grid.stack;
@@ -2265,10 +2248,10 @@
                 const csvContent = data.map(row => 
                     row.map(field => `"${String(field).replace(/"/g, '""')}"`).join(',')
                 ).join('\n');
-                
+
                 const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
                 const url = URL.createObjectURL(blob);
-                
+
                 const a = document.createElement('a');
                 a.href = url;
                 a.download = filename;
@@ -2276,7 +2259,7 @@
                 document.body.appendChild(a);
                 a.click();
                 document.body.removeChild(a);
-                
+
                 URL.revokeObjectURL(url);
             }
         }
@@ -2286,7 +2269,7 @@
             const urlParams = new URLSearchParams(window.location.search);
             const code = urlParams.get('code');
             const error = urlParams.get('error');
-            
+
             if (window.opener) {
                 if (error) {
                     window.opener.postMessage({ type: 'GOOGLE_AUTH_ERROR', error: error }, window.location.origin);
@@ -2309,7 +2292,7 @@
                     loadGoogleDriveFolders();
                 }
             },
-            
+
             async selectOneDrive() {
                 appState.currentProviderType = 'onedrive';
                 utils.showScreen('onedrive-auth-screen');
@@ -2325,7 +2308,7 @@
                     utils.elements.onedriveAuthStatus.textContent = 'Click to sign in with your Microsoft account';
                 }
             },
-            
+
             backToProviderSelection() {
                 appState.currentProvider = null;
                 appState.currentProviderType = null;
@@ -2340,50 +2323,50 @@
                 appState.currentProvider = providerInstance;
                 appState.currentFolder.id = folderId;
                 appState.currentFolder.name = folderName;
-                
+
                 await this.loadImages();
                 this.switchToCommonUI();
             },
-            
+
             async loadImages() {
                 utils.showScreen('loading-screen');
                 utils.updateLoadingProgress(0, 0);
-                
+
                 appState.currentProvider.onProgressCallback = (count) => {
                     utils.updateLoadingProgress(count, 0);
                 };
-                
+
                 try {
                     // Cloud-First: Always fetch, never trust cache for file list
                     utils.elements.loadingMessage.textContent = `Loading images from ${appState.currentProviderType}...`;
-                    
+
                     if (appState.currentProviderType === 'onedrive' && appState.currentProvider.metadataManager) {
                         await appState.currentProvider.metadataManager.loadMetadata();
                     }
-                    
+
                     const result = await appState.currentProvider.getFiles(appState.currentFolder.id);
                     const files = result.files || [];
-                    
+
                     if (files.length === 0) {
                         utils.showToast('No images found in this folder', 'info', true);
                         this.returnToFolderSelection();
                         return;
                     }
-                    
+
                     utils.updateLoadingProgress(files.length, files.length);
                     utils.elements.loadingMessage.textContent = 'Processing files...';
-                    
+
                     appState.imageFiles = files.map(file => this.processFileWithProviderMetadata(file));
-                    
+
                     const pngCount = files.filter(f => f.mimeType === 'image/png').length;
-                    
+
                     if (pngCount > 0) {
                         this.extractMetadataInBackground(appState.imageFiles.filter(f => f.mimeType === 'image/png'));
                     }
-                    
+
                     commonFunctions.initializeStacks();
                     commonFunctions.initializeImageDisplay();
-                    
+
                 } catch (error) {
                     utils.showToast(`Error loading images: ${error.message}`, 'error', true);
                     this.returnToFolderSelection();
@@ -2393,10 +2376,10 @@
                     }
                 }
             },
-            
+
             processFileWithProviderMetadata(file) {
                 let userMetadata;
-                
+
                 if (appState.currentProviderType === 'googledrive') {
                     userMetadata = {
                         stack: file.appProperties?.slideboxStack || 'in',
@@ -2411,7 +2394,7 @@
                         appState.currentProvider.metadataManager.getUserMetadata(file.id) :
                         { stack: 'in', tags: [], qualityRating: 0, contentRating: 0, notes: '', stackSequence: 0 };
                 }
-                
+
                 return {
                     id: file.id,
                     name: file.name,
@@ -2425,7 +2408,7 @@
                     downloadUrl: file.downloadUrl,
                     extractedMetadata: {},
                     metadataStatus: 'pending',
-                    
+
                     stack: userMetadata.stack || 'in',
                     tags: userMetadata.tags || [],
                     qualityRating: userMetadata.qualityRating || 0,
@@ -2434,19 +2417,19 @@
                     stackSequence: userMetadata.stackSequence || 0
                 };
             },
-            
+
             switchToCommonUI() {
                 utils.showScreen('app-container');
                 this.setupProviderAwareNavigation();
             },
-            
+
             setupProviderAwareNavigation() {
                 utils.elements.backButton.textContent = '← Folders';
                 utils.elements.backButton.onclick = () => this.returnToFolderSelection();
-                
+
                 this.setupFolderTooltips();
             },
-            
+
             setupFolderTooltips() {
                 utils.elements.backButton.addEventListener('mouseenter', () => {
                     const folderName = appState.currentFolder.name || 'Unknown';
@@ -2454,35 +2437,35 @@
                     const provider = appState.currentProviderType === 'googledrive' ? 'Google Drive' : 'OneDrive';
                     this.showTooltip(utils.elements.backButton, `${provider}: ${folderName} • ${imageCount} images`);
                 });
-                
+
                 utils.elements.backButton.addEventListener('mouseleave', this.hideTooltip);
             },
-            
+
             showTooltip(element, text) {
                 const existingTooltip = document.querySelector('.folder-tooltip');
                 if (existingTooltip) existingTooltip.remove();
-                
+
                 const tooltip = document.createElement('div');
                 tooltip.className = 'folder-tooltip';
                 tooltip.textContent = text;
-                
+
                 document.body.appendChild(tooltip);
-                
+
                 const rect = element.getBoundingClientRect();
                 tooltip.style.left = `${rect.left}px`;
                 tooltip.style.top = `${rect.bottom + 8}px`;
-                
+
                 const tooltipRect = tooltip.getBoundingClientRect();
                 if (tooltipRect.right > window.innerWidth) {
                     tooltip.style.left = `${window.innerWidth - tooltipRect.width - 10}px`;
                 }
             },
-            
+
             hideTooltip() {
                 const tooltip = document.querySelector('.folder-tooltip');
                 if (tooltip) tooltip.remove();
             },
-            
+
             returnToFolderSelection() {
                 if (appState.currentProviderType === 'googledrive') {
                     utils.showScreen('gdrive-folder-screen');
@@ -2490,29 +2473,29 @@
                     utils.showScreen('onedrive-folder-screen');
                 }
             },
-            
+
             async moveFileToStack(fileId, targetStack, sequence) {
                 const file = appState.imageFiles.find(f => f.id === fileId);
                 if (!file) throw new Error('File not found');
-                
+
                 file.stack = targetStack;
                 file.stackSequence = sequence;
-                
+
                 if (appState.currentProviderType === 'googledrive') {
                     await appState.currentProvider.moveFileToStack(fileId, targetStack, sequence);
                 } else {
                     await appState.currentProvider.metadataManager.updateUserMetadata(fileId, { stack: targetStack, stackSequence: sequence });
                 }
-                
+
                 return file;
             },
-            
+
             async updateUserMetadata(fileId, updates) {
                 const file = appState.imageFiles.find(f => f.id === fileId);
                 if (!file) throw new Error('File not found');
-                
+
                 Object.assign(file, updates);
-                
+
                 if (appState.currentProviderType === 'googledrive') {
                     const properties = {};
                     if (updates.stack) properties.slideboxStack = updates.stack;
@@ -2521,64 +2504,64 @@
                     if (updates.contentRating !== undefined) properties.contentRating = updates.contentRating.toString();
                     if (updates.notes !== undefined) properties.notes = updates.notes;
                     if (updates.stackSequence !== undefined) properties.stackSequence = updates.stackSequence.toString();
-                    
+
                     await appState.currentProvider.updateFileProperties(fileId, properties);
                 } else {
                     await appState.currentProvider.metadataManager.updateUserMetadata(fileId, updates);
                 }
             },
-            
+
             async deleteFile(fileId) {
                 return await appState.currentProvider.deleteFile(fileId);
             },
-            
+
             async extractMetadataInBackground(pngFiles) {
                 const BATCH_SIZE = 5;
-                
+
                 for (let i = 0; i < pngFiles.length; i += BATCH_SIZE) {
                     const batch = pngFiles.slice(i, i + BATCH_SIZE);
                     const batchPromises = batch.map(file => this.processFileMetadata(file));
-                    
+
                     try {
                         await Promise.allSettled(batchPromises);
                         // This data is volatile and just for the "Details" view, so we don't cache the whole file list here.
-                        
+
                         if (i + BATCH_SIZE < pngFiles.length) {
                             await new Promise(resolve => setTimeout(resolve, 100)); // Increased delay
                         }
-                        
+
                     } catch (error) {
                         console.warn('Batch processing error:', error);
                     }
                 }
             },
-            
+
             async processFileMetadata(file) {
                 if (file.metadataStatus === 'loaded' || file.metadataStatus === 'loading') return;
-                
+
                 file.metadataStatus = 'loading';
-                
+
                 const cachedMetadata = await appState.fileCache.getMetadata(file.id);
                 if (cachedMetadata) {
                     file.extractedMetadata = cachedMetadata;
                     file.metadataStatus = 'loaded';
                     return;
                 }
-                
+
                 // This is a "best effort" background process. The robust logic is in the Live Export.
                 try {
                     const metadata = await appState.metadataExtractor.fetchMetadata(file);
-                    
+
                     if (metadata.error) {
                         throw new Error(metadata.error);
                     }
-                    
+
                     if (Object.keys(metadata).length > 0) {
                         file.extractedMetadata = metadata;
                         await appState.fileCache.setMetadata(file.id, metadata);
                     }
                     file.metadataStatus = 'loaded';
-                    
+
                 } catch (error) {
                     // Fail silently. The Live Export process is the source of truth.
                     console.warn(`Background metadata extraction failed for ${file.name}: ${error.message}`);
@@ -2591,7 +2574,7 @@
         const commonFunctions = {
             initializeStacks() {
                 STACK_TYPES.forEach(stack => { appState.stacks[stack] = []; });
-                
+
                 appState.imageFiles.forEach(file => {
                     const stack = file.stack || 'in';
                     if (STACK_TYPES.includes(stack)) {
@@ -2600,11 +2583,11 @@
                         appState.stacks.in.push(file);
                     }
                 });
-                
+
                 STACK_TYPES.forEach(stack => {
                     appState.stacks[stack] = this.sortFiles(appState.stacks[stack]);
                 });
-                
+
                 this.updateStackCounts();
             },
 
@@ -2615,7 +2598,7 @@
                 });
 
                 STACK_TYPES.forEach(stack => { appState.stacks[stack] = []; });
-                
+
                 appState.imageFiles.forEach(file => {
                     if (appState.stacks[file.stack]) {
                         appState.stacks[file.stack].push(file);
@@ -2628,7 +2611,7 @@
                     appState.stacks[s] = this.sortFiles(appState.stacks[s]);
                 });
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -2639,7 +2622,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACK_TYPES.forEach(stack => {
                     const count = appState.stacks[stack].length;
@@ -2650,26 +2633,26 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 appState.currentImageIndex = 0;
                 appState.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 if (appState.stacks[stackName].length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 utils.elements.emptyState.classList.add('hidden');
                 const topImage = appState.stacks[stackName][0];
                 const imageIndex = appState.imageFiles.findIndex(f => f.id === topImage.id);
-                
+
                 if (imageIndex !== -1) {
                     appState.currentImageIndex = imageIndex;
                     appState.currentStack = stackName;
@@ -2679,13 +2662,13 @@
                     this.showEmptyState();
                 }
             },
-            
+
             async displayCurrentImage() {
                 if (appState.imageFiles.length === 0 || appState.currentImageIndex === -1) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 const currentFile = appState.imageFiles[appState.currentImageIndex];
                 if (!currentFile) {
                     this.showEmptyState();
@@ -2693,14 +2676,8 @@
                 }
 
                 utils.elements.detailsButton.style.display = 'flex'; // FIX: Show details button
-                
+
                 await utils.setImageSrc(utils.elements.centerImage, currentFile);
-                
-                const folderName = appState.currentFolder.name;
-                const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${currentFile.name.replace(/\.[^/.]+$/, "")}`;
-                utils.elements.filenameOverlay.href = appState.exportSystem.getDirectImageURL(currentFile);
-                utils.elements.filenameOverlay.classList.add('visible');
 
                 appState.currentScale = 1;
                 appState.panOffset = { x: 0, y: 0 };
@@ -2709,34 +2686,34 @@
                 if (currentFile.metadataStatus === 'pending') {
                     masterController.processFileMetadata(currentFile);
                 }
-                
+
                 if (appState.isFocusMode) {
                     focusMode.updateUI();
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${appState.currentScale}) translate(${appState.panOffset.x}px, ${appState.panOffset.y}px)`;
                 utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACK_TYPES.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${appState.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack) {
                 const currentImage = appState.imageFiles[appState.currentImageIndex];
                 if (!currentImage) return;
                 const currentStackName = currentImage.stack;
-        
+
                 let newSequence;
-        
+
                 if (currentStackName === targetStack) {
                     // FIX: When moving to the same stack, send to back by giving it the OLDEST timestamp.
                     const currentStackArray = appState.stacks[currentStackName];
@@ -2747,7 +2724,7 @@
                     } else {
                         newSequence = Date.now(); // Only image in stack, timestamp doesn't matter as much.
                     }
-        
+
                     const index = currentStackArray.findIndex(img => img.id === currentImage.id);
                     if (index > -1) {
                         const [item] = currentStackArray.splice(index, 1);
@@ -2766,23 +2743,23 @@
                     appState.stacks[targetStack].unshift(currentImage);
                     await masterController.moveFileToStack(currentImage.id, targetStack, newSequence);
                 }
-                
+
                 // The sort will now work correctly for both cases.
                 appState.stacks[targetStack] = this.sortFiles(appState.stacks[targetStack]);
                 if (currentStackName !== targetStack) {
                      appState.stacks[currentStackName] = this.sortFiles(appState.stacks[currentStackName]);
                 }
-        
+
                 this.updateStackCounts();
                 this.updateActiveProxTab();
-                
+
                 if (appState.stacks[appState.currentStack].length > 0) {
                     this.moveToNextImage();
                 } else {
                     this.showEmptyState();
                 }
             },
-            
+
             async moveToNextImage() {
                 const activeStackImages = appState.stacks[appState.currentStack];
                 if (activeStackImages.length > 0) {
@@ -2798,12 +2775,11 @@
                     this.showEmptyState();
                 }
             },
-            
+
             showEmptyState() {
                 appState.currentImageIndex = -1;
                 appState.currentImageLoadId = null;
                 utils.elements.centerImage.style.opacity = '0';
-                utils.elements.filenameOverlay.classList.remove('visible');
                 utils.elements.detailsButton.style.display = 'none'; // FIX: Hide details button
                 setTimeout(() => {
                     utils.elements.centerImage.src = '';
@@ -2821,7 +2797,7 @@
                 utils.showModal('grid-modal');
                 utils.elements.gridTitle.textContent = STACK_NAMES[stack] || stack;
                 appState.grid.stack = stack;
-                
+
                 // Reset states
                 appState.grid.selected = [];
                 appState.grid.filtered = [];
@@ -2831,7 +2807,7 @@
                 this.updateSelectionUI();
                 commonFunctions.updateStackCounts();
             },
-            
+
             close() {
                 utils.hideModal('grid-modal');
                 this.resetSearch();
@@ -2848,7 +2824,7 @@
                 } else {
                     commonFunctions.displayTopImageFromStack(appState.currentStack);
                 }
-                
+
                 appState.grid.stack = null;
                 appState.grid.selected = [];
             },
@@ -2869,7 +2845,7 @@
 
                 // Setup IntersectionObserver
                 if (state.observer) state.observer.disconnect();
-                
+
                 state.observer = new IntersectionObserver(this.handleIntersection.bind(this), { 
                     root: utils.elements.gridContent, 
                     rootMargin: "400px" // Pre-fetch images 400px before they are visible
@@ -2907,11 +2883,11 @@
                     const div = document.createElement('div');
                     div.className = 'grid-item';
                     div.dataset.fileId = file.id;
-                    
+
                     if (appState.grid.selected.includes(file.id)) {
                         div.classList.add('selected');
                     }
-                    
+
                     const img = document.createElement('img');
                     img.className = 'grid-image';
                     img.alt = file.name || 'Image';
@@ -2922,9 +2898,9 @@
                         img.src = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="150" height="150" viewBox="0 0 150 150" fill="none"%3E%3Crect width="150" height="150" fill="%23E5E7EB"/%3E%3Cpath d="M65 60H85V90H65V60Z" fill="%239CA3AF"/%3E%3Ccircle cx="75" cy="45" r="10" fill="%239CA3AF"/%3E%3C/svg%3E';
                         img.classList.add('loaded');
                     };
-                    
+
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    
+
                     div.appendChild(img);
                     container.appendChild(div);
                 });
@@ -2946,11 +2922,11 @@
                     }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = appState.grid.selected.indexOf(fileId);
-                
+
                 if (index === -1) {
                     appState.grid.selected.push(fileId);
                     gridItem.classList.add('selected');
@@ -2958,33 +2934,33 @@
                     appState.grid.selected.splice(index, 1);
                     gridItem.classList.remove('selected');
                 }
-                
+
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = appState.grid.selected.length;
                 const buttons = [utils.elements.tagSelected, utils.elements.moveSelected, utils.elements.deleteSelected, 
                                utils.elements.exportSelected, utils.elements.folderSelected];
-                
+
                 utils.elements.selectionText.textContent = `${count} selected`;
-                
+
                 buttons.forEach(btn => {
                     if (btn) btn.disabled = (count === 0);
                 });
             },
-            
+
             selectAll() {
                 const filesToSelect = appState.grid.lazyLoadState.allFiles;
                 appState.grid.selected = filesToSelect.map(f => f.id);
-                
+
                 document.querySelectorAll('#grid-container .grid-item').forEach(item => {
                     item.classList.add('selected');
                 });
-                
+
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item').forEach(item => 
                     item.classList.remove('selected')
@@ -2992,19 +2968,19 @@
                 appState.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = utils.elements.omniSearch.value.trim();
                 appState.grid.selected = [];
-                
+
                 if (!query) {
                     this.resetSearch();
                     return;
                 }
-                
+
                 appState.grid.filtered = this.searchImages(query);
                 appState.grid.selected = appState.grid.filtered.map(f => f.id);
-                
+
                 utils.elements.gridContainer.innerHTML = '';
                 this.initializeLazyLoad(appState.grid.stack);
                 this.updateSelectionUI();
@@ -3017,7 +2993,7 @@
                 this.initializeLazyLoad(appState.grid.stack);
                 commonFunctions.updateStackCounts();
             },
-            
+
             searchImages(query) {
                 const pattern = query
                     .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -3032,7 +3008,7 @@
                         file.notes || '',
                         JSON.stringify(file.extractedMetadata || {})
                     ].join(' ');
-                    
+
                     return regex.test(searchableText);
                 });
             }
@@ -3041,7 +3017,7 @@
         // ===== Details Modal =====
         const detailsModal = {
             currentTab: 'info',
-            
+
             async show() {
                 const currentFile = appState.imageFiles[appState.currentImageIndex];
                 if (!currentFile) return;
@@ -3050,59 +3026,59 @@
                     this.populateMetadataTab(currentFile);
                     await masterController.processFileMetadata(currentFile);
                 }
-                
+
                 this.populateAllTabs(currentFile);
                 utils.showModal('details-modal');
                 this.switchTab('info');
             },
-            
+
             hide() {
                 utils.hideModal('details-modal');
             },
-            
+
             switchTab(tabName) {
                 document.querySelectorAll('.tab-button').forEach(btn => {
                     btn.classList.toggle('active', btn.dataset.tab === tabName);
                 });
-                
+
                 document.querySelectorAll('.tab-content').forEach(content => {
                     content.classList.toggle('active', content.id === `tab-${tabName}`);
                 });
-                
+
                 this.currentTab = tabName;
             },
-            
+
             populateAllTabs(file) {
                 this.populateInfoTab(file);
                 this.populateTagsTab(file);
                 this.populateNotesTab(file);
                 this.populateMetadataTab(file);
             },
-            
+
             populateInfoTab(file) {
                 const filename = file.name || 'Unknown';
                 utils.elements.detailFilename.textContent = filename;
-                
+
                 if (appState.currentProviderType === 'googledrive') {
                     utils.elements.detailFilenameLink.href = `https://drive.google.com/file/d/${file.id}/view`;
                 } else {
                     utils.elements.detailFilenameLink.href = file.downloadUrl || '#';
                 }
                 utils.elements.detailFilenameLink.style.display = 'inline';
-                
+
                 const date = file.modifiedTime ? new Date(file.modifiedTime).toLocaleString() : 
                            file.createdTime ? new Date(file.createdTime).toLocaleString() : 'Unknown';
                 utils.elements.detailDate.textContent = date;
-                
+
                 const size = file.size ? utils.formatFileSize(file.size) : 'Unknown';
                 utils.elements.detailSize.textContent = size;
             },
-            
+
             populateTagsTab(file) {
                 const tags = file.tags || [];
-                
+
                 utils.elements.detailTags.innerHTML = '';
-                
+
                 tags.forEach(tag => {
                     const tagElement = document.createElement('div');
                     tagElement.className = 'tag-item';
@@ -3112,13 +3088,13 @@
                     `;
                     utils.elements.detailTags.appendChild(tagElement);
                 });
-                
+
                 const addButton = document.createElement('div');
                 addButton.className = 'add-tag-btn';
                 addButton.textContent = '+ Add Tag';
                 addButton.addEventListener('click', () => this.showAddTagInput());
                 utils.elements.detailTags.appendChild(addButton);
-                
+
                 utils.elements.detailTags.querySelectorAll('.tag-remove').forEach(btn => {
                     btn.addEventListener('click', (e) => {
                         const tagToRemove = e.target.dataset.tag;
@@ -3126,18 +3102,18 @@
                     });
                 });
             },
-            
+
             showAddTagInput() {
                 const input = document.createElement('input');
                 input.type = 'text';
                 input.className = 'tag-input';
                 input.placeholder = 'Enter tag name';
                 input.style.marginLeft = '8px';
-                
+
                 const addButton = utils.elements.detailTags.querySelector('.add-tag-btn');
                 addButton.parentNode.insertBefore(input, addButton);
                 input.focus();
-                
+
                 input.addEventListener('keydown', async (e) => {
                     if (e.key === 'Enter') {
                         const tagName = input.value.trim();
@@ -3146,10 +3122,10 @@
                             try {
                                 const currentTags = currentFile.tags || [];
                                 const newTags = [...new Set([...currentTags, tagName])];
-                                
+
                                 await masterController.updateUserMetadata(currentFile.id, { tags: newTags });
                                 appState.tags.add(tagName);
-                                
+
                                 this.populateTagsTab(currentFile);
                                 input.remove();
                             } catch (error) {
@@ -3160,31 +3136,31 @@
                         input.remove();
                     }
                 });
-                
+
                 input.addEventListener('blur', () => {
                     setTimeout(() => input.remove(), 100);
                 });
             },
-            
+
             async removeTag(file, tagToRemove) {
                 try {
                     const currentTags = file.tags || [];
                     const newTags = currentTags.filter(tag => tag !== tagToRemove);
-                    
+
                     await masterController.updateUserMetadata(file.id, { tags: newTags });
                     this.populateTagsTab(file);
                 } catch (error) {
                     utils.showToast('Failed to remove tag', 'error', true);
                 }
             },
-            
+
             populateNotesTab(file) {
                 utils.elements.detailNotes.value = file.notes || '';
-                
+
                 const newNotesTextarea = utils.elements.detailNotes.cloneNode(true);
                 utils.elements.detailNotes.parentNode.replaceChild(newNotesTextarea, utils.elements.detailNotes);
                 utils.elements.detailNotes = newNotesTextarea;
-                
+
                 utils.elements.detailNotes.addEventListener('blur', async () => {
                     const currentFile = appState.imageFiles[appState.currentImageIndex];
                     if (currentFile.notes !== utils.elements.detailNotes.value) {
@@ -3195,26 +3171,26 @@
                         }
                     }
                 });
-                
+
                 this.setupStarRating('quality', file.qualityRating || 0);
                 this.setupStarRating('content', file.contentRating || 0);
             },
-            
+
             setupStarRating(type, currentRating) {
                 const container = utils.elements[`${type}Rating`];
                 if (!container) return;
-        
+
                 let rating = currentRating;
                 const stars = container.querySelectorAll('.star');
-        
+
                 const updateVisuals = (r) => {
                     stars.forEach((star, index) => {
                         star.classList.toggle('active', index < r);
                     });
                 };
-        
+
                 container.onmouseleave = () => updateVisuals(rating);
-        
+
                 stars.forEach((star, index) => {
                     star.onmouseenter = () => updateVisuals(index + 1);
                     star.onclick = async () => {
@@ -3225,17 +3201,17 @@
                             rating = newRating;
                         }
                         updateVisuals(rating);
-        
+
                         const currentFile = appState.imageFiles[appState.currentImageIndex];
                         if (!currentFile) return;
-        
+
                         const updatePayload = {};
                         if (type === 'quality') {
                             updatePayload.qualityRating = rating;
                         } else {
                             updatePayload.contentRating = rating;
                         }
-        
+
                         try {
                             await masterController.updateUserMetadata(currentFile.id, updatePayload);
                         } catch (error) {
@@ -3245,39 +3221,39 @@
                         }
                     };
                 });
-        
+
                 updateVisuals(rating);
             },
-            
+
             populateMetadataTab(file) {
                 utils.elements.metadataTable.innerHTML = '';
-                
+
                 if (file.metadataStatus !== 'loaded') {
                     utils.elements.metadataTable.innerHTML = `<tr><td colspan="2" style="text-align:center; padding: 20px;"><div class="spinner" style="margin: 0 auto;"></div></td></tr>`;
                     return;
                 }
 
                 const metadata = file.extractedMetadata || {};
-                
+
                 if (Object.keys(metadata).length === 0) {
                     this.addMetadataRow('Status', 'No embedded metadata found', false);
                     return;
                 }
-                
+
                 const priorityFields = ['prompt', 'Prompt', 'model', 'Model', 'seed', 'Seed', 'negative_prompt', 'Negative_Prompt', 'steps', 'Steps', 'cfg_scale', 'CFG_Scale', 'sampler', 'Sampler', 'scheduler', 'Scheduler', 'api_call', 'API_Call'];
-                
+
                 priorityFields.forEach(field => {
                     if (metadata[field]) {
                         this.addMetadataRow(field, metadata[field], true);
                     }
                 });
-                
+
                 const remainingFields = Object.entries(metadata).filter(([key, value]) => 
                     !priorityFields.includes(key) && 
                     !priorityFields.includes(key.toLowerCase()) && 
                     value
                 );
-                
+
                 if (priorityFields.some(field => metadata[field]) && remainingFields.length > 0) {
                     const separatorRow = document.createElement('tr');
                     separatorRow.innerHTML = `
@@ -3287,11 +3263,11 @@
                     `;
                     utils.elements.metadataTable.appendChild(separatorRow);
                 }
-                
+
                 remainingFields.forEach(([key, value]) => {
                     this.addMetadataRow(key, value, false);
                 });
-                
+
                 if (Object.keys(metadata).length > 0) {
                     const separatorRow = document.createElement('tr');
                     separatorRow.innerHTML = `
@@ -3301,7 +3277,7 @@
                     `;
                     utils.elements.metadataTable.appendChild(separatorRow);
                 }
-                
+
                 this.addMetadataRow('File Name', file.name || 'Unknown', false);
                 this.addMetadataRow('File Size', file.size ? utils.formatFileSize(file.size) : 'Unknown', false);
                 this.addMetadataRow('MIME Type', file.mimeType || 'Unknown', false);
@@ -3309,14 +3285,14 @@
                 this.addMetadataRow('Modified', file.modifiedTime ? new Date(file.modifiedTime).toLocaleString() : 'Unknown', false);
                 this.addMetadataRow('Provider', appState.currentProviderType === 'googledrive' ? 'Google Drive' : 'OneDrive', false);
             },
-            
+
             addMetadataRow(key, value, needsCopyButton = false) {
                 const row = document.createElement('tr');
-                
+
                 const formattedKey = key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
-                
+
                 let formattedValue = String(value);
-                
+
                 if (formattedValue.length > 200) {
                     formattedValue = formattedValue
                         .replace(/,\s+/g, ',\n')
@@ -3326,23 +3302,23 @@
                 } else if (formattedValue.length > 100) {
                     formattedValue = formattedValue.replace(/\s+/g, ' ').trim();
                 }
-                
+
                 const keyCell = document.createElement('td');
                 keyCell.className = 'key-cell';
                 keyCell.textContent = formattedKey;
-                
+
                 const valueCell = document.createElement('td');
                 valueCell.className = 'value-cell';
-                
+
                 if (formattedValue.length > 500) {
                     valueCell.style.maxHeight = '120px';
                     valueCell.style.overflowY = 'auto';
                     valueCell.style.fontSize = '12px';
                     valueCell.style.lineHeight = '1.4';
                 }
-                
+
                 valueCell.textContent = formattedValue;
-                
+
                 if (needsCopyButton) {
                     const copyButton = document.createElement('button');
                     copyButton.className = 'copy-button copy-metadata';
@@ -3351,12 +3327,12 @@
                     copyButton.title = `Copy ${formattedKey} to clipboard`;
                     valueCell.appendChild(copyButton);
                 }
-                
+
                 row.appendChild(keyCell);
                 row.appendChild(valueCell);
                 utils.elements.metadataTable.appendChild(row);
             },
-            
+
             copyToClipboard(text) {
                 navigator.clipboard.writeText(text).then(() => {
                     utils.showToast('📋 Copied to clipboard', 'success', true);
@@ -3381,11 +3357,11 @@
         // ===== Unified Modal Manager =====
         const modalManager = {
             currentAction: null,
-            
+
             show(type, options = {}) {
                 this.currentAction = type;
                 const { title, content, confirmText = 'Confirm', confirmClass = 'btn-primary' } = options;
-                
+
                 utils.elements.actionTitle.textContent = title || 'Action';
                 utils.elements.actionContent.innerHTML = content || '';
                 utils.elements.actionConfirm.textContent = confirmText;
@@ -3395,12 +3371,12 @@
 
                 utils.showModal('action-modal');
             },
-            
+
             hide() {
                 utils.hideModal('action-modal');
                 this.currentAction = null;
             },
-            
+
             setupMoveAction() {
                 this.show('move', {
                     title: 'Move to Stack',
@@ -3413,7 +3389,7 @@
                     `,
                     confirmText: 'Cancel'
                 });
-                
+
                 document.querySelectorAll('.move-option').forEach(option => {
                     option.addEventListener('click', () => {
                         const targetStack = option.dataset.stack;
@@ -3421,7 +3397,7 @@
                     });
                 });
             },
-            
+
             setupTagAction() {
                 this.show('tag', {
                     title: 'Add Tags',
@@ -3438,7 +3414,7 @@
                     `,
                     confirmText: 'Apply'
                 });
-                
+
                 document.querySelectorAll('.tag-suggestion').forEach(btn => {
                     btn.addEventListener('click', () => {
                         const input = document.getElementById('modal-tag-input');
@@ -3446,12 +3422,12 @@
                     });
                 });
             },
-            
+
             setupDeleteAction() {
                 const selectedCount = appState.grid.selected.length;
                 const providerName = appState.currentProviderType === 'googledrive' ? 'Google Drive' : 'OneDrive';
                 const message = `Are you sure you want to move ${selectedCount} image(s) to your ${providerName} trash? This can be recovered from the provider's website.`;
-                
+
                 this.show('delete', {
                     title: 'Confirm Delete',
                     content: `<p style="color: #4b5563; margin-bottom: 16px;">${message}</p>`,
@@ -3459,7 +3435,7 @@
                     confirmClass: 'btn-danger'
                 });
             },
-            
+
             setupExportAction() {
                 this.show('export', {
                     title: 'Export to Spreadsheet',
@@ -3502,7 +3478,7 @@
                     });
                 });
             },
-            
+
             setupFolderMoveAction() {
                 this.show('folder-move', {
                     title: 'Move to Different Folder',
@@ -3518,7 +3494,7 @@
                     confirmText: 'Choose Destination Folder'
                 });
             },
-            
+
             async executeBulkAction(actionFn, successMessage) {
                 const confirmBtn = utils.elements.actionConfirm;
                 const originalText = confirmBtn.textContent;
@@ -3531,13 +3507,13 @@
 
                     utils.showToast(successMessage.replace('{count}', promises.length), 'success', true);
                     this.hide();
-                    
+
                     // Refresh grid view
                     gridView.destroyLazyLoad();
                     gridView.initializeLazyLoad(appState.grid.stack);
                     appState.grid.selected = [];
                     gridView.updateSelectionUI();
-                    
+
                     commonFunctions.updateStackCounts();
                 } catch (error) {
                     utils.showToast(`Failed to process some images: ${error.message}`, 'error', true);
@@ -3554,12 +3530,12 @@
                         const currentStack = file.stack;
                         const newSequence = Date.now();
                         await masterController.moveFileToStack(fileId, targetStack, newSequence);
-                        
+
                         const currentStackIndex = appState.stacks[currentStack].findIndex(f => f.id === fileId);
                         if (currentStackIndex !== -1) {
                             appState.stacks[currentStack].splice(currentStackIndex, 1);
                         }
-                        
+
                         file.stackSequence = newSequence;
                         appState.stacks[targetStack].unshift(file);
                         appState.stacks[targetStack] = commonFunctions.sortFiles(appState.stacks[targetStack]);
@@ -3586,7 +3562,7 @@
             async executeDelete() {
                 await this.executeBulkAction(async (fileId) => {
                     await masterController.deleteFile(fileId);
-                    
+
                     // Remove from local state
                     const fileIndex = appState.imageFiles.findIndex(f => f.id === fileId);
                     if (fileIndex > -1) {
@@ -3598,7 +3574,7 @@
                     }
                 }, `Moved {count} images to provider trash`);
             },
-            
+
             // ===== NEW: LIVE EXPORT PROCESS =====
             async executeExport() {
                 const fileIds = [...appState.grid.selected];
@@ -3606,7 +3582,7 @@
                 const total = filesToExport.length;
                 const results = [];
                 let failures = 0;
-                
+
                 // 1. Setup the new UI in the modal
                 utils.elements.actionTitle.textContent = `Live Export: 0 of ${total}`;
                 utils.elements.actionContent.innerHTML = `
@@ -3615,29 +3591,29 @@
                 const logEl = document.getElementById('export-log');
                 utils.elements.actionConfirm.disabled = true;
                 utils.elements.actionCancel.textContent = "Close";
-                
+
                 const log = (message) => {
                     logEl.textContent += message + '\n';
                     logEl.scrollTop = logEl.scrollHeight;
                 };
-                
+
                 log(`Starting export for ${total} images...`);
-                
+
                 // 2. Process each file sequentially with retries
                 for (let i = 0; i < filesToExport.length; i++) {
                     const file = filesToExport[i];
                     utils.elements.actionTitle.textContent = `Live Export: ${i + 1} of ${total}`;
                     log(`\n[${i+1}/${total}] Processing: ${file.name}`);
-                    
+
                     let extractedMetadata = {};
                     let success = false;
-                    
+
                     for (let attempt = 1; attempt <= 3; attempt++) {
                         try {
                             // This is a fresh, live fetch direct from the cloud
                             const metadata = await appState.metadataExtractor.fetchMetadata(file, true);
                             if (metadata.error) throw new Error(metadata.error);
-                            
+
                             extractedMetadata = metadata;
                             log(`  ✅ Success`);
                             success = true;
@@ -3654,37 +3630,37 @@
                             }
                         }
                     }
-                    
+
                     results.push({
                         ...file,
                         extractedMetadata: extractedMetadata
                     });
                 }
-                
+
                 // 3. Finalize and download
                 log('\n-------------------------------------');
                 log('Export process complete.');
                 log(`Successfully processed: ${total - failures} files.`);
                 log(`Failed: ${failures} files.`);
-                
+
                 if (results.length > 0) {
                     appState.exportSystem.exportData(results);
                     log('CSV file has been generated and downloaded.');
                 } else {
                     log('No data to export.');
                 }
-                
+
                 utils.elements.actionTitle.textContent = `Export Complete`;
                 utils.elements.actionConfirm.disabled = true;
                 utils.elements.actionCancel.textContent = "Close";
             },
-            
+
             executeFolderMove() {
                 appState.folderMoveMode = {
                     active: true,
                     files: [...appState.grid.selected],
                 };
-                
+
                 this.hide();
                 gridView.close();
                 masterController.returnToFolderSelection();
@@ -3696,28 +3672,28 @@
         function updateEmptyStateButtons() {
             const stacksWithImages = STACK_TYPES.filter(stack => appState.stacks[stack].length > 0);
             const hasOtherStacks = stacksWithImages.some(stack => stack !== appState.currentStack);
-            
+
             utils.elements.selectAnotherStackBtn.style.display = hasOtherStacks ? 'block' : 'none';
             utils.elements.selectAnotherFolderBtn.style.display = 'block';
         }
-        
+
         function acknowledgePillCounter(stackName) {
             const pill = document.getElementById(`pill-${stackName}`);
             if (pill) {
                 pill.classList.remove('triple-ripple', 'glow-effect');
                 pill.offsetHeight;
                 pill.classList.add('triple-ripple');
-                
+
                 setTimeout(() => {
                     pill.classList.add('glow-effect');
                 }, 100);
-                
+
                 setTimeout(() => {
                     pill.classList.remove('triple-ripple', 'glow-effect');
                 }, 3000);
             }
         }
-        
+
         // ===== Gesture System =====
         function setupGestureSystem() {
             let startPos = { x: 0, y: 0 };
@@ -3726,18 +3702,18 @@
             let lastTapTime = 0; // For double tap detection
 
             const edgeElements = [utils.elements.edgeTop, utils.elements.edgeBottom, utils.elements.edgeLeft, utils.elements.edgeRight];
-            
+
             function showEdgeGlow(direction) {
                 edgeElements.forEach(edge => edge.classList.remove('active'));
                 if (utils.elements[`edge${direction.charAt(0).toUpperCase() + direction.slice(1)}`]) {
                     utils.elements[`edge${direction.charAt(0).toUpperCase() + direction.slice(1)}`].classList.add('active');
                 }
             }
-            
+
             function hideAllEdgeGlows() {
                 edgeElements.forEach(edge => edge.classList.remove('active'));
             }
-            
+
             function determineSwipeDirection(deltaX, deltaY) {
                 if (Math.abs(deltaX) > Math.abs(deltaY)) {
                     return deltaX > 0 ? 'right' : 'left';
@@ -3745,7 +3721,7 @@
                     return deltaY > 0 ? 'bottom' : 'top';
                 }
             }
-            
+
             function directionToStack(direction) {
                 const mapping = {
                     'top': 'priority',
@@ -3755,18 +3731,18 @@
                 };
                 return mapping[direction];
             }
-            
+
             async function executeFlick(targetStack) {
                 if (appState.currentImageIndex === -1) return;
                 const currentImage = appState.imageFiles[appState.currentImageIndex];
                 if (!currentImage) return;
 
                 acknowledgePillCounter(targetStack);
-                
+
                 if (appState.hapticManager) {
                     appState.hapticManager.triggerFeedback('swipe');
                 }
-                
+
                 try {
                     await commonFunctions.moveToStack(targetStack);
                     hideAllEdgeGlows();
@@ -3775,15 +3751,15 @@
                     hideAllEdgeGlows();
                 }
             }
-            
+
             utils.elements.imageViewport.addEventListener('mousedown', handleStart);
             document.addEventListener('mousemove', handleMove);
             document.addEventListener('mouseup', handleEnd);
-            
+
             utils.elements.imageViewport.addEventListener('touchstart', handleStart, { passive: false });
             document.addEventListener('touchmove', handleMove, { passive: false });
             document.addEventListener('touchend', handleEnd, { passive: false });
-            
+
             function handleStart(e) {
                 // Double Tap Logic
                 const currentTime = Date.now();
@@ -3799,38 +3775,38 @@
                 if (appState.imageFiles.length === 0 || appState.currentImageIndex === -1) return;
                 if (e.touches && (e.touches.length > 1 || appState.isPinching)) return;
                 if (appState.currentScale > 1.1) return;
-                
+
                 // e.preventDefault(); // Don't prevent default immediately, allow tap to register
                 const point = e.touches ? e.touches[0] : e;
-                
+
                 startPos = { x: point.clientX, y: point.clientY };
                 currentPos = { x: point.clientX, y: point.clientY };
                 gestureStarted = false;
-                
+
                 appState.isDragging = true;
                 utils.elements.centerImage.classList.add('dragging');
             }
-            
+
             function handleMove(e) {
                 if (!appState.isDragging || appState.isFocusMode) return;
                 if (appState.imageFiles.length === 0) return;
-                
+
                 if (e.touches && e.touches.length > 1) {
                     appState.isDragging = false;
                     utils.elements.centerImage.classList.remove('dragging');
                     hideAllEdgeGlows();
                     return;
                 }
-                
+
                 e.preventDefault(); // Prevent default on move to stop scrolling
                 const point = e.touches ? e.touches[0] : e;
-                
+
                 currentPos = { x: point.clientX, y: point.clientY };
-                
+
                 const deltaX = currentPos.x - startPos.x;
                 const deltaY = currentPos.y - startPos.y;
                 const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
-                
+
                 if (distance > 30) {
                     gestureStarted = true;
                     const direction = determineSwipeDirection(deltaX, deltaY);
@@ -3842,22 +3818,22 @@
                     hideAllEdgeGlows();
                 }
             }
-            
+
             function handleEnd(e) {
                 if (!appState.isDragging || appState.isFocusMode) return;
-                
+
                 appState.isDragging = false;
                 utils.elements.centerImage.classList.remove('dragging');
-                
+
                 if (!gestureStarted) {
                     hideAllEdgeGlows();
                     return;
                 }
-                
+
                 const deltaX = currentPos.x - startPos.x;
                 const deltaY = currentPos.y - startPos.y;
                 const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
-                
+
                 if (distance > 80) {
                     const direction = determineSwipeDirection(deltaX, deltaY);
                     const targetStack = directionToStack(direction);
@@ -3866,11 +3842,11 @@
                         return;
                     }
                 }
-                
+
                 hideAllEdgeGlows();
             }
         }
-        
+
         // ===== Pinch Zoom System =====
         function setupPinchZoom() {
             function getDistance(touch1, touch2) {
@@ -3878,19 +3854,19 @@
                 const dy = touch1.clientY - touch2.clientY;
                 return Math.sqrt(dx * dx + dy * dy);
             }
-            
+
             function getCenter(touch1, touch2) {
                 return {
                     x: (touch1.clientX + touch2.clientX) / 2,
                     y: (touch1.clientY + touch2.clientY) / 2
                 };
             }
-            
+
             utils.elements.centerImage.addEventListener('touchstart', handleTouchStart, { passive: false });
             utils.elements.centerImage.addEventListener('touchmove', handleTouchMove, { passive: false });
             utils.elements.centerImage.addEventListener('touchend', handleTouchEnd, { passive: false });
             utils.elements.centerImage.addEventListener('wheel', handleWheel, { passive: false });
-            
+
             function handleTouchStart(e) {
                 if (e.touches.length === 2) {
                     e.preventDefault();
@@ -3901,62 +3877,62 @@
                     appState.lastTouchPos = { x: e.touches[0].clientX, y: e.touches[0].clientY };
                 }
             }
-            
+
             function handleTouchMove(e) {
                 if (e.touches.length === 2 && appState.isPinching) {
                     e.preventDefault();
-                    
+
                     const currentDistance = getDistance(e.touches[0], e.touches[1]);
                     const scaleFactor = currentDistance / appState.initialDistance;
-                    
+
                     let newScale = appState.currentScale * scaleFactor;
                     newScale = Math.max(appState.minScale, Math.min(appState.maxScale, newScale));
-                    
+
                     appState.currentScale = newScale;
                     appState.initialDistance = currentDistance;
-                    
+
                     commonFunctions.applyTransform();
                 } else if (e.touches.length === 1 && appState.currentScale > 1) {
                     e.preventDefault();
-                    
+
                     const deltaX = e.touches[0].clientX - appState.lastTouchPos.x;
                     const deltaY = e.touches[0].clientY - appState.lastTouchPos.y;
-                    
+
                     appState.panOffset.x += deltaX / appState.currentScale;
                     appState.panOffset.y += deltaY / appState.currentScale;
-                    
+
                     appState.lastTouchPos = { x: e.touches[0].clientX, y: e.touches[0].clientY };
-                    
+
                     commonFunctions.applyTransform();
                 }
             }
-            
+
             function handleTouchEnd(e) {
                 if (e.touches.length < 2) {
                     appState.isPinching = false;
                 }
-                
+
                 if (appState.currentScale < 1.1) {
                     appState.currentScale = 1;
                     appState.panOffset = { x: 0, y: 0 };
                     commonFunctions.applyTransform();
                 }
             }
-            
+
             function handleWheel(e) {
                 e.preventDefault();
-                
+
                 const scaleChange = e.deltaY > 0 ? 0.9 : 1.1;
                 let newScale = appState.currentScale * scaleChange;
                 newScale = Math.max(appState.minScale, Math.min(appState.maxScale, newScale));
-                
+
                 appState.currentScale = newScale;
-                
+
                 if (appState.currentScale <= 1.1) {
                     appState.currentScale = 1;
                     appState.panOffset = { x: 0, y: 0 };
                 }
-                
+
                 commonFunctions.applyTransform();
             }
         }
@@ -3997,10 +3973,10 @@
 
                 const currentFile = appState.imageFiles[appState.currentImageIndex];
                 const currentIndexInStack = stack.findIndex(f => f.id === currentFile.id);
-                
+
                 const nextIndexInStack = (currentIndexInStack + 1) % stack.length;
                 const nextFile = stack[nextIndexInStack];
-                
+
                 appState.currentImageIndex = appState.imageFiles.findIndex(f => f.id === nextFile.id);
                 await commonFunctions.displayCurrentImage();
             },
@@ -4022,18 +3998,18 @@
                 const fileToDelete = appState.imageFiles[appState.currentImageIndex];
                 const currentStackArray = appState.stacks[fileToDelete.stack];
                 const stackIndex = currentStackArray.findIndex(f => f.id === fileToDelete.id);
-                
+
                 try {
                     await masterController.deleteFile(fileToDelete.id);
-                    
+
                     // Remove from local state
                     const fileIndex = appState.imageFiles.findIndex(f => f.id === fileToDelete.id);
                     if (fileIndex > -1) appState.imageFiles.splice(fileIndex, 1);
-                    
+
                     if (stackIndex > -1) currentStackArray.splice(stackIndex, 1);
-                    
+
                     commonFunctions.updateStackCounts();
-                    
+
                     // Navigate to the next image or show empty state
                     if (currentStackArray.length === 0) {
                         this.toggle(); // Exit focus mode if stack is empty
@@ -4080,49 +4056,49 @@
                 }
             });
         }
-        
+
         // ===== Event Handlers =====
         function setupEventHandlers() {
             // Provider selection
             utils.elements.googleDriveBtn.addEventListener('click', () => appController.selectGoogleDrive());
             utils.elements.onedriveBtn.addEventListener('click', () => appController.selectOneDrive());
-            
+
             // Settings
             document.querySelectorAll('.intensity-btn').forEach(btn => {
                 btn.addEventListener('click', () => {
                     appState.visualCueManager.setIntensity(btn.dataset.level);
                 });
             });
-            
+
             document.getElementById('haptic-enabled').addEventListener('change', (e) => {
                 appState.hapticManager.setEnabled(e.target.checked);
             });
-            
+
             // Google Drive auth
             utils.elements.gdriveAuthButton.addEventListener('click', async () => {
                 const clientSecret = utils.elements.gdriveClientSecret.value.trim();
-                
+
                 if (!clientSecret) {
                     utils.elements.gdriveAuthStatus.textContent = 'Please enter client secret';
                     utils.elements.gdriveAuthStatus.className = 'status error';
                     return;
                 }
-                
+
                 utils.elements.gdriveAuthButton.disabled = true;
                 utils.elements.gdriveAuthButton.textContent = 'Connecting...';
                 utils.elements.gdriveAuthStatus.textContent = 'Connecting to Google Drive...';
                 utils.elements.gdriveAuthStatus.className = 'status info';
-                
+
                 try {
                     const provider = new GoogleDriveProvider();
                     const success = await provider.authenticate(clientSecret);
-                    
+
                     if (success) {
                         appState.currentProvider = provider;
                         utils.elements.gdriveAuthStatus.textContent = '✅ Connected to Google Drive!';
                         utils.elements.gdriveAuthStatus.className = 'status success';
                         utils.elements.gdriveClientSecret.value = '';
-                        
+
                         setTimeout(() => {
                             utils.showScreen('gdrive-folder-screen');
                             loadGoogleDriveFolders();
@@ -4136,25 +4112,25 @@
                     utils.elements.gdriveAuthButton.textContent = 'Connect Drive';
                 }
             });
-            
+
             utils.elements.gdriveBackButton.addEventListener('click', () => appController.backToProviderSelection());
-            
+
             // OneDrive auth
             utils.elements.onedriveAuthButton.addEventListener('click', async () => {
                 utils.elements.onedriveAuthButton.disabled = true;
                 utils.elements.onedriveAuthButton.textContent = 'Connecting...';
                 utils.elements.onedriveAuthStatus.textContent = 'Connecting to OneDrive...';
                 utils.elements.onedriveAuthStatus.className = 'status info';
-                
+
                 try {
                     const provider = new OneDriveProvider();
                     const success = await provider.authenticate();
-                    
+
                     if (success) {
                         appState.currentProvider = provider;
                         utils.elements.onedriveAuthStatus.textContent = '✅ Connected to OneDrive!';
                         utils.elements.onedriveAuthStatus.className = 'status success';
-                        
+
                         setTimeout(() => {
                             utils.showScreen('onedrive-folder-screen');
                             loadOneDriveFolders();
@@ -4168,9 +4144,9 @@
                     utils.elements.onedriveAuthButton.textContent = 'Connect OneDrive';
                 }
             });
-            
+
             utils.elements.onedriveBackButton.addEventListener('click', () => appController.backToProviderSelection());
-            
+
             // Folder management
             utils.elements.gdriveRefreshFolders.addEventListener('click', () => loadGoogleDriveFolders());
             utils.elements.gdriveBackToProvider.addEventListener('click', () => appController.backToProviderSelection());
@@ -4178,14 +4154,14 @@
                 appState.currentProvider.disconnect();
                 appController.backToProviderSelection();
             });
-            
+
             utils.elements.onedriveRefreshFolders.addEventListener('click', () => loadOneDriveFolders());
             utils.elements.onedriveBackToProvider.addEventListener('click', () => appController.backToProviderSelection());
             utils.elements.onedriveLogout.addEventListener('click', () => {
                 appState.currentProvider.disconnect();
                 appController.backToProviderSelection();
             });
-            
+
             // Loading screen cancel
             utils.elements.cancelLoading.addEventListener('click', () => {
                 if (appState.metadataExtractor) {
@@ -4194,7 +4170,7 @@
                 masterController.returnToFolderSelection();
                 utils.showToast('Loading cancelled', 'info', true);
             });
-            
+
             // Details modal
             utils.elements.detailsButton.addEventListener('click', () => {
                 if (appState.currentImageIndex !== -1) {
@@ -4202,7 +4178,7 @@
                 }
             });
             utils.elements.detailsClose.addEventListener('click', () => detailsModal.hide());
-            
+
             // Focus Mode
             utils.elements.focusStackName.addEventListener('click', () => modalManager.setupFocusStackSwitch());
             utils.elements.focusDeleteBtn.addEventListener('click', () => focusMode.deleteCurrentImage());
@@ -4211,26 +4187,26 @@
             document.querySelectorAll('.tab-button').forEach(btn => {
                 btn.addEventListener('click', () => detailsModal.switchTab(btn.dataset.tab));
             });
-            
+
             // Copy metadata buttons
             document.addEventListener('click', (e) => {
                 if (e.target.classList.contains('copy-metadata')) {
                     const value = e.target.dataset.value;
                     const button = e.target;
-                    
+
                     button.classList.add('copied');
                     const originalText = button.textContent;
                     button.textContent = '✓';
-                    
+
                     detailsModal.copyToClipboard(value);
-                    
+
                     setTimeout(() => {
                         button.classList.remove('copied');
                         button.textContent = originalText;
                     }, 1000);
                 }
             });
-            
+
             // Empty state buttons
             utils.elements.selectAnotherStackBtn.addEventListener('click', () => {
                 const stacksWithImages = STACK_TYPES.filter(stack => appState.stacks[stack].length > 0);
@@ -4242,22 +4218,22 @@
                     utils.elements.selectAnotherFolderBtn.style.display = 'block';
                 }
             });
-            
+
             utils.elements.selectAnotherFolderBtn.addEventListener('click', () => {
                 masterController.returnToFolderSelection();
             });
-            
+
             // Pill counter clicks
             STACK_TYPES.forEach(stackName => {
                 const pill = document.getElementById(`pill-${stackName}`);
                 if (pill) {
                     pill.addEventListener('click', (e) => {
                         e.stopPropagation();
-                        
+
                         if (appState.hapticManager) {
                             appState.hapticManager.triggerFeedback('pillTap');
                         }
-                        
+
                         if (appState.currentStack === stackName) {
                             gridView.open(stackName);
                         } else {
@@ -4267,31 +4243,31 @@
                     });
                 }
             });
-            
+
             // Grid controls
             utils.elements.closeGrid.addEventListener('click', () => gridView.close());
             utils.elements.selectAllBtn.addEventListener('click', () => gridView.selectAll());
             utils.elements.deselectAllBtn.addEventListener('click', () => gridView.deselectAll());
-            
+
             utils.elements.gridSize.addEventListener('input', () => {
                 const value = utils.elements.gridSize.value;
                 utils.elements.gridSizeValue.textContent = value;
                 utils.elements.gridContainer.style.gridTemplateColumns = `repeat(${value}, 1fr)`;
             });
-            
+
             // Search functionality
             utils.elements.omniSearchBtn.addEventListener('click', () => gridView.performSearch());
             utils.elements.omniSearch.addEventListener('keydown', (e) => {
                 if (e.key === 'Enter') gridView.performSearch();
             });
-            
+
             // Action buttons
             utils.elements.moveSelected.addEventListener('click', () => modalManager.setupMoveAction());
             utils.elements.tagSelected.addEventListener('click', () => modalManager.setupTagAction());
             utils.elements.deleteSelected.addEventListener('click', () => modalManager.setupDeleteAction());
             utils.elements.exportSelected.addEventListener('click', () => modalManager.setupExportAction());
             utils.elements.folderSelected.addEventListener('click', () => modalManager.setupFolderMoveAction());
-            
+
             utils.elements.actionCancel.addEventListener('click', () => modalManager.hide());
             utils.elements.actionConfirm.addEventListener('click', () => {
                 if (modalManager.currentAction === 'move') {
@@ -4306,21 +4282,21 @@
                     modalManager.executeFolderMove();
                 }
             });
-            
+
             // Keyboard navigation
             document.addEventListener('keydown', (e) => {
                 if (utils.elements.appContainer.classList.contains('hidden')) return;
-                
+
                 if (!utils.elements.detailsModal.classList.contains('hidden')) {
                     if (e.key === 'Escape') detailsModal.hide();
                     return;
                 }
-                
+
                 if (!utils.elements.gridModal.classList.contains('hidden')) {
                     if (e.key === 'Escape') gridView.close();
                     return;
                 }
-                
+
                 if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
 
                 if (appState.isFocusMode) {
@@ -4329,14 +4305,14 @@
                     if (e.key === 'Escape') focusMode.toggle();
                     return;
                 }
-                
+
                 const keyMap = {
                     'ArrowUp': 'priority',
                     'ArrowDown': 'trash',
                     'ArrowLeft': 'in',
                     'ArrowRight': 'out'
                 };
-                
+
                 if (keyMap[e.key]) {
                     e.preventDefault();
                     const targetStack = keyMap[e.key];
@@ -4346,7 +4322,7 @@
                     }
                     return;
                 }
-                
+
                 switch (e.key) {
                     case 'Tab':
                         e.preventDefault();
@@ -4358,22 +4334,22 @@
                 }
             });
         }
-        
+
         function switchToStack(stackName) {
             appState.currentStack = stackName;
             commonFunctions.updateActiveProxTab();
             commonFunctions.displayTopImageFromStack(stackName);
         }
-        
+
         function cycleThroughProxTabs() {
             const stackOrder = ['in', 'out', 'priority', 'trash'];
             const currentIndex = stackOrder.indexOf(appState.currentStack);
             const nextIndex = (currentIndex + 1) % stackOrder.length;
             const nextStack = stackOrder[nextIndex];
-            
+
             switchToStack(nextStack);
         }
-        
+
         // ===== Folder Loading Functions =====
         async function loadGoogleDriveFolders() {
             utils.elements.gdriveFolderList.innerHTML = `
@@ -4382,10 +4358,10 @@
                     <span>Loading folders...</span>
                 </div>
             `;
-            
+
             try {
                 const folders = await appState.currentProvider.getFolders();
-                
+
                 if (folders.length === 0) {
                     utils.elements.gdriveFolderList.innerHTML = `
                         <div style="text-align: center; padding: 40px; color: rgba(255, 255, 255, 0.7);">
@@ -4394,9 +4370,9 @@
                     `;
                     return;
                 }
-                
+
                 utils.elements.gdriveFolderList.innerHTML = '';
-                
+
                 folders.forEach(folder => {
                     const div = document.createElement('div');
                     div.className = 'folder-item';
@@ -4409,7 +4385,7 @@
                             <div class="folder-date">${new Date(folder.modifiedTime).toLocaleDateString()}</div>
                         </div>
                     `;
-                    
+
                     div.addEventListener('click', () => {
                         if (appState.folderMoveMode.active) {
                             handleFolderMoveSelection(folder.id, folder.name);
@@ -4419,12 +4395,12 @@
                     });
                     utils.elements.gdriveFolderList.appendChild(div);
                 });
-                
+
             } catch (error) {
                 utils.showToast(`Error loading folders: ${error.message}`, 'error', true);
             }
         }
-        
+
         async function loadOneDriveFolders() {
             utils.elements.onedriveFolderList.innerHTML = `
                 <div style="display: flex; align-items: center; justify-content: center; padding: 40px; color: rgba(255, 255, 255, 0.7);">
@@ -4432,7 +4408,7 @@
                     <span>Loading folders...</span>
                 </div>
             `;
-            
+
             try {
                 const folders = await appState.currentProvider.getFolders();
                 displayOneDriveFolders(folders);
@@ -4441,10 +4417,10 @@
                 utils.showToast('Error loading folders', 'error', true);
             }
         }
-        
+
         function displayOneDriveFolders(folders) {
             utils.elements.onedriveFolderList.innerHTML = '';
-            
+
             if (folders.length === 0) {
                 utils.elements.onedriveFolderList.innerHTML = `
                     <div style="text-align: center; padding: 40px; color: rgba(255, 255, 255, 0.7);">
@@ -4453,14 +4429,14 @@
                 `;
                 return;
             }
-            
+
             folders.forEach(folder => {
                 const div = document.createElement('div');
                 div.className = 'folder-item';
-                
+
                 const hasChildren = folder.hasChildren;
                 const iconColor = hasChildren ? 'var(--app-accent)' : 'rgba(255, 255, 255, 0.6)';
-                
+
                 div.innerHTML = `
                     <svg class="folder-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" style="color: ${iconColor};">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"></path>
@@ -4477,17 +4453,17 @@
                         <button class="folder-action-btn select-btn" data-folder-id="${folder.id}">Select</button>
                     </div>
                 `;
-                
+
                 utils.elements.onedriveFolderList.appendChild(div);
             });
-            
+
             document.querySelectorAll('.drill-btn').forEach(btn => {
                 btn.addEventListener('click', async (e) => {
                     e.stopPropagation();
                     const folderId = btn.dataset.folderId;
                     const folderElement = btn.closest('.folder-item');
                     const folderName = folderElement.querySelector('.folder-name').textContent;
-                    
+
                     try {
                         const subfolders = await appState.currentProvider.drillIntoFolder({ id: folderId, name: folderName });
                         displayOneDriveFolders(subfolders);
@@ -4497,14 +4473,14 @@
                     }
                 });
             });
-            
+
             document.querySelectorAll('.select-btn').forEach(btn => {
                 btn.addEventListener('click', (e) => {
                     e.stopPropagation();
                     const folderId = btn.dataset.folderId;
                     const folderElement = btn.closest('.folder-item');
                     const folderName = folderElement.querySelector('.folder-name').textContent;
-                    
+
                     if (appState.folderMoveMode.active) {
                         handleFolderMoveSelection(folderId, folderName);
                     } else {
@@ -4523,7 +4499,7 @@
                 for(let i = 0; i < filesToMove.length; i++) {
                     const fileId = filesToMove[i];
                     await appState.currentProvider.moveFileToFolder(fileId, folderId);
-                    
+
                     const fileIndex = appState.imageFiles.findIndex(f => f.id === fileId);
                     if (fileIndex > -1) {
                         const [file] = appState.imageFiles.splice(fileIndex, 1);
@@ -4536,25 +4512,25 @@
                 }
 
                 utils.showToast(`Moved ${filesToMove.length} images to ${folderName}`, 'success', true);
-                
+
                 await appState.fileCache.clearCacheForFolder(appState.currentFolder.id);
                 appState.folderMoveMode = { active: false, files: [] };
                 commonFunctions.rebuildStacks();
                 commonFunctions.updateStackCounts();
                 masterController.returnToFolderSelection();
-                
+
             } catch (error) {
                 utils.showToast('Error moving files', 'error', true);
                 masterController.returnToFolderSelection();
             }
         }
-        
+
         function updateOneDriveNavigation() {
             const currentPath = appState.currentProvider.getCurrentPath();
             const canGoUp = appState.currentProvider.canGoUp();
-            
+
             utils.elements.onedriveFolderSubtitle.textContent = `Current: ${currentPath}`;
-            
+
             const refreshBtn = utils.elements.onedriveRefreshFolders;
             if (canGoUp) {
                 refreshBtn.textContent = '← Go Up';
@@ -4572,35 +4548,35 @@
                 refreshBtn.onclick = () => loadOneDriveFolders();
             }
         }
-        
+
         // ===== Initialize App =====
         async function initApp() {
             try {
                 utils.init();
-                
+
                 appState.visualCueManager = new VisualCueManager();
                 appState.hapticManager = new HapticFeedbackManager();
                 appState.exportSystem = new ExportSystem();
-                
+
                 appState.fileCache = new EnhancedFileCache();
                 await appState.fileCache.init();
-                
+
                 appState.metadataExtractor = new ProgressiveMetadataExtractor();
-                
+
                 utils.showScreen('provider-screen');
-                
+
                 setupEventHandlers();
                 setupGestureSystem();
                 setupFocusModeGestures(); // Initialize the new gesture handler
                 setupPinchZoom();
-                
+
                 commonFunctions.updateActiveProxTab();
-                
+
             } catch (error) {
                 utils.showToast('Failed to initialize app', 'error', true);
             }
         }
-        
+
         document.addEventListener('DOMContentLoaded', initApp);
     </script>
 </body>

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -349,16 +339,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -372,7 +361,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,10 +376,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -410,7 +399,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tag-section { display: flex; flex-direction: column; gap: 6px; }
@@ -439,11 +428,10 @@
         .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -458,7 +446,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
@@ -483,6 +471,10 @@
         }
         .app-footer .footer-link:focus-visible {
             outline: none;
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -512,10 +504,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -540,19 +528,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -696,7 +682,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -711,7 +697,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -740,7 +726,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -748,7 +734,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -769,23 +755,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -796,7 +782,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -806,11 +791,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -826,7 +809,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -841,7 +824,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -864,7 +847,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -884,7 +867,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -896,7 +879,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -908,14 +891,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -935,19 +918,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -958,7 +941,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -970,7 +953,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -980,7 +963,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1096,7 +1079,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1104,11 +1086,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1123,7 +1105,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1132,11 +1115,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1147,7 +1129,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1162,12 +1144,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1179,27 +1161,27 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1215,7 +1197,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1225,22 +1207,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1325,7 +1332,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3290,7 +3297,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -3994,7 +4001,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if (state.syncManager) {
@@ -4679,7 +4686,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -4690,7 +4697,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -4701,7 +4708,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -4709,12 +4716,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -4726,21 +4733,21 @@
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -4758,10 +4765,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4822,22 +4826,22 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack, options = {}) {
                 const { source = 'ui:direct' } = options;
                 if (state.isImageTransitioning) return;
@@ -4999,7 +5003,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -5072,7 +5076,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -5088,7 +5092,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -5097,7 +5101,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -5105,7 +5109,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -5115,13 +5119,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
@@ -5270,10 +5274,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6381,7 +6385,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -6730,7 +6734,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -349,16 +339,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -372,7 +361,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,10 +376,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -410,7 +399,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tag-section { display: flex; flex-direction: column; gap: 6px; }
@@ -439,11 +428,10 @@
         .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -458,7 +446,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
@@ -483,6 +471,10 @@
         }
         .app-footer .footer-link:focus-visible {
             outline: none;
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -512,10 +504,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -540,19 +528,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -696,7 +682,7 @@
         </div>
         <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -711,7 +697,7 @@
         </div>
         <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -740,7 +726,7 @@
         </div>
         <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -748,7 +734,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -769,23 +755,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -796,7 +782,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -806,11 +791,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -826,7 +809,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -841,7 +824,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -864,7 +847,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -884,7 +867,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -896,7 +879,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -908,14 +891,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -935,19 +918,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -958,7 +941,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -970,7 +953,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -980,7 +963,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1026,7 +1009,7 @@
                 }
                 return this.normalizeFavorite(input);
             },
-            
+
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1034,11 +1017,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1053,7 +1036,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1062,11 +1046,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1077,7 +1060,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1092,12 +1075,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1109,27 +1092,27 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1145,7 +1128,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1155,22 +1138,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1183,7 +1191,7 @@
                     img.onerror = () => {
                         if (state.currentImageLoadId !== loadId) return;
                         let fallbackUrl = this.getFallbackImageUrl(file);
-                        
+
                         img.onerror = () => {
                             if (state.currentImageLoadId !== loadId) return;
                             img.src = 'data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'150\' height=\'150\' viewBox=\'0 0 150 150\' fill=\'none\'%3E%3Crect width=\'150\' height=\'150\' fill=\'%23E5E7EB\'/%3E%3Cpath d=\'M65 60H85V90H65V60Z\' fill=\'%239CA3AF\'/%3E%3Ccircle cx=\'75\' cy=\'45\' r=\'10\' fill=\'%239CA3AF\'/%3E%3C/svg%3E';
@@ -1195,7 +1203,7 @@
                     img.alt = file.name || 'Image';
                 });
             },
-            
+
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
                     if (file.thumbnailLink) {
@@ -1256,7 +1264,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3214,7 +3222,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -3900,7 +3908,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if (state.syncManager) {
@@ -4518,7 +4526,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -4529,7 +4537,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -4540,7 +4548,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -4548,12 +4556,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -4565,21 +4573,21 @@
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -4597,10 +4605,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4661,22 +4666,22 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack, options = {}) {
                 const { source = 'ui:direct' } = options;
                 if (state.isImageTransitioning) return;
@@ -4833,7 +4838,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -4906,7 +4911,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -4922,7 +4927,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -4931,7 +4936,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -4939,7 +4944,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -4949,13 +4954,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
@@ -5104,10 +5109,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6215,7 +6220,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -6564,7 +6569,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -349,16 +339,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -372,7 +361,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,10 +376,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -410,7 +399,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tag-section { display: flex; flex-direction: column; gap: 6px; }
@@ -439,11 +428,10 @@
         .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -458,7 +446,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
@@ -483,6 +471,10 @@
         }
         .app-footer .footer-link:focus-visible {
             outline: none;
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -512,10 +504,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -540,19 +528,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -696,7 +682,7 @@
         </div>
         <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -711,7 +697,7 @@
         </div>
         <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -740,7 +726,7 @@
         </div>
         <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -748,7 +734,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -769,23 +755,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -796,7 +782,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -806,11 +791,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -826,7 +809,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -841,7 +824,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -864,7 +847,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -884,7 +867,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -896,7 +879,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -908,14 +891,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -935,19 +918,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -958,7 +941,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -970,7 +953,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -980,7 +963,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1027,7 +1010,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1035,11 +1017,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1054,7 +1036,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1063,11 +1046,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1078,7 +1060,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1093,12 +1075,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1110,27 +1092,27 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1146,7 +1128,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1156,22 +1138,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1184,7 +1191,7 @@
                     img.onerror = () => {
                         if (state.currentImageLoadId !== loadId) return;
                         let fallbackUrl = this.getFallbackImageUrl(file);
-                        
+
                         img.onerror = () => {
                             if (state.currentImageLoadId !== loadId) return;
                             img.src = 'data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'150\' height=\'150\' viewBox=\'0 0 150 150\' fill=\'none\'%3E%3Crect width=\'150\' height=\'150\' fill=\'%23E5E7EB\'/%3E%3Cpath d=\'M65 60H85V90H65V60Z\' fill=\'%239CA3AF\'/%3E%3Ccircle cx=\'75\' cy=\'45\' r=\'10\' fill=\'%239CA3AF\'/%3E%3C/svg%3E';
@@ -1196,7 +1203,7 @@
                     img.alt = file.name || 'Image';
                 });
             },
-            
+
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
                     if (file.thumbnailLink) {
@@ -1257,7 +1264,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3215,7 +3222,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -3901,7 +3908,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if (state.syncManager) {
@@ -4519,7 +4526,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -4530,7 +4537,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -4541,7 +4548,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -4549,12 +4556,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -4566,21 +4573,21 @@
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -4598,10 +4605,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4662,22 +4666,22 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack, options = {}) {
                 const { source = 'ui:direct' } = options;
                 if (state.isImageTransitioning) return;
@@ -4834,7 +4838,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -4907,7 +4911,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -4923,7 +4927,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -4932,7 +4936,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -4940,7 +4944,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -4950,13 +4954,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
@@ -5105,10 +5109,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6635,7 +6639,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/ui-v2-old.html
+++ b/ui-v2-old.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -359,16 +349,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -382,7 +371,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -397,10 +386,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -420,7 +409,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tags-container.tag-editor-container { display: flex; flex-direction: column; gap: 12px; min-height: 0; }
@@ -444,11 +433,10 @@
         .tag-suggestion:hover { background-color: #d1d5db; }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -463,12 +451,16 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -498,10 +490,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -526,19 +514,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -682,7 +668,7 @@
         </div>
         <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -697,7 +683,7 @@
         </div>
         <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -712,7 +698,7 @@
         </div>
         <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -734,7 +720,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -755,23 +741,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -782,7 +768,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -792,11 +777,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -812,7 +795,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -827,7 +810,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -851,7 +834,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -871,7 +854,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -883,7 +866,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -895,14 +878,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -922,19 +905,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -945,7 +928,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -957,7 +940,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -967,7 +950,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1011,7 +994,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1019,11 +1001,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1038,7 +1020,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1047,11 +1030,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1062,7 +1044,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1077,12 +1059,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1094,7 +1076,7 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
@@ -1102,20 +1084,20 @@
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
                     searchHelperRecent: document.getElementById('search-helper-recent'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1131,7 +1113,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1141,22 +1123,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1169,7 +1176,7 @@
                     img.onerror = () => {
                         if (state.currentImageLoadId !== loadId) return;
                         let fallbackUrl = this.getFallbackImageUrl(file);
-                        
+
                         img.onerror = () => {
                             if (state.currentImageLoadId !== loadId) return;
                             img.src = 'data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'150\' height=\'150\' viewBox=\'0 0 150 150\' fill=\'none\'%3E%3Crect width=\'150\' height=\'150\' fill=\'%23E5E7EB\'/%3E%3Cpath d=\'M65 60H85V90H65V60Z\' fill=\'%239CA3AF\'/%3E%3Ccircle cx=\'75\' cy=\'45\' r=\'10\' fill=\'%239CA3AF\'/%3E%3C/svg%3E';
@@ -1181,7 +1188,7 @@
                     img.alt = file.name || 'Image';
                 });
             },
-            
+
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
                     if (file.thumbnailLink) {
@@ -1242,7 +1249,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -1892,7 +1899,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -2350,7 +2357,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if(state.syncManager) state.syncManager.start();
@@ -2652,7 +2659,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -2663,7 +2670,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -2674,7 +2681,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -2682,12 +2689,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -2699,21 +2706,21 @@
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -2730,10 +2737,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -2794,26 +2798,26 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack) {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                
+
                 const currentImage = currentStackArray[state.currentStackPosition];
                 if (!currentImage) return;
 
@@ -2844,7 +2848,7 @@
                     Utils.showToast(`Error moving image: ${error.message}`, 'error', true);
                 }
             },
-            
+
             showEmptyState() {
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
@@ -2873,7 +2877,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -2946,7 +2950,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -2962,7 +2966,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -2971,7 +2975,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -2979,7 +2983,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -2989,13 +2993,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const searchInput = Utils.elements.omniSearch;
                 const query = searchInput.value.trim();
@@ -3129,10 +3133,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -4141,7 +4145,7 @@
             init(modal, header) {
                 let pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
                 let isDragging = false;
-                
+
                 header.onmousedown = dragMouseDown;
 
                 function dragMouseDown(e) {
@@ -4162,7 +4166,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -4508,7 +4512,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -349,16 +339,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -372,7 +361,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,10 +376,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -410,7 +399,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tag-section { display: flex; flex-direction: column; gap: 6px; }
@@ -439,11 +428,10 @@
         .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -458,7 +446,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
@@ -483,6 +471,10 @@
         }
         .app-footer .footer-link:focus-visible {
             outline: none;
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -512,10 +504,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -540,19 +528,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -696,7 +682,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -711,7 +697,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -740,7 +726,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -748,7 +734,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -769,23 +755,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -796,7 +782,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -806,11 +791,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -826,7 +809,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -841,7 +824,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -864,7 +847,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -884,7 +867,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -896,7 +879,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -908,14 +891,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -935,19 +918,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -958,7 +941,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -970,7 +953,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -980,7 +963,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1096,7 +1079,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1104,11 +1086,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1123,7 +1105,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1132,11 +1115,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1147,7 +1129,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1162,12 +1144,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1179,27 +1161,27 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1215,7 +1197,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1225,22 +1207,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1325,7 +1332,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3290,7 +3297,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -3994,7 +4001,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if (state.syncManager) {
@@ -4679,7 +4686,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -4690,7 +4697,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -4701,7 +4708,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -4709,12 +4716,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -4726,21 +4733,21 @@
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -4758,10 +4765,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4822,22 +4826,22 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack, options = {}) {
                 const { source = 'ui:direct' } = options;
                 if (state.isImageTransitioning) return;
@@ -4999,7 +5003,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -5072,7 +5076,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -5088,7 +5092,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -5097,7 +5101,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -5105,7 +5109,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -5115,13 +5119,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
@@ -5270,10 +5274,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6381,7 +6385,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -6730,7 +6734,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -349,16 +339,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -372,7 +361,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,10 +376,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -410,7 +399,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tag-section { display: flex; flex-direction: column; gap: 6px; }
@@ -439,11 +428,10 @@
         .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -458,7 +446,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
@@ -483,6 +471,10 @@
         }
         .app-footer .footer-link:focus-visible {
             outline: none;
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -512,10 +504,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -540,19 +528,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -696,7 +682,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -711,7 +697,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -740,7 +726,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -748,7 +734,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -769,23 +755,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -796,7 +782,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -806,11 +791,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -826,7 +809,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -841,7 +824,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -864,7 +847,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -884,7 +867,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -896,7 +879,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -908,14 +891,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -935,19 +918,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -958,7 +941,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -970,7 +953,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -980,7 +963,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1096,7 +1079,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1104,11 +1086,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1123,7 +1105,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1132,11 +1115,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1147,7 +1129,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1162,12 +1144,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1179,27 +1161,27 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1215,7 +1197,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1225,22 +1207,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1325,7 +1332,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3290,7 +3297,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -3994,7 +4001,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if (state.syncManager) {
@@ -4679,7 +4686,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -4690,7 +4697,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -4701,7 +4708,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -4709,12 +4716,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -4726,21 +4733,21 @@
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -4758,10 +4765,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4822,22 +4826,22 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack, options = {}) {
                 const { source = 'ui:direct' } = options;
                 if (state.isImageTransitioning) return;
@@ -4999,7 +5003,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -5072,7 +5076,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -5088,7 +5092,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -5097,7 +5101,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -5105,7 +5109,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -5115,13 +5119,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
@@ -5270,10 +5274,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6381,7 +6385,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -6730,7 +6734,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -349,16 +339,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -372,7 +361,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,10 +376,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -410,7 +399,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tag-section { display: flex; flex-direction: column; gap: 6px; }
@@ -439,11 +428,10 @@
         .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -458,7 +446,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
@@ -483,6 +471,10 @@
         }
         .app-footer .footer-link:focus-visible {
             outline: none;
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -512,10 +504,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -540,19 +528,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -696,7 +682,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -711,7 +697,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -740,7 +726,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -748,7 +734,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -769,23 +755,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -796,7 +782,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -806,11 +791,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -826,7 +809,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -841,7 +824,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -864,7 +847,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -884,7 +867,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -896,7 +879,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -908,14 +891,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -935,19 +918,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -958,7 +941,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -970,7 +953,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -980,7 +963,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1096,7 +1079,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1104,11 +1086,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1123,7 +1105,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1132,11 +1115,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1147,7 +1129,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1162,12 +1144,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1179,27 +1161,27 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1215,7 +1197,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1225,22 +1207,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1325,7 +1332,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3290,7 +3297,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -3994,7 +4001,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if (state.syncManager) {
@@ -4679,7 +4686,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -4690,7 +4697,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -4701,7 +4708,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -4709,12 +4716,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -4726,21 +4733,21 @@
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -4758,10 +4765,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4822,22 +4826,22 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack, options = {}) {
                 const { source = 'ui:direct' } = options;
                 if (state.isImageTransitioning) return;
@@ -4999,7 +5003,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -5072,7 +5076,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -5088,7 +5092,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -5097,7 +5101,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -5105,7 +5109,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -5115,13 +5119,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
@@ -5270,10 +5274,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6381,7 +6385,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -6730,7 +6734,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -349,16 +339,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -372,7 +361,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,10 +376,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -410,7 +399,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tag-section { display: flex; flex-direction: column; gap: 6px; }
@@ -439,11 +428,10 @@
         .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -458,7 +446,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
@@ -483,6 +471,10 @@
         }
         .app-footer .footer-link:focus-visible {
             outline: none;
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -512,10 +504,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -540,19 +528,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -696,7 +682,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -711,7 +697,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -740,7 +726,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -748,7 +734,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -769,23 +755,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -796,7 +782,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -806,11 +791,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -826,7 +809,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -841,7 +824,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -864,7 +847,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -884,7 +867,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -896,7 +879,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -908,14 +891,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -935,19 +918,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -958,7 +941,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -970,7 +953,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -980,7 +963,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1096,7 +1079,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1104,11 +1086,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1123,7 +1105,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1132,11 +1115,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1147,7 +1129,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1162,12 +1144,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1179,27 +1161,27 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1215,7 +1197,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1225,22 +1207,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1325,7 +1332,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3290,7 +3297,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -3994,7 +4001,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if (state.syncManager) {
@@ -4679,7 +4686,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -4690,7 +4697,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -4701,7 +4708,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -4709,12 +4716,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -4726,21 +4733,21 @@
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -4758,10 +4765,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4822,22 +4826,22 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack, options = {}) {
                 const { source = 'ui:direct' } = options;
                 if (state.isImageTransitioning) return;
@@ -4999,7 +5003,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -5072,7 +5076,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -5088,7 +5092,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -5097,7 +5101,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -5105,7 +5109,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -5115,13 +5119,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
@@ -5270,10 +5274,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6381,7 +6385,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -6730,7 +6734,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -349,16 +339,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -372,7 +361,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,10 +376,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -410,7 +399,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tag-section { display: flex; flex-direction: column; gap: 6px; }
@@ -439,11 +428,10 @@
         .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -458,7 +446,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
@@ -483,6 +471,10 @@
         }
         .app-footer .footer-link:focus-visible {
             outline: none;
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -512,10 +504,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -540,19 +528,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -696,7 +682,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -711,7 +697,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -740,7 +726,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -748,7 +734,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -769,23 +755,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -796,7 +782,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -806,11 +791,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -826,7 +809,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -841,7 +824,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -864,7 +847,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -884,7 +867,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -896,7 +879,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -908,14 +891,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -935,19 +918,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -958,7 +941,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -970,7 +953,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -980,7 +963,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1096,7 +1079,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1104,11 +1086,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1123,7 +1105,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1132,11 +1115,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1147,7 +1129,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1162,12 +1144,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1179,27 +1161,27 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1215,7 +1197,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1225,22 +1207,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1325,7 +1332,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3290,7 +3297,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -3994,7 +4001,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if (state.syncManager) {
@@ -4679,7 +4686,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -4690,7 +4697,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -4701,7 +4708,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -4709,12 +4716,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -4726,21 +4733,21 @@
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -4758,10 +4765,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4822,22 +4826,22 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack, options = {}) {
                 const { source = 'ui:direct' } = options;
                 if (state.isImageTransitioning) return;
@@ -4999,7 +5003,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -5072,7 +5076,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -5088,7 +5092,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -5097,7 +5101,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -5105,7 +5109,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -5115,13 +5119,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
@@ -5270,10 +5274,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6381,7 +6385,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -6730,7 +6734,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -349,16 +339,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -372,7 +361,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,10 +376,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -410,7 +399,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tag-section { display: flex; flex-direction: column; gap: 6px; }
@@ -439,11 +428,10 @@
         .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -458,7 +446,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
@@ -483,6 +471,10 @@
         }
         .app-footer .footer-link:focus-visible {
             outline: none;
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -512,10 +504,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -540,19 +528,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -696,7 +682,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -711,7 +697,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -740,7 +726,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -748,7 +734,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -769,23 +755,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -796,7 +782,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -806,11 +791,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -826,7 +809,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -841,7 +824,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -864,7 +847,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -884,7 +867,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -896,7 +879,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -908,14 +891,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -935,19 +918,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -958,7 +941,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -970,7 +953,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -980,7 +963,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1096,7 +1079,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1104,11 +1086,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1123,7 +1105,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1132,11 +1115,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1147,7 +1129,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1162,12 +1144,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1179,27 +1161,27 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1215,7 +1197,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1225,22 +1207,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1325,7 +1332,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3290,7 +3297,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -3994,7 +4001,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if (state.syncManager) {
@@ -4679,7 +4686,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -4690,7 +4697,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -4701,7 +4708,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -4709,12 +4716,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -4726,21 +4733,21 @@
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -4758,10 +4765,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4822,22 +4826,22 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack, options = {}) {
                 const { source = 'ui:direct' } = options;
                 if (state.isImageTransitioning) return;
@@ -4999,7 +5003,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -5072,7 +5076,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -5088,7 +5092,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -5097,7 +5101,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -5105,7 +5109,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -5115,13 +5119,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
@@ -5270,10 +5274,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6381,7 +6385,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -6730,7 +6734,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -349,16 +339,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -372,7 +361,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,10 +376,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -410,7 +399,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tag-section { display: flex; flex-direction: column; gap: 6px; }
@@ -439,11 +428,10 @@
         .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -458,7 +446,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
@@ -483,6 +471,10 @@
         }
         .app-footer .footer-link:focus-visible {
             outline: none;
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -512,10 +504,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -540,19 +528,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -696,7 +682,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -711,7 +697,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -740,7 +726,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -748,7 +734,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -769,23 +755,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -796,7 +782,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -806,11 +791,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -826,7 +809,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -841,7 +824,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -864,7 +847,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -884,7 +867,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -896,7 +879,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -908,14 +891,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -935,19 +918,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -958,7 +941,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -970,7 +953,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -980,7 +963,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1096,7 +1079,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1104,11 +1086,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1123,7 +1105,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1132,11 +1115,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1147,7 +1129,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1162,12 +1144,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1179,27 +1161,27 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1215,7 +1197,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1225,22 +1207,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1325,7 +1332,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3290,7 +3297,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -3994,7 +4001,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if (state.syncManager) {
@@ -4679,7 +4686,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -4690,7 +4697,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -4701,7 +4708,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -4709,12 +4716,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -4726,21 +4733,21 @@
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -4758,10 +4765,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4822,22 +4826,22 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack, options = {}) {
                 const { source = 'ui:direct' } = options;
                 if (state.isImageTransitioning) return;
@@ -4999,7 +5003,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -5072,7 +5076,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -5088,7 +5092,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -5097,7 +5101,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -5105,7 +5109,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -5115,13 +5119,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
@@ -5270,10 +5274,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6381,7 +6385,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -6730,7 +6734,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -349,16 +339,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -372,7 +361,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,10 +376,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -410,7 +399,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tag-section { display: flex; flex-direction: column; gap: 6px; }
@@ -439,11 +428,10 @@
         .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -458,7 +446,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
@@ -483,6 +471,10 @@
         }
         .app-footer .footer-link:focus-visible {
             outline: none;
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -512,10 +504,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -540,19 +528,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -696,7 +682,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -711,7 +697,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -740,7 +726,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -748,7 +734,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -769,23 +755,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -796,7 +782,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -806,11 +791,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -826,7 +809,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -841,7 +824,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -864,7 +847,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -884,7 +867,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -896,7 +879,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -908,14 +891,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -935,19 +918,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -958,7 +941,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -970,7 +953,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -980,7 +963,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1096,7 +1079,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1104,11 +1086,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1123,7 +1105,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1132,11 +1115,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1147,7 +1129,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1162,12 +1144,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1179,27 +1161,27 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1215,7 +1197,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1225,22 +1207,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1325,7 +1332,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3290,7 +3297,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -3994,7 +4001,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if (state.syncManager) {
@@ -4679,7 +4686,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -4690,7 +4697,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -4701,7 +4708,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -4709,12 +4716,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -4726,21 +4733,21 @@
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -4758,10 +4765,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4822,22 +4826,22 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack, options = {}) {
                 const { source = 'ui:direct' } = options;
                 if (state.isImageTransitioning) return;
@@ -4999,7 +5003,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -5072,7 +5076,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -5088,7 +5092,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -5097,7 +5101,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -5105,7 +5109,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -5115,13 +5119,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
@@ -5270,10 +5274,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6392,7 +6396,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -6741,7 +6745,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -349,16 +339,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -372,7 +361,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,10 +376,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -410,7 +399,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tag-section { display: flex; flex-direction: column; gap: 6px; }
@@ -439,11 +428,10 @@
         .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -458,7 +446,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
@@ -483,6 +471,10 @@
         }
         .app-footer .footer-link:focus-visible {
             outline: none;
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -512,10 +504,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -540,19 +528,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -696,7 +682,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -711,7 +697,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -740,7 +726,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -748,7 +734,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -769,23 +755,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -796,7 +782,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -806,11 +791,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -826,7 +809,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -841,7 +824,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -864,7 +847,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -884,7 +867,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -896,7 +879,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -908,14 +891,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -935,19 +918,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -958,7 +941,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -970,7 +953,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -980,7 +963,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1096,7 +1079,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1104,11 +1086,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1123,7 +1105,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1132,11 +1115,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1147,7 +1129,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1162,12 +1144,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1179,27 +1161,27 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1215,7 +1197,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1225,22 +1207,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1325,7 +1332,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3290,7 +3297,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -3994,7 +4001,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if (state.syncManager) {
@@ -4679,7 +4686,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -4690,7 +4697,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -4701,7 +4708,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -4709,12 +4716,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -4726,21 +4733,21 @@
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -4758,10 +4765,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4822,22 +4826,22 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack, options = {}) {
                 const { source = 'ui:direct' } = options;
                 if (state.isImageTransitioning) return;
@@ -4999,7 +5003,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -5072,7 +5076,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -5088,7 +5092,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -5097,7 +5101,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -5105,7 +5109,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -5115,13 +5119,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
@@ -5270,10 +5274,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6392,7 +6396,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -6741,7 +6745,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -349,16 +339,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -372,7 +361,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,10 +376,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -410,7 +399,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tag-section { display: flex; flex-direction: column; gap: 6px; }
@@ -439,11 +428,10 @@
         .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -458,7 +446,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
@@ -483,6 +471,10 @@
         }
         .app-footer .footer-link:focus-visible {
             outline: none;
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -512,10 +504,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -540,19 +528,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -696,7 +682,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -711,7 +697,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -740,7 +726,7 @@
         </div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -748,7 +734,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -769,23 +755,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -796,7 +782,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -806,11 +791,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -826,7 +809,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -841,7 +824,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -864,7 +847,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -884,7 +867,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -896,7 +879,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -908,14 +891,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -935,19 +918,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -958,7 +941,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -970,7 +953,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -980,7 +963,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1096,7 +1079,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1104,11 +1086,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1123,7 +1105,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1132,11 +1115,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1147,7 +1129,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1162,12 +1144,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1179,27 +1161,27 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1215,7 +1197,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1225,22 +1207,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1325,7 +1332,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3290,7 +3297,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -3994,7 +4001,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if (state.syncManager) {
@@ -4679,7 +4686,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -4690,7 +4697,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -4701,7 +4708,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -4709,12 +4716,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -4726,21 +4733,21 @@
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -4758,10 +4765,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4822,22 +4826,22 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack, options = {}) {
                 const { source = 'ui:direct' } = options;
                 if (state.isImageTransitioning) return;
@@ -4999,7 +5003,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -5072,7 +5076,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -5088,7 +5092,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -5097,7 +5101,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -5105,7 +5109,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -5115,13 +5119,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
@@ -5270,10 +5274,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6381,7 +6385,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -6730,7 +6734,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
         .search-helper-icon {
@@ -349,16 +339,15 @@
         }
         .search-helper-popup a:hover, .search-helper-popup a:focus-visible { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -372,7 +361,7 @@
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -387,10 +376,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -410,7 +399,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { margin-bottom: 16px; }
         .tag-editor-container { display: flex; flex-direction: column; gap: 12px; }
         .tag-section { display: flex; flex-direction: column; gap: 6px; }
@@ -439,11 +428,10 @@
         .tag-chip--recent .tag-chip-remove:hover { background: rgba(107, 114, 128, 0.12); }
         .tag-editor-note { font-size: 12px; color: #6b7280; }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -458,7 +446,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
@@ -483,6 +471,10 @@
         }
         .app-footer .footer-link:focus-visible {
             outline: none;
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -512,10 +504,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -540,19 +528,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -696,7 +682,7 @@
         </div>
         <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -711,7 +697,7 @@
         </div>
         <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -726,7 +712,7 @@
         </div>
         <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -740,7 +726,7 @@
         </div>
         <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -748,7 +734,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -769,23 +755,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -796,7 +782,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -806,11 +791,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -826,7 +809,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -841,7 +824,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper" id="search-helper">
@@ -864,7 +847,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -884,7 +867,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -896,7 +879,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -908,14 +891,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -935,19 +918,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating" data-rating-type="quality">
@@ -958,7 +941,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating" data-rating-type="content">
@@ -970,7 +953,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -980,7 +963,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
@@ -1096,7 +1079,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1104,11 +1086,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1123,7 +1105,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1132,11 +1115,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1147,7 +1129,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1162,12 +1144,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1179,27 +1161,27 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
                     searchHelperClose: document.getElementById('search-helper-close'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     notesSelected: document.getElementById('notes-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1215,7 +1197,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1225,22 +1207,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1325,7 +1332,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -3290,7 +3297,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -3994,7 +4001,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if (state.syncManager) {
@@ -4679,7 +4686,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -4690,7 +4697,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -4701,7 +4708,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -4709,12 +4716,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -4726,21 +4733,21 @@
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -4758,10 +4765,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -4822,22 +4826,22 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack, options = {}) {
                 const { source = 'ui:direct' } = options;
                 if (state.isImageTransitioning) return;
@@ -4999,7 +5003,7 @@
                 this.updateSelectionUI();
                 Core.updateStackCounts();
             },
-            
+
             async close() {
                 try {
                     if (state.grid.isDirty) {
@@ -5072,7 +5076,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -5088,7 +5092,7 @@
                     if (lazyState.observer) { lazyState.observer.observe(sentinel); }
                 }
             },
-            
+
             toggleSelection(e, fileId) {
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
@@ -5097,7 +5101,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.notesSelected, Utils.elements.moveSelected,
@@ -5105,7 +5109,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -5115,13 +5119,13 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
@@ -5270,10 +5274,10 @@
                     topItems = stackArray.filter(f => selectedIds.has(f.id)).sort((a,b) => a.name.localeCompare(b.name));
                     bottomItems = stackArray.filter(f => !selectedIds.has(f.id));
                 } else { return; }
-                
+
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -6381,7 +6385,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -6730,7 +6734,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();

--- a/ui.html
+++ b/ui.html
@@ -19,28 +19,28 @@
         }
 
         * { box-sizing: border-box; }
-        
+
         body, html {
             margin: 0; padding: 0; height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             overflow: hidden; background: #000; overscroll-behavior: none; touch-action: none;
         }
-        
+
         .screen {
             position: fixed; inset: 0; background: var(--dark);
             display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 1000;
         }
         .screen.hidden { display: none; }
-        
+
         .card {
             background: var(--glass); backdrop-filter: blur(20px);
             border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 20px;
             padding: 40px; text-align: center; max-width: 500px; width: 90%;
         }
-        
+
         .title { color: white; font-size: 24px; font-weight: 600; margin-bottom: 16px; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .subtitle { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 24px; }
-        
+
         .input, .notes-textarea, .tag-input {
             width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 12px;
             background: var(--glass); color: white; font-size: 14px; margin-bottom: 16px; backdrop-filter: blur(10px);
@@ -54,7 +54,7 @@
         #action-modal .tag-input, #grid-modal .input {
             color: #1f2937; background: #f3f4f6; border-color: #d1d5db;
         }
-        
+
         .button, .folder-button, .btn {
             background: linear-gradient(45deg, var(--accent), #d97706); border: none; border-radius: 15px;
             color: white; font-size: 18px; font-weight: 600; padding: 16px 32px; cursor: pointer;
@@ -64,14 +64,14 @@
             transform: translateY(-2px); box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
         }
         .button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
-        
+
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
             font-size: 14px; backdrop-filter: blur(10px); width: auto;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
-        
+
         .btn { padding: 4px 12px; border-radius: 6px; font-size: 14px; font-weight: 500; margin-bottom: 0; width: auto; }
         .btn-primary { background-color: #3b82f6; }
         .btn-primary:hover:not(:disabled) { background-color: #2563eb; }
@@ -79,7 +79,7 @@
         .btn-danger:hover:not(:disabled) { background-color: #dc2626; }
         .btn-secondary { background-color: #e5e7eb; color: #4b5563; }
         .btn-secondary:hover:not(:disabled) { background-color: #d1d5db; }
-        
+
         .provider-button {
             display: flex; align-items: center; justify-content: center; gap: 12px;
             background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
@@ -91,13 +91,13 @@
             background: rgba(255, 255, 255, 0.2); border-color: var(--accent);
             transform: translateY(-2px); box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
         }
-        
+
         .settings-section {
             margin-top: 30px; padding-top: 20px; border-top: 1px solid rgba(255, 255, 255, 0.2);
         }
-        
+
         .intensity-options { display: flex; gap: 8px; justify-content: center; margin-bottom: 16px; }
-        
+
         .intensity-btn {
             padding: 8px 16px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
             background: rgba(255, 255, 255, 0.1); color: white; cursor: pointer; font-size: 12px;
@@ -105,29 +105,19 @@
         }
         .intensity-btn:hover { background: rgba(255, 255, 255, 0.2); }
         .intensity-btn.active { border-color: var(--accent); background: rgba(245, 158, 11, 0.2); color: var(--accent); }
-        
+
         .checkbox-label {
             color: rgba(255, 255, 255, 0.9); font-size: 14px; display: flex;
             align-items: center; gap: 8px; cursor: pointer; justify-content: center;
         }
-        
+
         .status {
             padding: 12px; border-radius: 8px; margin-top: 16px; font-size: 14px; font-weight: 500;
         }
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
+
         .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
@@ -141,7 +131,7 @@
         .folder-info { flex: 1; }
         .folder-name { font-weight: 500; margin-bottom: 2px; }
         .folder-date { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-        
+
         .folder-actions { display: flex; gap: 8px; margin-left: 12px; }
         .folder-action-btn {
             padding: 6px 12px; border: 1px solid rgba(255, 255, 255, 0.3); border-radius: 8px;
@@ -153,20 +143,20 @@
         .folder-action-btn.drill-btn:hover { background: rgba(245, 158, 11, 0.2); }
         .folder-action-btn.select-btn { border-color: rgba(16, 185, 129, 0.4); color: #10b981; }
         .folder-action-btn.select-btn:hover { background: rgba(16, 185, 129, 0.2); }
-        
+
         .spinner {
             width: 20px; height: 20px; border: 2px solid rgba(245, 158, 11, 0.3);
             border-radius: 50%; border-top-color: var(--accent); animation: spin 1s linear infinite; margin-right: 12px;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
-        
+
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
-        
+
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
-        
+
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
             max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none;
@@ -174,7 +164,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-        
+
         .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
@@ -185,7 +175,7 @@
         .edge-glow.left { top: 0; left: 0; bottom: 0; width: 8px; background: linear-gradient(90deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.right { top: 0; right: 0; bottom: 0; width: 8px; background: linear-gradient(270deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.active { opacity: 1; }
-        
+
         .pill-counter {
             position: fixed; backdrop-filter: blur(10px); border-radius: 20px; padding: 12px 20px; font-size: 18px; font-weight: 500;
             color: black; opacity: 0; transition: all 0.3s ease;
@@ -199,7 +189,7 @@
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
-        
+
         .pill-counter::before, .pill-counter::after {
             content: ''; position: absolute; border: 2px solid rgba(245, 158, 11, 0.8); border-radius: 16px; opacity: 0; pointer-events: none; z-index: -1;
         }
@@ -210,11 +200,11 @@
             box-shadow: 0 0 25px rgba(245, 158, 11, var(--glow)), 0 0 50px rgba(245, 158, 11, calc(var(--glow) * 0.6));
             animation: sustainedGlow 1s ease-out calc(var(--ripple) * 1); 
         }
-        
+
         .high-intensity-mode .pill-counter.glow-effect {
             box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8), 0 0 100px rgba(245, 158, 11, 0.6);
         }
-        
+
         @keyframes tripleRipple1 {
             0% { opacity: 0.9; transform: scale(1); top: -4px; left: -4px; right: -4px; bottom: -4px; }
             100% { opacity: 0; transform: scale(2); top: -20px; left: -20px; right: -20px; bottom: -20px; }
@@ -233,7 +223,7 @@
             50% { box-shadow: 0 0 35px rgba(245, 158, 11, 1), 0 0 70px rgba(245, 158, 11, 0.8); }
             100% { box-shadow: 0 0 10px rgba(245, 158, 11, 0.4); }
         }
-        
+
         .empty-state {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;
             color: rgba(255, 255, 255, 0.7); font-size: 18px; font-weight: 300;
@@ -246,7 +236,7 @@
             transition: all 0.2s ease;
         }
         .new-images-button:hover { background: rgba(245, 158, 11, 0.4); transform: translateY(-2px); }
-        
+
         .modal { 
             position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.5); 
             display: flex; align-items: center; justify-content: center; z-index: 50; 
@@ -259,7 +249,7 @@
             position: absolute; /* For dragging */
         }
         .action-modal { max-width: 448px; padding: 24px; }
-        
+
         .modal-header { 
             position: sticky; top: 0; background: white; z-index: 10; border-bottom: 1px solid #e5e7eb; 
             border-top-left-radius: 8px; border-top-right-radius: 8px;
@@ -282,7 +272,7 @@
         }
         .close-btn:hover { color: #374151; background: rgba(0, 0, 0, 0.05); }
         .close-btn svg { width: 24px; height: 24px; }
-        
+
         .grid-row-2 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex;
             align-items: center; justify-content: space-between;
@@ -297,11 +287,11 @@
         }
         .deselect-all-btn:hover { color: #1e3a8a; background: rgba(0, 0, 0, 0.05); }
         .deselect-all-btn svg { width: 16px; height: 16px; }
-        
+
         .zoom-control { display: flex; align-items: center; gap: 8px; }
         #grid-size { width: 80px; }
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
-        
+
         .grid-row-3 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
         }
@@ -313,7 +303,7 @@
             color: #9ca3af; cursor: pointer; display: none;
         }
         #clear-search-btn:hover { color: #6b7280; }
-        
+
         /* NEW: Search Helper */
         .search-helper { position: relative; }
         .search-helper-icon { color: #9ca3af; cursor: pointer; display: flex; align-items: center; }
@@ -331,16 +321,15 @@
         }
         .search-helper-popup a:hover { background: #f3f4f6; }
 
-
         .grid-row-4 {
             padding: 8px 16px; border-bottom: 1px solid #e5e7eb; min-height: 41px; display: flex; justify-content: flex-start;
         }
         .bulk-actions { display: flex; align-items: center; gap: 8px; }
         .bulk-actions .btn { padding: 4px 10px; font-size: 13px; }
-        
+
         .grid-content { flex: 1; overflow-y: auto; padding: 16px; }
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
-        
+
         .grid-item {
             position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
             display: flex; align-items: center; justify-content: center; overflow: hidden;
@@ -371,7 +360,7 @@
         }
         .grid-drag-ghost .grid-drag-handle { display: none; }
 
-        .filename-overlay {
+        .grid-filename-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
@@ -386,10 +375,10 @@
             pointer-events: none;
         }
 
-        .grid-item:hover .filename-overlay {
+        .grid-item:hover .grid-filename-overlay {
             opacity: 1;
         }
-        
+
         .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -409,7 +398,7 @@
         .details-content { flex: 1; overflow-y: auto; overflow-x: hidden; min-height: 0; }
         .tab-content { display: none; padding: 20px; height: 100%; }
         .tab-content.active { display: block; }
-        
+
         .tags-container { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; min-height: 40px; }
         .tag-item { display: inline-flex; align-items: center; background: #dbeafe; color: #1e40af; padding: 4px 8px; border-radius: 12px; font-size: 12px; gap: 6px; }
         .tag-remove {
@@ -422,7 +411,7 @@
             font-size: 12px; color: #6b7280; cursor: pointer; transition: all 0.2s;
         }
         .add-tag-btn:hover { background: #e5e7eb; color: #374151; }
-        
+
         /* NEW: Action Modal Tag Chips */
         #tag-chip-container { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
         .tag-chip {
@@ -436,11 +425,10 @@
         }
         .tag-chip-remove:hover { background: rgba(99, 102, 241, 0.1); }
 
-
         .star-rating { display: flex; gap: 4px; }
         .star { width: 24px; height: 24px; cursor: pointer; color: #d1d5db; transition: color 0.2s; }
         .star:hover, .star.active { color: #fbbf24; }
-        
+
         .metadata-table { width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; font-size: 13px; }
         .metadata-table td { padding: 8px 12px; border-bottom: 1px solid #e5e7eb; vertical-align: top; word-wrap: break-word; }
         .metadata-table .key-cell {
@@ -455,12 +443,16 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
+
         .app-footer {
             position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
             color: rgba(255, 255, 255, 0.6); text-align: center;
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+        }
+        .app-footer .footer-status-message {
+            display: inline-block;
+            margin-right: 8px;
         }
 
         /* NEW: Standardized UI Button */
@@ -490,10 +482,6 @@
         /* Focus Mode UI elements */
         .focus-mode-ui { display: none; }
         #focus-stack-name { top: 20px; left: 20px; }
-        #focus-filename-display {
-            top: 20px; left: 50%; transform: translateX(-50%);
-            color: #e5e7eb; font-size: 14px;
-        }
         #focus-image-count { bottom: 20px; left: 20px; color: #e5e7eb; }
         #focus-delete-btn { bottom: 20px; right: 20px; color: #e5e7eb; }
         #focus-favorite-btn {
@@ -518,19 +506,17 @@
         #focus-favorite-btn.favorited {
             color: #ef4444; /* Solid red */
         }
-
-        #focus-filename-display,
         #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
-        .app-container.focus-mode #center-trash-btn { display: none; }
+        .app-container.focus-mode #center-trash-btn,
 
         .app-container.focus-mode .focus-mode-ui { display: flex; }
-        
+
         .hidden { display: none !important; }
-        
+
         @supports (height: 100dvh) {
             .app-container, .image-viewport { height: 100dvh; }
         }
@@ -674,7 +660,7 @@
         </div>
         <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
     </div>
-    
+
     <!-- Unified Auth Screen -->
     <div class="screen hidden" id="auth-screen">
         <div class="card">
@@ -689,7 +675,7 @@
         </div>
         <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
     </div>
-    
+
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
         <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
@@ -704,7 +690,7 @@
         </div>
         <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
     </div>
-    
+
     <!-- Loading Screen -->
     <div class="screen hidden" id="loading-screen" style="z-index: 1500;">
         <div class="card">
@@ -718,7 +704,7 @@
         </div>
         <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
     </div>
-    
+
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
         <button class="ui-button" id="back-button">
@@ -726,7 +712,7 @@
             Folders
         </button>
         <button class="ui-button" id="details-button">Details</button>
-        
+
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
@@ -747,23 +733,23 @@
                 <div class="hub" id="gesture-hub-b"></div>
             </div>
         </div>
-        
+
         <div class="edge-glow top" id="edge-top"></div>
         <div class="edge-glow bottom" id="edge-bottom"></div>
         <div class="edge-glow left" id="edge-left"></div>
         <div class="edge-glow right" id="edge-right"></div>
-        
+
         <div class="pill-counter top" id="pill-priority" data-stack="priority">0</div>
         <div class="pill-counter bottom-center" id="pill-trash" data-stack="trash">0</div>
         <div class="pill-counter left active" id="pill-in" data-stack="in">0</div>
         <div class="pill-counter right" id="pill-out" data-stack="out">0</div>
-        
+
         <div class="empty-state hidden" id="empty-state">
             <div class="empty-message">No more images in this stack</div>
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        
+
         <!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
@@ -774,7 +760,6 @@
 
         <!-- Focus Mode UI -->
         <button id="focus-stack-name" class="ui-button focus-mode-ui"></button>
-        <div id="focus-filename-display" class="ui-button focus-mode-ui" style="background: transparent; border: none; cursor: default;"></div>
         <div id="focus-image-count" class="ui-button focus-mode-ui"></div>
         <button id="focus-favorite-btn" class="focus-mode-ui">
             <svg id="focus-favorite-icon" style="width: 28px; height: 28px;" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/></svg>
@@ -784,11 +769,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
-        <div id="toast" class="toast"></div>
         <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
     </div>
-    
+
     <!-- Enhanced Grid Modal -->
     <div id="grid-modal" class="modal hidden">
         <div class="modal-content">
@@ -804,7 +787,7 @@
                         </svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-2">
                     <span class="selection-count">
                         <span id="selection-text">0 selected</span>
@@ -819,7 +802,7 @@
                         <span id="grid-size-value">4</span>
                     </div>
                 </div>
-                
+
                 <div class="grid-row-3">
                     <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
                     <div class="search-helper">
@@ -837,7 +820,7 @@
                          <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
-                
+
                 <div class="grid-row-4">
                     <div class="bulk-actions">
                         <button id="tag-selected" class="btn btn-primary">Tag</button>
@@ -856,7 +839,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Unified Action Modal -->
     <div id="action-modal" class="modal hidden">
         <div class="modal-content action-modal">
@@ -868,7 +851,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Details Modal -->
     <div id="details-modal" class="modal hidden">
         <div class="modal-content details-modal-content">
@@ -880,14 +863,14 @@
                     </svg>
                 </button>
             </div>
-            
+
             <div class="tab-nav">
                 <button class="tab-button active" data-tab="info">Info</button>
                 <button class="tab-button" data-tab="tags">Tags</button>
                 <button class="tab-button" data-tab="notes">Notes</button>
                 <button class="tab-button" data-tab="metadata">Metadata</button>
             </div>
-            
+
             <div class="details-content">
                 <div id="tab-info" class="tab-content active">
                     <div style="margin-bottom: 20px;">
@@ -907,19 +890,19 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-tags" class="tab-content">
                     <div style="margin-bottom: 20px;">
                         <div class="tags-container" id="detail-tags"></div>
                     </div>
                 </div>
-                
+
                 <div id="tab-notes" class="tab-content">
                     <div style="margin-bottom: 24px;">
                         <label for="detail-notes" style="font-size: 14px; color: #6b7280; min-width: 80px; font-weight: 500;">Notes:</label>
                         <textarea id="detail-notes" class="notes-textarea" placeholder="Add your notes here..."></textarea>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Quality Rating:</div>
                         <div class="star-rating" id="quality-rating">
@@ -930,7 +913,7 @@
                             <svg class="star" data-rating="5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
                         </div>
                     </div>
-                    
+
                     <div style="margin-bottom: 20px;">
                         <div style="font-size: 14px; font-weight: 500; color: #374151; margin-bottom: 8px;">Content Rating:</div>
                         <div class="star-rating" id="content-rating">
@@ -942,7 +925,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="tab-metadata" class="tab-content">
                     <table class="metadata-table" id="metadata-table"></table>
                 </div>
@@ -952,7 +935,7 @@
 
     <script>
         // ===== ORBITAL8 Goji Version - App Root =====
-        
+
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const createDefaultGridDragSession = () => ({
@@ -1006,7 +989,6 @@
                 return this.normalizeFavorite(input);
             },
 
-            
             init() {
                 this.elements = {
                     providerScreen: document.getElementById('provider-screen'),
@@ -1014,11 +996,11 @@
                     folderScreen: document.getElementById('folder-screen'),
                     loadingScreen: document.getElementById('loading-screen'),
                     appContainer: document.getElementById('app-container'),
-                    
+
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
-                    
+
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
                     gdriveSecretContainer: document.getElementById('gdrive-secret-container'),
@@ -1033,7 +1015,8 @@
                     folderRefreshButton: document.getElementById('folder-refresh-button'),
                     folderBackButton: document.getElementById('folder-back-button'),
                     folderLogoutButton: document.getElementById('folder-logout-button'),
-                    
+                    footers: Array.from(document.querySelectorAll('.app-footer')),
+
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
                     detailsButton: document.getElementById('details-button'),
@@ -1042,11 +1025,10 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
-                    
+
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    focusFilenameDisplay: document.getElementById('focus-filename-display'),
+
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1057,7 +1039,7 @@
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
                     cancelLoading: document.getElementById('cancel-loading'),
-                    
+
                     edgeTop: document.getElementById('edge-top'),
                     edgeBottom: document.getElementById('edge-bottom'),
                     edgeLeft: document.getElementById('edge-left'),
@@ -1072,12 +1054,12 @@
                     gestureTriLeft: document.getElementById('gesture-tri-left'),
                     gestureHalfLeft: document.getElementById('gesture-half-left'),
                     gestureHalfRight: document.getElementById('gesture-half-right'),
-                    
+
                     pillPriority: document.getElementById('pill-priority'),
                     pillTrash: document.getElementById('pill-trash'),
                     pillIn: document.getElementById('pill-in'),
                     pillOut: document.getElementById('pill-out'),
-                    
+
                     gridModal: document.getElementById('grid-modal'),
                     gridContent: document.getElementById('grid-content'),
                     gridTitle: document.getElementById('grid-title'),
@@ -1089,22 +1071,22 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
-                    
+
                     tagSelected: document.getElementById('tag-selected'),
                     moveSelected: document.getElementById('move-selected'),
                     deleteSelected: document.getElementById('delete-selected'),
                     exportSelected: document.getElementById('export-selected'),
                     folderSelected: document.getElementById('folder-selected'),
-                    
+
                     actionModal: document.getElementById('action-modal'),
                     actionTitle: document.getElementById('action-title'),
                     actionContent: document.getElementById('action-content'),
                     actionCancel: document.getElementById('action-cancel'),
                     actionConfirm: document.getElementById('action-confirm'),
-                    
+
                     detailsModal: document.getElementById('details-modal'),
                     detailsModalHeader: document.getElementById('details-modal-header'),
                     gridModalHeaderMain: document.getElementById('grid-modal-header-main'),
@@ -1120,7 +1102,7 @@
                     metadataTable: document.getElementById('metadata-table')
                 };
             },
-            
+
             showScreen(screenId) {
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
@@ -1130,22 +1112,47 @@
                     }
                 });
             },
-            
+
             showModal(id) { document.getElementById(id).classList.remove('hidden'); },
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
-            
+
             showToast(message, type = 'success', important = false) {
-                if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = this.elements.footers || [];
+                if (!footers.length) {
+                    const logFn = type === 'error' ? console.error : type === 'info' ? console.info : console.log;
+                    logFn(`[${type.toUpperCase()}] ${message}`);
+                } else {
+                    const icon = type === 'error' ? '⚠️' : type === 'info' ? 'ℹ️' : '✅';
+                    const duration = important ? 6000 : 3500;
+                    footers.forEach((footer) => {
+                        let statusSpan = footer.querySelector('.footer-status-message');
+                        if (!statusSpan) {
+                            statusSpan = document.createElement('span');
+                            statusSpan.className = 'footer-status-message';
+                            const baselineText = footer.dataset.baselineText || footer.textContent.trim();
+                            statusSpan.dataset.baselineText = baselineText;
+                            statusSpan.textContent = baselineText;
+                            footer.dataset.baselineText = baselineText;
+                            const textNodes = Array.from(footer.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE);
+                            textNodes.forEach((node) => footer.removeChild(node));
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        if (statusSpan._statusTimeout) {
+                            clearTimeout(statusSpan._statusTimeout);
+                        }
+                        statusSpan.textContent = `${icon} ${message}`;
+                        statusSpan._statusTimeout = setTimeout(() => {
+                            statusSpan.textContent = statusSpan.dataset.baselineText || '';
+                            statusSpan._statusTimeout = null;
+                        }, duration);
+                    });
+                }
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
             },
-            
+
             async setImageSrc(img, file) {
                 const loadId = file.id + '_' + Date.now();
                 state.currentImageLoadId = loadId;
@@ -1158,7 +1165,7 @@
                     img.onerror = () => {
                         if (state.currentImageLoadId !== loadId) return;
                         let fallbackUrl = this.getFallbackImageUrl(file);
-                        
+
                         img.onerror = () => {
                             if (state.currentImageLoadId !== loadId) return;
                             img.src = 'data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'150\' height=\'150\' viewBox=\'0 0 150 150\' fill=\'none\'%3E%3Crect width=\'150\' height=\'150\' fill=\'%23E5E7EB\'/%3E%3Cpath d=\'M65 60H85V90H65V60Z\' fill=\'%239CA3AF\'/%3E%3Ccircle cx=\'75\' cy=\'45\' r=\'10\' fill=\'%239CA3AF\'/%3E%3C/svg%3E';
@@ -1170,7 +1177,7 @@
                     img.alt = file.name || 'Image';
                 });
             },
-            
+
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
                     if (file.thumbnailLink) {
@@ -1231,7 +1238,7 @@
                 const i = Math.floor(Math.log(bytes) / Math.log(k));
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
-            
+
             updateLoadingProgress(current, total, message = '') {
                 state.loadingProgress = { current, total };
                 this.elements.loadingCounter.textContent = current;
@@ -1428,7 +1435,7 @@
                     let response;
                     const requestOptions = {};
                     if(state.activeRequests) requestOptions.signal = state.activeRequests.signal;
-                    
+
                     if (state.providerType === 'googledrive') {
                         response = await state.provider.makeApiCall(`/files/${file.id}?alt=media`, { headers: { 'Range': 'bytes=0-65535' }, ...requestOptions }, false);
                     } else {
@@ -1886,7 +1893,7 @@
                     state.currentFolder.id = folderId;
                     state.currentFolder.name = folderName;
                     state.activeRequests = new AbortController();
-                    
+
                     await this.loadImages();
                     this.switchToCommonUI();
                     if(state.syncManager) state.syncManager.start();
@@ -2188,7 +2195,7 @@
                 });
                 this.updateStackCounts();
             },
-            
+
             sortFiles(files) {
                 return [...files].sort((a, b) => {
                     const seqA = a.stackSequence || 0;
@@ -2199,7 +2206,7 @@
                     return (a.name || '').localeCompare(b.name || '');
                 });
             },
-            
+
             updateStackCounts() {
                 STACKS.forEach(stack => {
                     const count = state.stacks[stack] ? state.stacks[stack].length : 0;
@@ -2210,7 +2217,7 @@
                     }
                 });
             },
-            
+
             initializeImageDisplay() {
                 if (state.imageFiles.length === 0) {
                     this.showEmptyState();
@@ -2218,12 +2225,12 @@
                 }
                 state.currentStackPosition = 0;
                 state.currentStack = 'in';
-                
+
                 this.displayTopImageFromStack('in');
                 this.updateActiveProxTab();
                 this.updateStackCounts();
             },
-            
+
             async displayTopImageFromStack(stackName) {
                 try {
                     const stack = state.stacks[stackName];
@@ -2235,21 +2242,21 @@
                     Utils.elements.emptyState.classList.add('hidden');
                     state.currentStack = stackName;
                     state.currentStackPosition = 0;
-                    
+
                     await this.displayCurrentImage();
                     this.updateActiveProxTab();
                 } catch (error) {
                     Utils.showToast(`Error displaying stack: ${error.message}`, 'error', true);
                 }
             },
-            
+
             async displayCurrentImage() {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) {
                     this.showEmptyState();
                     return;
                 }
-                
+
                 if (state.currentStackPosition >= currentStackArray.length) {
                     state.currentStackPosition = currentStackArray.length - 1;
                 }
@@ -2266,10 +2273,7 @@
                 try {
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
-                    
-                    const folderName = state.currentFolder.name;
-                    const truncatedFolder = folderName.length > 20 ? folderName.substring(0, 20) + '...' : folderName;
-                    
+
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };
                     this.applyTransform();
@@ -2330,26 +2334,26 @@
                     Utils.elements.focusFavoriteBtn.setAttribute('aria-label', label);
                 }
             },
-            
+
             applyTransform() {
                 const transform = `scale(${state.currentScale}) translate(${state.panOffset.x}px, ${state.panOffset.y}px)`;
                 Utils.elements.centerImage.style.transform = transform;
             },
-            
+
             updateActiveProxTab() {
                 STACKS.forEach(stack => {
                     const pill = document.getElementById(`pill-${stack}`);
                     if (pill) pill.classList.remove('active');
                 });
-                
+
                 const currentPill = document.getElementById(`pill-${state.currentStack}`);
                 if (currentPill) currentPill.classList.add('active');
             },
-            
+
             async moveToStack(targetStack) {
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) return;
-                
+
                 const currentImage = currentStackArray[state.currentStackPosition];
                 if (!currentImage) return;
 
@@ -2380,7 +2384,7 @@
                     Utils.showToast(`Error moving image: ${error.message}`, 'error', true);
                 }
             },
-            
+
             showEmptyState() {
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
@@ -2483,7 +2487,7 @@
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
                     const overlay = document.createElement('div');
-                    overlay.className = 'filename-overlay';
+                    overlay.className = 'grid-filename-overlay';
                     overlay.textContent = file.name;
                     div.appendChild(img);
                     div.appendChild(overlay);
@@ -2681,7 +2685,7 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             updateSelectionUI() {
                 const count = state.grid.selected.length;
                 const buttons = [Utils.elements.tagSelected, Utils.elements.moveSelected, Utils.elements.deleteSelected, 
@@ -2689,7 +2693,7 @@
                 Utils.elements.selectionText.textContent = `${count} selected`;
                 buttons.forEach(btn => { if (btn) btn.disabled = (count === 0); });
             },
-            
+
             selectAll() {
                 const filesToSelect = state.grid.lazyLoadState.allFiles;
                 state.grid.selected = filesToSelect.map(f => f.id);
@@ -2699,20 +2703,20 @@
                 state.grid.isDirty = true;
                 this.updateSelectionUI();
             },
-            
+
             deselectAll() {
                 document.querySelectorAll('#grid-container .grid-item.selected').forEach(item => item.classList.remove('selected') );
                 state.grid.selected = [];
                 this.updateSelectionUI();
             },
-            
+
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
                 Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
                 state.grid.selected = [];
                 if (!query) { this.resetSearch(); return; }
                 state.grid.filtered = this.searchImages(query);
-                
+
                 Utils.elements.gridContainer.innerHTML = '';
                 if (state.grid.filtered.length === 0) {
                     Utils.elements.gridEmptyState.classList.remove('hidden');
@@ -2736,7 +2740,7 @@
                 Core.updateStackCounts();
                 this.deselectAll();
             },
-            
+
             searchImages(query) {
                 const lowerCaseQuery = query.toLowerCase();
                 const terms = lowerCaseQuery.split(/\s+/).filter(t => t);
@@ -2818,7 +2822,7 @@
 
                 const newStack = [...topItems, ...bottomItems];
                 const timestamp = Date.now();
-                
+
                 newStack.forEach((file, i) => {
                     file.stackSequence = timestamp - i;
                 });
@@ -3246,7 +3250,7 @@
                     this.hide();
                     return;
                 }
-                
+
                 await this.executeBulkAction({
                     action: async (fileId) => {
                         const file = state.imageFiles.find(f => f.id === fileId);
@@ -3874,7 +3878,7 @@
             init(modal, header) {
                 let pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
                 let isDragging = false;
-                
+
                 header.onmousedown = dragMouseDown;
 
                 function dragMouseDown(e) {
@@ -3895,7 +3899,7 @@
                     pos2 = pos4 - e.clientY;
                     pos3 = e.clientX;
                     pos4 = e.clientY;
-                    
+
                     let newTop = modal.offsetTop - pos2;
                     let newLeft = modal.offsetLeft - pos1;
 
@@ -4114,7 +4118,7 @@
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-                    
+
                     try {
                         if (state.isFocusMode) {
                             if (e.key === 'ArrowRight') await Gestures.nextImage();


### PR DESCRIPTION
## Summary
- remove the filename overlay markup, styles, and update hooks from every UI variant so the footer is no longer obscured
- drop the toast container and rework the shared `showToast` helper to update inline footer status spans while keeping haptic feedback for important events
- add footer status styling and element tracking across the variants and baseline template so the footer messaging shows correctly without the overlay

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e022e0c06c832d857cb009edc59696