### PR TITLE
Fix footer toast baseline handling

### DIFF
--- a/index+holdj.html
+++ b/index+holdj.html
@@ -456,6 +456,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
 
         /* NEW: Standardized UI Button */
         .ui-button {
@@ -1045,7 +1051,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/index.html
+++ b/index.html
@@ -503,6 +503,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -1269,7 +1275,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/performance-v1 (1).html
+++ b/performance-v1 (1).html
@@ -473,6 +473,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
 
         /* NEW: Standardized UI Button */
         .ui-button {
@@ -1034,7 +1040,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/performance-v1.html
+++ b/performance-v1.html
@@ -493,6 +493,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -1190,7 +1196,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/performance-v2.html
+++ b/performance-v2.html
@@ -478,6 +478,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
 
         /* NEW: Standardized UI Button */
         .ui-button {
@@ -1211,7 +1217,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/performance.html
+++ b/performance.html
@@ -493,6 +493,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -1259,7 +1265,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/poc-hold.html
+++ b/poc-hold.html
@@ -474,6 +474,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
 
         /* NEW: Standardized UI Button */
         .ui-button {
@@ -1138,7 +1144,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/thebaseline.html
+++ b/thebaseline.html
@@ -480,6 +480,12 @@
             color: rgba(255, 255, 255, 0.6); text-align: center; padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .footer-link {
             color: rgba(255, 255, 255, 0.6);
             text-decoration: none;
@@ -1087,8 +1093,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
-                
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && appState.hapticManager) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     appState.hapticManager.triggerFeedback(hapticType);

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -503,6 +503,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -1269,7 +1275,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -503,6 +503,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -1199,7 +1205,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -503,6 +503,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -1200,7 +1206,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/ui-v2-old.html
+++ b/ui-v2-old.html
@@ -508,6 +508,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
 
         /* NEW: Standardized UI Button */
         .ui-button {
@@ -1185,7 +1191,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -503,6 +503,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -1269,7 +1275,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -503,6 +503,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -1269,7 +1275,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -503,6 +503,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -1269,7 +1275,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -503,6 +503,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -1269,7 +1275,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -503,6 +503,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -1269,7 +1275,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -503,6 +503,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -1269,7 +1275,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -503,6 +503,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -1269,7 +1275,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -503,6 +503,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -1269,7 +1275,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -503,6 +503,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -1269,7 +1275,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -503,6 +503,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -1269,7 +1275,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -503,6 +503,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -1269,7 +1275,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);

--- a/ui.html
+++ b/ui.html
@@ -500,6 +500,12 @@
             padding: 4px 8px;
             font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
         }
+        .app-footer .footer-status {
+            color: inherit;
+        }
+        .app-footer .footer-status:not(:empty) {
+            margin-right: 8px;
+        }
 
         /* NEW: Standardized UI Button */
         .ui-button {
@@ -1174,7 +1180,44 @@
                 const toast = this.elements.toast;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
+                const footers = Array.from(document.querySelectorAll('.app-footer'));
+                const footerStatuses = footers.map(footer => {
+                    let statusSpan = footer.querySelector('.footer-status');
+                    if (!statusSpan) {
+                        statusSpan = document.createElement('span');
+                        statusSpan.className = 'footer-status';
+                        const baselineAttr = footer.dataset.baselineText;
+                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
+                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
+                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
+                        statusSpan.dataset.baselineText = baselineText;
+                        if (textNodes.length) {
+                            footer.insertBefore(statusSpan, textNodes[0]);
+                            textNodes.forEach(node => footer.removeChild(node));
+                        } else {
+                            footer.insertBefore(statusSpan, footer.firstChild);
+                        }
+                        statusSpan.textContent = baselineText;
+                    } else if (statusSpan.dataset.baselineText === undefined) {
+                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                    }
+                    const baselineText = statusSpan.dataset.baselineText ?? '';
+                    statusSpan.textContent = message;
+                    statusSpan.classList.remove('success', 'error', 'info');
+                    statusSpan.classList.add(type);
+                    return { statusSpan, baselineText };
+                });
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                }
+                this._toastHideTimer = setTimeout(() => {
+                    toast.classList.remove('show');
+                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
+                        statusSpan.textContent = baselineText;
+                        statusSpan.classList.remove('success', 'error', 'info');
+                    });
+                    this._toastHideTimer = null;
+                }, 3000);
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);


### PR DESCRIPTION
## Summary
- update toast helpers across the baseline and shared variants to capture footer baseline text from existing text nodes or explicit data attributes before displaying toast messages
- add footer status styling so the injected spans display without affecting link-only footers and reset to the stored baseline after the toast timeout

## Testing
- Manual Playwright verification of toast reset on `thebaseline.html` and `index.html`


------
https://chatgpt.com/codex/tasks/task_e_68e0b8f77024832d856e792211590e37