### PR TITLE
Switch Drive asset links to export=view baseline

### DIFF
--- a/index.html
+++ b/index.html
@@ -1063,7 +1063,7 @@
             },
             buildUcDownloadUrl(fileId) {
                 if (!fileId) return null;
-                return `https://drive.google.com/uc?export=download&id=${fileId}`;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
             },
             buildApiDownloadUrl(fileId) {
                 if (!fileId) return null;
@@ -1081,7 +1081,7 @@
                     }
                     if (host === 'drive.google.com') {
                         if (parsed.pathname.startsWith('/uc')) {
-                            parsed.searchParams.set('export', 'download');
+                            parsed.searchParams.set('export', 'view');
                             if (!parsed.searchParams.get('id') && fileId) {
                                 parsed.searchParams.set('id', fileId);
                             }
@@ -3543,7 +3543,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3667,7 +3667,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -1063,7 +1063,7 @@
             },
             buildUcDownloadUrl(fileId) {
                 if (!fileId) return null;
-                return `https://drive.google.com/uc?export=download&id=${fileId}`;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
             },
             buildApiDownloadUrl(fileId) {
                 if (!fileId) return null;
@@ -1081,7 +1081,7 @@
                     }
                     if (host === 'drive.google.com') {
                         if (parsed.pathname.startsWith('/uc')) {
-                            parsed.searchParams.set('export', 'download');
+                            parsed.searchParams.set('export', 'view');
                             if (!parsed.searchParams.get('id') && fileId) {
                                 parsed.searchParams.set('id', fileId);
                             }
@@ -3543,7 +3543,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3667,7 +3667,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -3467,7 +3467,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3573,7 +3573,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -3468,7 +3468,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3574,7 +3574,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -1063,7 +1063,7 @@
             },
             buildUcDownloadUrl(fileId) {
                 if (!fileId) return null;
-                return `https://drive.google.com/uc?export=download&id=${fileId}`;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
             },
             buildApiDownloadUrl(fileId) {
                 if (!fileId) return null;
@@ -1081,7 +1081,7 @@
                     }
                     if (host === 'drive.google.com') {
                         if (parsed.pathname.startsWith('/uc')) {
-                            parsed.searchParams.set('export', 'download');
+                            parsed.searchParams.set('export', 'view');
                             if (!parsed.searchParams.get('id') && fileId) {
                                 parsed.searchParams.set('id', fileId);
                             }
@@ -3543,7 +3543,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3667,7 +3667,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -1063,7 +1063,7 @@
             },
             buildUcDownloadUrl(fileId) {
                 if (!fileId) return null;
-                return `https://drive.google.com/uc?export=download&id=${fileId}`;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
             },
             buildApiDownloadUrl(fileId) {
                 if (!fileId) return null;
@@ -1081,7 +1081,7 @@
                     }
                     if (host === 'drive.google.com') {
                         if (parsed.pathname.startsWith('/uc')) {
-                            parsed.searchParams.set('export', 'download');
+                            parsed.searchParams.set('export', 'view');
                             if (!parsed.searchParams.get('id') && fileId) {
                                 parsed.searchParams.set('id', fileId);
                             }
@@ -3543,7 +3543,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3667,7 +3667,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -1063,7 +1063,7 @@
             },
             buildUcDownloadUrl(fileId) {
                 if (!fileId) return null;
-                return `https://drive.google.com/uc?export=download&id=${fileId}`;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
             },
             buildApiDownloadUrl(fileId) {
                 if (!fileId) return null;
@@ -1081,7 +1081,7 @@
                     }
                     if (host === 'drive.google.com') {
                         if (parsed.pathname.startsWith('/uc')) {
-                            parsed.searchParams.set('export', 'download');
+                            parsed.searchParams.set('export', 'view');
                             if (!parsed.searchParams.get('id') && fileId) {
                                 parsed.searchParams.set('id', fileId);
                             }
@@ -3543,7 +3543,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3667,7 +3667,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -1063,7 +1063,7 @@
             },
             buildUcDownloadUrl(fileId) {
                 if (!fileId) return null;
-                return `https://drive.google.com/uc?export=download&id=${fileId}`;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
             },
             buildApiDownloadUrl(fileId) {
                 if (!fileId) return null;
@@ -1081,7 +1081,7 @@
                     }
                     if (host === 'drive.google.com') {
                         if (parsed.pathname.startsWith('/uc')) {
-                            parsed.searchParams.set('export', 'download');
+                            parsed.searchParams.set('export', 'view');
                             if (!parsed.searchParams.get('id') && fileId) {
                                 parsed.searchParams.set('id', fileId);
                             }
@@ -3543,7 +3543,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3667,7 +3667,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -1063,7 +1063,7 @@
             },
             buildUcDownloadUrl(fileId) {
                 if (!fileId) return null;
-                return `https://drive.google.com/uc?export=download&id=${fileId}`;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
             },
             buildApiDownloadUrl(fileId) {
                 if (!fileId) return null;
@@ -1081,7 +1081,7 @@
                     }
                     if (host === 'drive.google.com') {
                         if (parsed.pathname.startsWith('/uc')) {
-                            parsed.searchParams.set('export', 'download');
+                            parsed.searchParams.set('export', 'view');
                             if (!parsed.searchParams.get('id') && fileId) {
                                 parsed.searchParams.set('id', fileId);
                             }
@@ -3543,7 +3543,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3667,7 +3667,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -1063,7 +1063,7 @@
             },
             buildUcDownloadUrl(fileId) {
                 if (!fileId) return null;
-                return `https://drive.google.com/uc?export=download&id=${fileId}`;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
             },
             buildApiDownloadUrl(fileId) {
                 if (!fileId) return null;
@@ -1081,7 +1081,7 @@
                     }
                     if (host === 'drive.google.com') {
                         if (parsed.pathname.startsWith('/uc')) {
-                            parsed.searchParams.set('export', 'download');
+                            parsed.searchParams.set('export', 'view');
                             if (!parsed.searchParams.get('id') && fileId) {
                                 parsed.searchParams.set('id', fileId);
                             }
@@ -3543,7 +3543,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3667,7 +3667,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -1063,7 +1063,7 @@
             },
             buildUcDownloadUrl(fileId) {
                 if (!fileId) return null;
-                return `https://drive.google.com/uc?export=download&id=${fileId}`;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
             },
             buildApiDownloadUrl(fileId) {
                 if (!fileId) return null;
@@ -1081,7 +1081,7 @@
                     }
                     if (host === 'drive.google.com') {
                         if (parsed.pathname.startsWith('/uc')) {
-                            parsed.searchParams.set('export', 'download');
+                            parsed.searchParams.set('export', 'view');
                             if (!parsed.searchParams.get('id') && fileId) {
                                 parsed.searchParams.set('id', fileId);
                             }
@@ -3543,7 +3543,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3667,7 +3667,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -1063,7 +1063,7 @@
             },
             buildUcDownloadUrl(fileId) {
                 if (!fileId) return null;
-                return `https://drive.google.com/uc?export=download&id=${fileId}`;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
             },
             buildApiDownloadUrl(fileId) {
                 if (!fileId) return null;
@@ -1081,7 +1081,7 @@
                     }
                     if (host === 'drive.google.com') {
                         if (parsed.pathname.startsWith('/uc')) {
-                            parsed.searchParams.set('export', 'download');
+                            parsed.searchParams.set('export', 'view');
                             if (!parsed.searchParams.get('id') && fileId) {
                                 parsed.searchParams.set('id', fileId);
                             }
@@ -3543,7 +3543,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3667,7 +3667,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -1063,7 +1063,7 @@
             },
             buildUcDownloadUrl(fileId) {
                 if (!fileId) return null;
-                return `https://drive.google.com/uc?export=download&id=${fileId}`;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
             },
             buildApiDownloadUrl(fileId) {
                 if (!fileId) return null;
@@ -1081,7 +1081,7 @@
                     }
                     if (host === 'drive.google.com') {
                         if (parsed.pathname.startsWith('/uc')) {
-                            parsed.searchParams.set('export', 'download');
+                            parsed.searchParams.set('export', 'view');
                             if (!parsed.searchParams.get('id') && fileId) {
                                 parsed.searchParams.set('id', fileId);
                             }
@@ -3543,7 +3543,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3667,7 +3667,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -1063,7 +1063,7 @@
             },
             buildUcDownloadUrl(fileId) {
                 if (!fileId) return null;
-                return `https://drive.google.com/uc?export=download&id=${fileId}`;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
             },
             buildApiDownloadUrl(fileId) {
                 if (!fileId) return null;
@@ -1081,7 +1081,7 @@
                     }
                     if (host === 'drive.google.com') {
                         if (parsed.pathname.startsWith('/uc')) {
-                            parsed.searchParams.set('export', 'download');
+                            parsed.searchParams.set('export', 'view');
                             if (!parsed.searchParams.get('id') && fileId) {
                                 parsed.searchParams.set('id', fileId);
                             }
@@ -3543,7 +3543,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3667,7 +3667,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -1063,7 +1063,7 @@
             },
             buildUcDownloadUrl(fileId) {
                 if (!fileId) return null;
-                return `https://drive.google.com/uc?export=download&id=${fileId}`;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
             },
             buildApiDownloadUrl(fileId) {
                 if (!fileId) return null;
@@ -1081,7 +1081,7 @@
                     }
                     if (host === 'drive.google.com') {
                         if (parsed.pathname.startsWith('/uc')) {
-                            parsed.searchParams.set('export', 'download');
+                            parsed.searchParams.set('export', 'view');
                             if (!parsed.searchParams.get('id') && fileId) {
                                 parsed.searchParams.set('id', fileId);
                             }
@@ -3543,7 +3543,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3667,7 +3667,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: apiDownloadUrl || this.buildUcDownloadUrl(file.id),
+                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };


### PR DESCRIPTION
## Summary
- update Drive link helpers across index.html and legacy UIs to return https://drive.google.com/uc?id=${fileId}&export=view
- adjust URL normalization to preserve export=view and prefer the new pattern when collecting file metadata

## Testing
- not run (manual verification required)

------
https://chatgpt.com/codex/tasks/task_e_68e1518af4fc832dbc25ce2502821477