### PR TITLE
Align toast notifications with footer overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,18 +127,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
-        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+.folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
             background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
@@ -184,36 +173,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
-
-        
-        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+.edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
             bottom: 0; left: 0; right: 0; height: 8px; 
@@ -409,27 +369,7 @@
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-
-        .grid-filename-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.7);
-            color: white;
-            padding: 8px;
-            font-size: 14px;
-            text-align: center;
-            opacity: 0;
-            transition: opacity 0.3s;
-            pointer-events: none;
-        }
-
-        .grid-item:hover .grid-filename-overlay {
-            opacity: 1;
-        }
-        
-        .details-modal-content { 
+.details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
@@ -496,18 +436,58 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
-        .app-footer {
-            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
-            color: rgba(255, 255, 255, 0.6); text-align: center;
-            padding: 4px 8px;
-            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+.app-footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6);
+            text-align: center;
+            padding: 8px 12px;
+            font-size: 10px;
+            z-index: 5;
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .app-footer .footer-baseline {
+            color: rgba(255, 255, 255, 0.6);
         }
         .app-footer .footer-status {
-            color: inherit;
+            position: absolute;
+            inset: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 14px;
+            border-radius: 9999px;
+            background: rgba(0, 0, 0, 0.85);
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: nowrap;
+            max-width: calc(100% - 24px);
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-        .app-footer .footer-status:not(:empty) {
-            margin-right: 8px;
+        .app-footer .footer-status.active {
+            opacity: 1;
+        }
+        .app-footer .footer-status.success {
+            background: rgba(16, 185, 129, 0.9);
+        }
+        .app-footer .footer-status.info {
+            background: rgba(59, 130, 246, 0.9);
+        }
+        .app-footer .footer-status.error {
+            background: rgba(239, 68, 68, 0.9);
         }
         .app-footer .footer-link {
             background: transparent;
@@ -521,10 +501,6 @@
             transition: color 0.2s ease;
         }
         .app-footer .footer-link:hover,
-        .app-footer .footer-link:focus-visible {
-            color: #f59e0b;
-            text-decoration: underline;
-        }
         .app-footer .footer-link:focus-visible {
             outline: none;
         }
@@ -587,9 +563,7 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #center-trash-btn,
-        .app-container.focus-mode .filename-overlay { display: none; }
-
-        .app-container.focus-mode .focus-mode-ui { display: flex; }
+.app-container.focus-mode .focus-mode-ui { display: flex; }
         
         .hidden { display: none !important; }
         
@@ -731,10 +705,19 @@
                         Enable Haptic Feedback (Mobile)
                     </label>
                 </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="debug-toasts-enabled" checked style="margin: 0;">
+                        Enable Debug Toasts
+                    </label>
+                </div>
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -749,7 +732,10 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -764,7 +750,10 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Loading Screen -->
@@ -778,7 +767,10 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Main App Container -->
@@ -825,10 +817,7 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
-
-        
-        <!-- Center Stage UI -->
+<!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -848,8 +837,10 @@
             </svg>
         </button>
         
-        <div id="toast" class="toast"></div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -1040,7 +1031,8 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
-            pendingBackgroundProbe: null
+            pendingBackgroundProbe: null,
+            showDebugToasts: true
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -1149,6 +1141,7 @@
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
+                    debugToastToggle: document.getElementById('debug-toasts-enabled'),
                     
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
@@ -1173,11 +1166,9 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1271,45 +1262,35 @@
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                    return;
+                }
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                const footers = Array.from(document.querySelectorAll('.app-footer'));
-                const footerStatuses = footers.map(footer => {
+                const statusElements = [];
+                document.querySelectorAll('.app-footer').forEach(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
                     if (!statusSpan) {
                         statusSpan = document.createElement('span');
                         statusSpan.className = 'footer-status';
-                        const baselineAttr = footer.dataset.baselineText;
-                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
-                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
-                        statusSpan.dataset.baselineText = baselineText;
-                        if (textNodes.length) {
-                            footer.insertBefore(statusSpan, textNodes[0]);
-                            textNodes.forEach(node => footer.removeChild(node));
-                        } else {
-                            footer.insertBefore(statusSpan, footer.firstChild);
-                        }
-                        statusSpan.textContent = baselineText;
-                    } else if (statusSpan.dataset.baselineText === undefined) {
-                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                        statusSpan.setAttribute('aria-live', 'polite');
+                        footer.appendChild(statusSpan);
                     }
-                    const baselineText = statusSpan.dataset.baselineText ?? '';
                     statusSpan.textContent = message;
-                    statusSpan.classList.remove('success', 'error', 'info');
-                    statusSpan.classList.add(type);
-                    return { statusSpan, baselineText };
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                    statusSpan.classList.add('active', type);
+                    statusElements.push(statusSpan);
                 });
+                if (statusElements.length === 0) {
+                    return;
+                }
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    toast.classList.remove('show');
-                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
-                        statusSpan.textContent = baselineText;
-                        statusSpan.classList.remove('success', 'error', 'info');
+                    statusElements.forEach(statusSpan => {
+                        statusSpan.textContent = '';
+                        statusSpan.classList.remove('active', 'success', 'error', 'info');
                     });
                     this._toastHideTimer = null;
                 }, 3000);
@@ -1317,6 +1298,17 @@
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
+            },
+
+            clearFooterToasts() {
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                    this._toastHideTimer = null;
+                }
+                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
+                    statusSpan.textContent = '';
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                });
             },
             
             async setImageSrc(img, file) {
@@ -4847,8 +4839,7 @@
                     const folderName = state.currentFolder?.name || '';
                     const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
                     const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-                    if (Utils.elements.filenameOverlay) {
-                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+/ ${filenameWithoutExtension}`;
                         const directUrl = state.export?.getDirectImageURL?.(currentFile);
                         Utils.elements.filenameOverlay.href = directUrl || '#';
                         Utils.elements.filenameOverlay.classList.add('visible');
@@ -5062,10 +5053,7 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
-                if (Utils.elements.filenameOverlay) {
-                    Utils.elements.filenameOverlay.classList.remove('visible');
-                }
-                this.updateImageCounters();
+this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -5166,11 +5154,7 @@
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    const overlay = document.createElement('div');
-                    overlay.className = 'grid-filename-overlay';
-                    overlay.textContent = file.name;
                     div.appendChild(img);
-                    div.appendChild(overlay);
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
@@ -6579,7 +6563,27 @@
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
                 });
-                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+                const hapticToggle = document.getElementById('haptic-enabled');
+                if (hapticToggle) {
+                    hapticToggle.addEventListener('change', (e) => {
+                        if (state.haptic) {
+                            state.haptic.setEnabled(e.target.checked);
+                        }
+                    });
+                }
+                const debugToggle = document.getElementById('debug-toasts-enabled');
+                state.showDebugToasts = debugToggle ? debugToggle.checked : true;
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                }
+                if (debugToggle) {
+                    debugToggle.addEventListener('change', (e) => {
+                        state.showDebugToasts = e.target.checked;
+                        if (!state.showDebugToasts) {
+                            Utils.clearFooterToasts();
+                        }
+                    });
+                }
             },
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -127,18 +127,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
-        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+.folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
             background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
@@ -184,36 +173,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
-
-        
-        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+.edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
             bottom: 0; left: 0; right: 0; height: 8px; 
@@ -409,27 +369,7 @@
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-
-        .grid-filename-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.7);
-            color: white;
-            padding: 8px;
-            font-size: 14px;
-            text-align: center;
-            opacity: 0;
-            transition: opacity 0.3s;
-            pointer-events: none;
-        }
-
-        .grid-item:hover .grid-filename-overlay {
-            opacity: 1;
-        }
-        
-        .details-modal-content { 
+.details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
@@ -496,18 +436,58 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
-        .app-footer {
-            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
-            color: rgba(255, 255, 255, 0.6); text-align: center;
-            padding: 4px 8px;
-            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+.app-footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6);
+            text-align: center;
+            padding: 8px 12px;
+            font-size: 10px;
+            z-index: 5;
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .app-footer .footer-baseline {
+            color: rgba(255, 255, 255, 0.6);
         }
         .app-footer .footer-status {
-            color: inherit;
+            position: absolute;
+            inset: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 14px;
+            border-radius: 9999px;
+            background: rgba(0, 0, 0, 0.85);
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: nowrap;
+            max-width: calc(100% - 24px);
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-        .app-footer .footer-status:not(:empty) {
-            margin-right: 8px;
+        .app-footer .footer-status.active {
+            opacity: 1;
+        }
+        .app-footer .footer-status.success {
+            background: rgba(16, 185, 129, 0.9);
+        }
+        .app-footer .footer-status.info {
+            background: rgba(59, 130, 246, 0.9);
+        }
+        .app-footer .footer-status.error {
+            background: rgba(239, 68, 68, 0.9);
         }
         .app-footer .footer-link {
             background: transparent;
@@ -520,12 +500,10 @@
             text-decoration: none;
             transition: color 0.2s ease;
         }
-        .app-footer .footer-link:hover,
-        .app-footer .footer-link:focus-visible {
-            color: #f59e0b;
-            text-decoration: underline;
+        .app-footer .footer-link:hover,        .app-footer .footer-link:focus-visible {
+            outline: none;
         }
-        .app-footer .footer-link:focus-visible {
+.app-footer .footer-link:focus-visible {
             outline: none;
         }
 
@@ -587,9 +565,7 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #center-trash-btn,
-        .app-container.focus-mode .filename-overlay { display: none; }
-
-        .app-container.focus-mode .focus-mode-ui { display: flex; }
+.app-container.focus-mode .focus-mode-ui { display: flex; }
         
         .hidden { display: none !important; }
         
@@ -731,10 +707,19 @@
                         Enable Haptic Feedback (Mobile)
                     </label>
                 </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="debug-toasts-enabled" checked style="margin: 0;">
+                        Enable Debug Toasts
+                    </label>
+                </div>
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -749,7 +734,10 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -764,7 +752,10 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Loading Screen -->
@@ -778,7 +769,10 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Main App Container -->
@@ -825,10 +819,7 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
-
-        
-        <!-- Center Stage UI -->
+<!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -848,8 +839,10 @@
             </svg>
         </button>
         
-        <div id="toast" class="toast"></div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -1040,7 +1033,8 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
-            pendingBackgroundProbe: null
+            pendingBackgroundProbe: null,
+            showDebugToasts: true
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -1149,6 +1143,7 @@
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
+                    debugToastToggle: document.getElementById('debug-toasts-enabled'),
                     
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
@@ -1173,11 +1168,9 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1271,45 +1264,35 @@
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
+                if (!state.showDebugToasts) {
+                    this.clearFooterToasts();
+                    return;
+                }
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                const footers = Array.from(document.querySelectorAll('.app-footer'));
-                const footerStatuses = footers.map(footer => {
+                const statusElements = [];
+                document.querySelectorAll('.app-footer').forEach(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
                     if (!statusSpan) {
                         statusSpan = document.createElement('span');
                         statusSpan.className = 'footer-status';
-                        const baselineAttr = footer.dataset.baselineText;
-                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
-                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
-                        statusSpan.dataset.baselineText = baselineText;
-                        if (textNodes.length) {
-                            footer.insertBefore(statusSpan, textNodes[0]);
-                            textNodes.forEach(node => footer.removeChild(node));
-                        } else {
-                            footer.insertBefore(statusSpan, footer.firstChild);
-                        }
-                        statusSpan.textContent = baselineText;
-                    } else if (statusSpan.dataset.baselineText === undefined) {
-                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                        statusSpan.setAttribute('aria-live', 'polite');
+                        footer.appendChild(statusSpan);
                     }
-                    const baselineText = statusSpan.dataset.baselineText ?? '';
                     statusSpan.textContent = message;
-                    statusSpan.classList.remove('success', 'error', 'info');
-                    statusSpan.classList.add(type);
-                    return { statusSpan, baselineText };
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                    statusSpan.classList.add('active', type);
+                    statusElements.push(statusSpan);
                 });
+                if (statusElements.length === 0) {
+                    return;
+                }
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    toast.classList.remove('show');
-                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
-                        statusSpan.textContent = baselineText;
-                        statusSpan.classList.remove('success', 'error', 'info');
+                    statusElements.forEach(statusSpan => {
+                        statusSpan.textContent = '';
+                        statusSpan.classList.remove('active', 'success', 'error', 'info');
                     });
                     this._toastHideTimer = null;
                 }, 3000);
@@ -1317,6 +1300,17 @@
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
+            },
+
+            clearFooterToasts() {
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                    this._toastHideTimer = null;
+                }
+                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
+                    statusSpan.textContent = '';
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                });
             },
             
             async setImageSrc(img, file) {
@@ -4847,8 +4841,7 @@
                     const folderName = state.currentFolder?.name || '';
                     const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
                     const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-                    if (Utils.elements.filenameOverlay) {
-                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+/ ${filenameWithoutExtension}`;
                         const directUrl = state.export?.getDirectImageURL?.(currentFile);
                         Utils.elements.filenameOverlay.href = directUrl || '#';
                         Utils.elements.filenameOverlay.classList.add('visible');
@@ -5062,10 +5055,7 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
-                if (Utils.elements.filenameOverlay) {
-                    Utils.elements.filenameOverlay.classList.remove('visible');
-                }
-                this.updateImageCounters();
+this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -5166,11 +5156,7 @@
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    const overlay = document.createElement('div');
-                    overlay.className = 'grid-filename-overlay';
-                    overlay.textContent = file.name;
                     div.appendChild(img);
-                    div.appendChild(overlay);
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
@@ -6573,8 +6559,29 @@
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
                 });
-                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+                const hapticToggle = document.getElementById('haptic-enabled');
+                if (hapticToggle) {
+                    hapticToggle.addEventListener('change', (e) => {
+                        if (state.haptic) {
+                            state.haptic.setEnabled(e.target.checked);
+                        }
+                    });
+                }
+                const debugToggle = document.getElementById('debug-toasts-enabled');
+                state.showDebugToasts = debugToggle ? debugToggle.checked : true;
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                }
+                if (debugToggle) {
+                    debugToggle.addEventListener('change', (e) => {
+                        state.showDebugToasts = e.target.checked;
+                        if (!state.showDebugToasts) {
+                            Utils.clearFooterToasts();
+                        }
+                    });
+                }
             },
+
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
                 Utils.elements.authBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -127,18 +127,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
-        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+.folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
             background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
@@ -184,36 +173,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
-
-        
-        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+.edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
             bottom: 0; left: 0; right: 0; height: 8px; 
@@ -409,27 +369,7 @@
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-
-        .grid-filename-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.7);
-            color: white;
-            padding: 8px;
-            font-size: 14px;
-            text-align: center;
-            opacity: 0;
-            transition: opacity 0.3s;
-            pointer-events: none;
-        }
-
-        .grid-item:hover .grid-filename-overlay {
-            opacity: 1;
-        }
-        
-        .details-modal-content { 
+.details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
@@ -496,18 +436,58 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
-        .app-footer {
-            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
-            color: rgba(255, 255, 255, 0.6); text-align: center;
-            padding: 4px 8px;
-            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+.app-footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6);
+            text-align: center;
+            padding: 8px 12px;
+            font-size: 10px;
+            z-index: 5;
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .app-footer .footer-baseline {
+            color: rgba(255, 255, 255, 0.6);
         }
         .app-footer .footer-status {
-            color: inherit;
+            position: absolute;
+            inset: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 14px;
+            border-radius: 9999px;
+            background: rgba(0, 0, 0, 0.85);
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: nowrap;
+            max-width: calc(100% - 24px);
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-        .app-footer .footer-status:not(:empty) {
-            margin-right: 8px;
+        .app-footer .footer-status.active {
+            opacity: 1;
+        }
+        .app-footer .footer-status.success {
+            background: rgba(16, 185, 129, 0.9);
+        }
+        .app-footer .footer-status.info {
+            background: rgba(59, 130, 246, 0.9);
+        }
+        .app-footer .footer-status.error {
+            background: rgba(239, 68, 68, 0.9);
         }
         .app-footer .footer-link {
             background: transparent;
@@ -520,12 +500,10 @@
             text-decoration: none;
             transition: color 0.2s ease;
         }
-        .app-footer .footer-link:hover,
-        .app-footer .footer-link:focus-visible {
-            color: #f59e0b;
-            text-decoration: underline;
+        .app-footer .footer-link:hover,        .app-footer .footer-link:focus-visible {
+            outline: none;
         }
-        .app-footer .footer-link:focus-visible {
+.app-footer .footer-link:focus-visible {
             outline: none;
         }
 
@@ -587,9 +565,7 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #center-trash-btn,
-        .app-container.focus-mode .filename-overlay { display: none; }
-
-        .app-container.focus-mode .focus-mode-ui { display: flex; }
+.app-container.focus-mode .focus-mode-ui { display: flex; }
         
         .hidden { display: none !important; }
         
@@ -731,10 +707,19 @@
                         Enable Haptic Feedback (Mobile)
                     </label>
                 </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="debug-toasts-enabled" checked style="margin: 0;">
+                        Enable Debug Toasts
+                    </label>
+                </div>
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -749,7 +734,10 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -764,7 +752,10 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Loading Screen -->
@@ -778,7 +769,10 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Main App Container -->
@@ -825,10 +819,7 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
-
-        
-        <!-- Center Stage UI -->
+<!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -848,8 +839,10 @@
             </svg>
         </button>
         
-        <div id="toast" class="toast"></div>
-        <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -1039,7 +1032,8 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
-            pendingBackgroundProbe: null
+            pendingBackgroundProbe: null,
+            showDebugToasts: true
         };
         const Utils = {
             elements: {},
@@ -1079,6 +1073,7 @@
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
+                    debugToastToggle: document.getElementById('debug-toasts-enabled'),
                     
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
@@ -1103,11 +1098,9 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1201,45 +1194,35 @@
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
+                if (!state.showDebugToasts) {
+                    this.clearFooterToasts();
+                    return;
+                }
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                const footers = Array.from(document.querySelectorAll('.app-footer'));
-                const footerStatuses = footers.map(footer => {
+                const statusElements = [];
+                document.querySelectorAll('.app-footer').forEach(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
                     if (!statusSpan) {
                         statusSpan = document.createElement('span');
                         statusSpan.className = 'footer-status';
-                        const baselineAttr = footer.dataset.baselineText;
-                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
-                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
-                        statusSpan.dataset.baselineText = baselineText;
-                        if (textNodes.length) {
-                            footer.insertBefore(statusSpan, textNodes[0]);
-                            textNodes.forEach(node => footer.removeChild(node));
-                        } else {
-                            footer.insertBefore(statusSpan, footer.firstChild);
-                        }
-                        statusSpan.textContent = baselineText;
-                    } else if (statusSpan.dataset.baselineText === undefined) {
-                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                        statusSpan.setAttribute('aria-live', 'polite');
+                        footer.appendChild(statusSpan);
                     }
-                    const baselineText = statusSpan.dataset.baselineText ?? '';
                     statusSpan.textContent = message;
-                    statusSpan.classList.remove('success', 'error', 'info');
-                    statusSpan.classList.add(type);
-                    return { statusSpan, baselineText };
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                    statusSpan.classList.add('active', type);
+                    statusElements.push(statusSpan);
                 });
+                if (statusElements.length === 0) {
+                    return;
+                }
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    toast.classList.remove('show');
-                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
-                        statusSpan.textContent = baselineText;
-                        statusSpan.classList.remove('success', 'error', 'info');
+                    statusElements.forEach(statusSpan => {
+                        statusSpan.textContent = '';
+                        statusSpan.classList.remove('active', 'success', 'error', 'info');
                     });
                     this._toastHideTimer = null;
                 }, 3000);
@@ -1247,6 +1230,17 @@
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
+            },
+
+            clearFooterToasts() {
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                    this._toastHideTimer = null;
+                }
+                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
+                    statusSpan.textContent = '';
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                });
             },
             
             async setImageSrc(img, file) {
@@ -4686,8 +4680,7 @@
                     const folderName = state.currentFolder?.name || '';
                     const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
                     const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-                    if (Utils.elements.filenameOverlay) {
-                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+/ ${filenameWithoutExtension}`;
                         const directUrl = state.export?.getDirectImageURL?.(currentFile);
                         Utils.elements.filenameOverlay.href = directUrl || '#';
                         Utils.elements.filenameOverlay.classList.add('visible');
@@ -4901,10 +4894,7 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
-                if (Utils.elements.filenameOverlay) {
-                    Utils.elements.filenameOverlay.classList.remove('visible');
-                }
-                this.updateImageCounters();
+this.updateImageCounters();
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
                     Utils.elements.centerImage.alt = 'No images in this stack';
@@ -5000,11 +4990,7 @@
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    const overlay = document.createElement('div');
-                    overlay.className = 'grid-filename-overlay';
-                    overlay.textContent = file.name;
                     div.appendChild(img);
-                    div.appendChild(overlay);
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
@@ -6424,8 +6410,29 @@
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
                 });
-                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+                const hapticToggle = document.getElementById('haptic-enabled');
+                if (hapticToggle) {
+                    hapticToggle.addEventListener('change', (e) => {
+                        if (state.haptic) {
+                            state.haptic.setEnabled(e.target.checked);
+                        }
+                    });
+                }
+                const debugToggle = document.getElementById('debug-toasts-enabled');
+                state.showDebugToasts = debugToggle ? debugToggle.checked : true;
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                }
+                if (debugToggle) {
+                    debugToggle.addEventListener('change', (e) => {
+                        state.showDebugToasts = e.target.checked;
+                        if (!state.showDebugToasts) {
+                            Utils.clearFooterToasts();
+                        }
+                    });
+                }
             },
+
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
                 Utils.elements.authBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -127,18 +127,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
-        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+.folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
             background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
@@ -184,36 +173,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
-
-        
-        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+.edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
             bottom: 0; left: 0; right: 0; height: 8px; 
@@ -409,27 +369,7 @@
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-
-        .grid-filename-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.7);
-            color: white;
-            padding: 8px;
-            font-size: 14px;
-            text-align: center;
-            opacity: 0;
-            transition: opacity 0.3s;
-            pointer-events: none;
-        }
-
-        .grid-item:hover .grid-filename-overlay {
-            opacity: 1;
-        }
-        
-        .details-modal-content { 
+.details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
@@ -496,18 +436,58 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
-        .app-footer {
-            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
-            color: rgba(255, 255, 255, 0.6); text-align: center;
-            padding: 4px 8px;
-            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+.app-footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6);
+            text-align: center;
+            padding: 8px 12px;
+            font-size: 10px;
+            z-index: 5;
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .app-footer .footer-baseline {
+            color: rgba(255, 255, 255, 0.6);
         }
         .app-footer .footer-status {
-            color: inherit;
+            position: absolute;
+            inset: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 14px;
+            border-radius: 9999px;
+            background: rgba(0, 0, 0, 0.85);
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: nowrap;
+            max-width: calc(100% - 24px);
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-        .app-footer .footer-status:not(:empty) {
-            margin-right: 8px;
+        .app-footer .footer-status.active {
+            opacity: 1;
+        }
+        .app-footer .footer-status.success {
+            background: rgba(16, 185, 129, 0.9);
+        }
+        .app-footer .footer-status.info {
+            background: rgba(59, 130, 246, 0.9);
+        }
+        .app-footer .footer-status.error {
+            background: rgba(239, 68, 68, 0.9);
         }
         .app-footer .footer-link {
             background: transparent;
@@ -520,12 +500,10 @@
             text-decoration: none;
             transition: color 0.2s ease;
         }
-        .app-footer .footer-link:hover,
-        .app-footer .footer-link:focus-visible {
-            color: #f59e0b;
-            text-decoration: underline;
+        .app-footer .footer-link:hover,        .app-footer .footer-link:focus-visible {
+            outline: none;
         }
-        .app-footer .footer-link:focus-visible {
+.app-footer .footer-link:focus-visible {
             outline: none;
         }
 
@@ -587,9 +565,7 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #center-trash-btn,
-        .app-container.focus-mode .filename-overlay { display: none; }
-
-        .app-container.focus-mode .focus-mode-ui { display: flex; }
+.app-container.focus-mode .focus-mode-ui { display: flex; }
         
         .hidden { display: none !important; }
         
@@ -731,10 +707,19 @@
                         Enable Haptic Feedback (Mobile)
                     </label>
                 </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="debug-toasts-enabled" checked style="margin: 0;">
+                        Enable Debug Toasts
+                    </label>
+                </div>
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -749,7 +734,10 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -764,7 +752,10 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Loading Screen -->
@@ -778,7 +769,10 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Main App Container -->
@@ -825,10 +819,7 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
-
-        
-        <!-- Center Stage UI -->
+<!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -848,8 +839,10 @@
             </svg>
         </button>
         
-        <div id="toast" class="toast"></div>
-        <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -1039,7 +1032,8 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
-            pendingBackgroundProbe: null
+            pendingBackgroundProbe: null,
+            showDebugToasts: true
         };
         const Utils = {
             elements: {},
@@ -1080,6 +1074,7 @@
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
+                    debugToastToggle: document.getElementById('debug-toasts-enabled'),
                     
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
@@ -1104,11 +1099,9 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1202,45 +1195,35 @@
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
+                if (!state.showDebugToasts) {
+                    this.clearFooterToasts();
+                    return;
+                }
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                const footers = Array.from(document.querySelectorAll('.app-footer'));
-                const footerStatuses = footers.map(footer => {
+                const statusElements = [];
+                document.querySelectorAll('.app-footer').forEach(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
                     if (!statusSpan) {
                         statusSpan = document.createElement('span');
                         statusSpan.className = 'footer-status';
-                        const baselineAttr = footer.dataset.baselineText;
-                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
-                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
-                        statusSpan.dataset.baselineText = baselineText;
-                        if (textNodes.length) {
-                            footer.insertBefore(statusSpan, textNodes[0]);
-                            textNodes.forEach(node => footer.removeChild(node));
-                        } else {
-                            footer.insertBefore(statusSpan, footer.firstChild);
-                        }
-                        statusSpan.textContent = baselineText;
-                    } else if (statusSpan.dataset.baselineText === undefined) {
-                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                        statusSpan.setAttribute('aria-live', 'polite');
+                        footer.appendChild(statusSpan);
                     }
-                    const baselineText = statusSpan.dataset.baselineText ?? '';
                     statusSpan.textContent = message;
-                    statusSpan.classList.remove('success', 'error', 'info');
-                    statusSpan.classList.add(type);
-                    return { statusSpan, baselineText };
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                    statusSpan.classList.add('active', type);
+                    statusElements.push(statusSpan);
                 });
+                if (statusElements.length === 0) {
+                    return;
+                }
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    toast.classList.remove('show');
-                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
-                        statusSpan.textContent = baselineText;
-                        statusSpan.classList.remove('success', 'error', 'info');
+                    statusElements.forEach(statusSpan => {
+                        statusSpan.textContent = '';
+                        statusSpan.classList.remove('active', 'success', 'error', 'info');
                     });
                     this._toastHideTimer = null;
                 }, 3000);
@@ -1248,6 +1231,17 @@
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
+            },
+
+            clearFooterToasts() {
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                    this._toastHideTimer = null;
+                }
+                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
+                    statusSpan.textContent = '';
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                });
             },
             
             async setImageSrc(img, file) {
@@ -4687,8 +4681,7 @@
                     const folderName = state.currentFolder?.name || '';
                     const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
                     const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-                    if (Utils.elements.filenameOverlay) {
-                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+/ ${filenameWithoutExtension}`;
                         const directUrl = state.export?.getDirectImageURL?.(currentFile);
                         Utils.elements.filenameOverlay.href = directUrl || '#';
                         Utils.elements.filenameOverlay.classList.add('visible');
@@ -4902,10 +4895,7 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
-                if (Utils.elements.filenameOverlay) {
-                    Utils.elements.filenameOverlay.classList.remove('visible');
-                }
-                this.updateImageCounters();
+this.updateImageCounters();
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
                     Utils.elements.centerImage.alt = 'No images in this stack';
@@ -5001,11 +4991,7 @@
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    const overlay = document.createElement('div');
-                    overlay.className = 'grid-filename-overlay';
-                    overlay.textContent = file.name;
                     div.appendChild(img);
-                    div.appendChild(overlay);
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
@@ -6495,8 +6481,29 @@
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
                 });
-                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+                const hapticToggle = document.getElementById('haptic-enabled');
+                if (hapticToggle) {
+                    hapticToggle.addEventListener('change', (e) => {
+                        if (state.haptic) {
+                            state.haptic.setEnabled(e.target.checked);
+                        }
+                    });
+                }
+                const debugToggle = document.getElementById('debug-toasts-enabled');
+                state.showDebugToasts = debugToggle ? debugToggle.checked : true;
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                }
+                if (debugToggle) {
+                    debugToggle.addEventListener('change', (e) => {
+                        state.showDebugToasts = e.target.checked;
+                        if (!state.showDebugToasts) {
+                            Utils.clearFooterToasts();
+                        }
+                    });
+                }
             },
+
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
                 Utils.elements.authBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });

--- a/ui-v2-old.html
+++ b/ui-v2-old.html
@@ -127,18 +127,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
-        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+.folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
             background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
@@ -184,36 +173,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
-
-        
-        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+.edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
             bottom: 0; left: 0; right: 0; height: 8px; 
@@ -419,27 +379,7 @@
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-
-        .grid-filename-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.7);
-            color: white;
-            padding: 8px;
-            font-size: 14px;
-            text-align: center;
-            opacity: 0;
-            transition: opacity 0.3s;
-            pointer-events: none;
-        }
-
-        .grid-item:hover .grid-filename-overlay {
-            opacity: 1;
-        }
-        
-        .details-modal-content { 
+.details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
@@ -501,21 +441,79 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
-        .app-footer {
-            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
-            color: rgba(255, 255, 255, 0.6); text-align: center;
-            padding: 4px 8px;
-            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+.app-footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6);
+            text-align: center;
+            padding: 8px 12px;
+            font-size: 10px;
+            z-index: 5;
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .app-footer .footer-baseline {
+            color: rgba(255, 255, 255, 0.6);
         }
         .app-footer .footer-status {
-            color: inherit;
+            position: absolute;
+            inset: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 14px;
+            border-radius: 9999px;
+            background: rgba(0, 0, 0, 0.85);
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: nowrap;
+            max-width: calc(100% - 24px);
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-        .app-footer .footer-status:not(:empty) {
-            margin-right: 8px;
+        .app-footer .footer-status.active {
+            opacity: 1;
         }
-
-        /* NEW: Standardized UI Button */
+        .app-footer .footer-status.success {
+            background: rgba(16, 185, 129, 0.9);
+        }
+        .app-footer .footer-status.info {
+            background: rgba(59, 130, 246, 0.9);
+        }
+        .app-footer .footer-status.error {
+            background: rgba(239, 68, 68, 0.9);
+        }
+        .app-footer .footer-link {
+            background: transparent;
+            border: none;
+            color: rgba(255, 255, 255, 0.65);
+            cursor: pointer;
+            font: inherit;
+            margin-left: 8px;
+            padding: 0;
+            text-decoration: none;
+            transition: color 0.2s ease;
+        }
+        .app-footer .footer-link:hover,
+        .app-footer .footer-link:focus-visible {
+            color: #f59e0b;
+            text-decoration: underline;
+        }
+        .app-footer .footer-link:focus-visible {
+            outline: none;
+        }
+/* NEW: Standardized UI Button */
         .ui-button {
             background: rgba(0, 0, 0, 0.4);
             color: #e5e7eb; /* light grey */
@@ -573,9 +571,7 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #center-trash-btn,
-        .app-container.focus-mode .filename-overlay { display: none; }
-
-        .app-container.focus-mode .focus-mode-ui { display: flex; }
+.app-container.focus-mode .focus-mode-ui { display: flex; }
         
         .hidden { display: none !important; }
         
@@ -717,10 +713,19 @@
                         Enable Haptic Feedback (Mobile)
                     </label>
                 </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="debug-toasts-enabled" checked style="margin: 0;">
+                        Enable Debug Toasts
+                    </label>
+                </div>
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-M-2025-09-18 04:16 AM</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -735,7 +740,10 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-M-2025-09-18 04:16 AM</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -750,7 +758,10 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-M-2025-09-18 04:16 AM</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Loading Screen -->
@@ -764,7 +775,10 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-M-2025-09-18 04:16 AM</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Main App Container -->
@@ -811,10 +825,7 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
-
-        
-        <!-- Center Stage UI -->
+<!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -834,8 +845,10 @@
             </svg>
         </button>
         
-        <div id="toast" class="toast"></div>
-        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-M-2025-09-18 04:16 AM</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -1023,7 +1036,8 @@
             tags: new Set(), loadingProgress: { current: 0, total: 0 },
             folderMoveMode: { active: false, files: [] },
             activeRequests: new AbortController(),
-            sessionVisitedFolders: new Set()
+            sessionVisitedFolders: new Set(),
+            showDebugToasts: true
         };
         const Utils = {
             elements: {},
@@ -1064,6 +1078,7 @@
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
+                    debugToastToggle: document.getElementById('debug-toasts-enabled'),
                     
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
@@ -1088,11 +1103,9 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1187,45 +1200,35 @@
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
+                if (!state.showDebugToasts) {
+                    this.clearFooterToasts();
+                    return;
+                }
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                const footers = Array.from(document.querySelectorAll('.app-footer'));
-                const footerStatuses = footers.map(footer => {
+                const statusElements = [];
+                document.querySelectorAll('.app-footer').forEach(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
                     if (!statusSpan) {
                         statusSpan = document.createElement('span');
                         statusSpan.className = 'footer-status';
-                        const baselineAttr = footer.dataset.baselineText;
-                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
-                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
-                        statusSpan.dataset.baselineText = baselineText;
-                        if (textNodes.length) {
-                            footer.insertBefore(statusSpan, textNodes[0]);
-                            textNodes.forEach(node => footer.removeChild(node));
-                        } else {
-                            footer.insertBefore(statusSpan, footer.firstChild);
-                        }
-                        statusSpan.textContent = baselineText;
-                    } else if (statusSpan.dataset.baselineText === undefined) {
-                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                        statusSpan.setAttribute('aria-live', 'polite');
+                        footer.appendChild(statusSpan);
                     }
-                    const baselineText = statusSpan.dataset.baselineText ?? '';
                     statusSpan.textContent = message;
-                    statusSpan.classList.remove('success', 'error', 'info');
-                    statusSpan.classList.add(type);
-                    return { statusSpan, baselineText };
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                    statusSpan.classList.add('active', type);
+                    statusElements.push(statusSpan);
                 });
+                if (statusElements.length === 0) {
+                    return;
+                }
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    toast.classList.remove('show');
-                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
-                        statusSpan.textContent = baselineText;
-                        statusSpan.classList.remove('success', 'error', 'info');
+                    statusElements.forEach(statusSpan => {
+                        statusSpan.textContent = '';
+                        statusSpan.classList.remove('active', 'success', 'error', 'info');
                     });
                     this._toastHideTimer = null;
                 }, 3000);
@@ -1233,6 +1236,17 @@
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
+            },
+
+            clearFooterToasts() {
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                    this._toastHideTimer = null;
+                }
+                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
+                    statusSpan.textContent = '';
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                });
             },
             
             async setImageSrc(img, file) {
@@ -2812,8 +2826,7 @@
                     const folderName = state.currentFolder?.name || '';
                     const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
                     const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-                    if (Utils.elements.filenameOverlay) {
-                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+/ ${filenameWithoutExtension}`;
                         const directUrl = state.export?.getDirectImageURL?.(currentFile);
                         Utils.elements.filenameOverlay.href = directUrl || '#';
                         Utils.elements.filenameOverlay.classList.add('visible');
@@ -2934,10 +2947,7 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
-                if (Utils.elements.filenameOverlay) {
-                    Utils.elements.filenameOverlay.classList.remove('visible');
-                }
-                this.updateImageCounters();
+this.updateImageCounters();
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
                     Utils.elements.centerImage.alt = 'No images in this stack';
@@ -3033,11 +3043,7 @@
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    const overlay = document.createElement('div');
-                    overlay.className = 'grid-filename-overlay';
-                    overlay.textContent = file.name;
                     div.appendChild(img);
-                    div.appendChild(overlay);
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
@@ -4313,8 +4319,29 @@
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
                 });
-                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+                const hapticToggle = document.getElementById('haptic-enabled');
+                if (hapticToggle) {
+                    hapticToggle.addEventListener('change', (e) => {
+                        if (state.haptic) {
+                            state.haptic.setEnabled(e.target.checked);
+                        }
+                    });
+                }
+                const debugToggle = document.getElementById('debug-toasts-enabled');
+                state.showDebugToasts = debugToggle ? debugToggle.checked : true;
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                }
+                if (debugToggle) {
+                    debugToggle.addEventListener('change', (e) => {
+                        state.showDebugToasts = e.target.checked;
+                        if (!state.showDebugToasts) {
+                            Utils.clearFooterToasts();
+                        }
+                    });
+                }
             },
+
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
                 Utils.elements.authBackButton.addEventListener('click', () => App.backToProviderSelection());

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -127,18 +127,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
-        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+.folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
             background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
@@ -184,36 +173,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
-
-        
-        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+.edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
             bottom: 0; left: 0; right: 0; height: 8px; 
@@ -409,27 +369,7 @@
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-
-        .grid-filename-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.7);
-            color: white;
-            padding: 8px;
-            font-size: 14px;
-            text-align: center;
-            opacity: 0;
-            transition: opacity 0.3s;
-            pointer-events: none;
-        }
-
-        .grid-item:hover .grid-filename-overlay {
-            opacity: 1;
-        }
-        
-        .details-modal-content { 
+.details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
@@ -496,18 +436,58 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
-        .app-footer {
-            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
-            color: rgba(255, 255, 255, 0.6); text-align: center;
-            padding: 4px 8px;
-            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+.app-footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6);
+            text-align: center;
+            padding: 8px 12px;
+            font-size: 10px;
+            z-index: 5;
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .app-footer .footer-baseline {
+            color: rgba(255, 255, 255, 0.6);
         }
         .app-footer .footer-status {
-            color: inherit;
+            position: absolute;
+            inset: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 14px;
+            border-radius: 9999px;
+            background: rgba(0, 0, 0, 0.85);
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: nowrap;
+            max-width: calc(100% - 24px);
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-        .app-footer .footer-status:not(:empty) {
-            margin-right: 8px;
+        .app-footer .footer-status.active {
+            opacity: 1;
+        }
+        .app-footer .footer-status.success {
+            background: rgba(16, 185, 129, 0.9);
+        }
+        .app-footer .footer-status.info {
+            background: rgba(59, 130, 246, 0.9);
+        }
+        .app-footer .footer-status.error {
+            background: rgba(239, 68, 68, 0.9);
         }
         .app-footer .footer-link {
             background: transparent;
@@ -520,12 +500,10 @@
             text-decoration: none;
             transition: color 0.2s ease;
         }
-        .app-footer .footer-link:hover,
-        .app-footer .footer-link:focus-visible {
-            color: #f59e0b;
-            text-decoration: underline;
+        .app-footer .footer-link:hover,        .app-footer .footer-link:focus-visible {
+            outline: none;
         }
-        .app-footer .footer-link:focus-visible {
+.app-footer .footer-link:focus-visible {
             outline: none;
         }
 
@@ -587,9 +565,7 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #center-trash-btn,
-        .app-container.focus-mode .filename-overlay { display: none; }
-
-        .app-container.focus-mode .focus-mode-ui { display: flex; }
+.app-container.focus-mode .focus-mode-ui { display: flex; }
         
         .hidden { display: none !important; }
         
@@ -731,10 +707,19 @@
                         Enable Haptic Feedback (Mobile)
                     </label>
                 </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="debug-toasts-enabled" checked style="margin: 0;">
+                        Enable Debug Toasts
+                    </label>
+                </div>
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -749,7 +734,10 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -764,7 +752,10 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Loading Screen -->
@@ -778,7 +769,10 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Main App Container -->
@@ -825,10 +819,7 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
-
-        
-        <!-- Center Stage UI -->
+<!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -848,8 +839,10 @@
             </svg>
         </button>
         
-        <div id="toast" class="toast"></div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -1040,7 +1033,8 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
-            pendingBackgroundProbe: null
+            pendingBackgroundProbe: null,
+            showDebugToasts: true
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -1149,6 +1143,7 @@
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
+                    debugToastToggle: document.getElementById('debug-toasts-enabled'),
                     
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
@@ -1173,11 +1168,9 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1271,45 +1264,35 @@
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
+                if (!state.showDebugToasts) {
+                    this.clearFooterToasts();
+                    return;
+                }
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                const footers = Array.from(document.querySelectorAll('.app-footer'));
-                const footerStatuses = footers.map(footer => {
+                const statusElements = [];
+                document.querySelectorAll('.app-footer').forEach(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
                     if (!statusSpan) {
                         statusSpan = document.createElement('span');
                         statusSpan.className = 'footer-status';
-                        const baselineAttr = footer.dataset.baselineText;
-                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
-                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
-                        statusSpan.dataset.baselineText = baselineText;
-                        if (textNodes.length) {
-                            footer.insertBefore(statusSpan, textNodes[0]);
-                            textNodes.forEach(node => footer.removeChild(node));
-                        } else {
-                            footer.insertBefore(statusSpan, footer.firstChild);
-                        }
-                        statusSpan.textContent = baselineText;
-                    } else if (statusSpan.dataset.baselineText === undefined) {
-                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                        statusSpan.setAttribute('aria-live', 'polite');
+                        footer.appendChild(statusSpan);
                     }
-                    const baselineText = statusSpan.dataset.baselineText ?? '';
                     statusSpan.textContent = message;
-                    statusSpan.classList.remove('success', 'error', 'info');
-                    statusSpan.classList.add(type);
-                    return { statusSpan, baselineText };
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                    statusSpan.classList.add('active', type);
+                    statusElements.push(statusSpan);
                 });
+                if (statusElements.length === 0) {
+                    return;
+                }
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    toast.classList.remove('show');
-                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
-                        statusSpan.textContent = baselineText;
-                        statusSpan.classList.remove('success', 'error', 'info');
+                    statusElements.forEach(statusSpan => {
+                        statusSpan.textContent = '';
+                        statusSpan.classList.remove('active', 'success', 'error', 'info');
                     });
                     this._toastHideTimer = null;
                 }, 3000);
@@ -1317,6 +1300,17 @@
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
+            },
+
+            clearFooterToasts() {
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                    this._toastHideTimer = null;
+                }
+                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
+                    statusSpan.textContent = '';
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                });
             },
             
             async setImageSrc(img, file) {
@@ -4847,8 +4841,7 @@
                     const folderName = state.currentFolder?.name || '';
                     const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
                     const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-                    if (Utils.elements.filenameOverlay) {
-                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+/ ${filenameWithoutExtension}`;
                         const directUrl = state.export?.getDirectImageURL?.(currentFile);
                         Utils.elements.filenameOverlay.href = directUrl || '#';
                         Utils.elements.filenameOverlay.classList.add('visible');
@@ -5062,10 +5055,7 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
-                if (Utils.elements.filenameOverlay) {
-                    Utils.elements.filenameOverlay.classList.remove('visible');
-                }
-                this.updateImageCounters();
+this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -5166,11 +5156,7 @@
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    const overlay = document.createElement('div');
-                    overlay.className = 'grid-filename-overlay';
-                    overlay.textContent = file.name;
                     div.appendChild(img);
-                    div.appendChild(overlay);
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
@@ -6573,8 +6559,29 @@
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
                 });
-                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+                const hapticToggle = document.getElementById('haptic-enabled');
+                if (hapticToggle) {
+                    hapticToggle.addEventListener('change', (e) => {
+                        if (state.haptic) {
+                            state.haptic.setEnabled(e.target.checked);
+                        }
+                    });
+                }
+                const debugToggle = document.getElementById('debug-toasts-enabled');
+                state.showDebugToasts = debugToggle ? debugToggle.checked : true;
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                }
+                if (debugToggle) {
+                    debugToggle.addEventListener('change', (e) => {
+                        state.showDebugToasts = e.target.checked;
+                        if (!state.showDebugToasts) {
+                            Utils.clearFooterToasts();
+                        }
+                    });
+                }
             },
+
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
                 Utils.elements.authBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -127,18 +127,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
-        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+.folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
             background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
@@ -184,36 +173,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
-
-        
-        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+.edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
             bottom: 0; left: 0; right: 0; height: 8px; 
@@ -409,27 +369,7 @@
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-
-        .grid-filename-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.7);
-            color: white;
-            padding: 8px;
-            font-size: 14px;
-            text-align: center;
-            opacity: 0;
-            transition: opacity 0.3s;
-            pointer-events: none;
-        }
-
-        .grid-item:hover .grid-filename-overlay {
-            opacity: 1;
-        }
-        
-        .details-modal-content { 
+.details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
@@ -496,18 +436,58 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
-        .app-footer {
-            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
-            color: rgba(255, 255, 255, 0.6); text-align: center;
-            padding: 4px 8px;
-            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+.app-footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6);
+            text-align: center;
+            padding: 8px 12px;
+            font-size: 10px;
+            z-index: 5;
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .app-footer .footer-baseline {
+            color: rgba(255, 255, 255, 0.6);
         }
         .app-footer .footer-status {
-            color: inherit;
+            position: absolute;
+            inset: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 14px;
+            border-radius: 9999px;
+            background: rgba(0, 0, 0, 0.85);
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: nowrap;
+            max-width: calc(100% - 24px);
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-        .app-footer .footer-status:not(:empty) {
-            margin-right: 8px;
+        .app-footer .footer-status.active {
+            opacity: 1;
+        }
+        .app-footer .footer-status.success {
+            background: rgba(16, 185, 129, 0.9);
+        }
+        .app-footer .footer-status.info {
+            background: rgba(59, 130, 246, 0.9);
+        }
+        .app-footer .footer-status.error {
+            background: rgba(239, 68, 68, 0.9);
         }
         .app-footer .footer-link {
             background: transparent;
@@ -520,12 +500,10 @@
             text-decoration: none;
             transition: color 0.2s ease;
         }
-        .app-footer .footer-link:hover,
-        .app-footer .footer-link:focus-visible {
-            color: #f59e0b;
-            text-decoration: underline;
+        .app-footer .footer-link:hover,        .app-footer .footer-link:focus-visible {
+            outline: none;
         }
-        .app-footer .footer-link:focus-visible {
+.app-footer .footer-link:focus-visible {
             outline: none;
         }
 
@@ -587,9 +565,7 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #center-trash-btn,
-        .app-container.focus-mode .filename-overlay { display: none; }
-
-        .app-container.focus-mode .focus-mode-ui { display: flex; }
+.app-container.focus-mode .focus-mode-ui { display: flex; }
         
         .hidden { display: none !important; }
         
@@ -731,10 +707,19 @@
                         Enable Haptic Feedback (Mobile)
                     </label>
                 </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="debug-toasts-enabled" checked style="margin: 0;">
+                        Enable Debug Toasts
+                    </label>
+                </div>
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -749,7 +734,10 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -764,7 +752,10 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Loading Screen -->
@@ -778,7 +769,10 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Main App Container -->
@@ -825,10 +819,7 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
-
-        
-        <!-- Center Stage UI -->
+<!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -848,8 +839,10 @@
             </svg>
         </button>
         
-        <div id="toast" class="toast"></div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -1040,7 +1033,8 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
-            pendingBackgroundProbe: null
+            pendingBackgroundProbe: null,
+            showDebugToasts: true
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -1149,6 +1143,7 @@
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
+                    debugToastToggle: document.getElementById('debug-toasts-enabled'),
                     
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
@@ -1173,11 +1168,9 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1271,45 +1264,35 @@
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
+                if (!state.showDebugToasts) {
+                    this.clearFooterToasts();
+                    return;
+                }
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                const footers = Array.from(document.querySelectorAll('.app-footer'));
-                const footerStatuses = footers.map(footer => {
+                const statusElements = [];
+                document.querySelectorAll('.app-footer').forEach(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
                     if (!statusSpan) {
                         statusSpan = document.createElement('span');
                         statusSpan.className = 'footer-status';
-                        const baselineAttr = footer.dataset.baselineText;
-                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
-                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
-                        statusSpan.dataset.baselineText = baselineText;
-                        if (textNodes.length) {
-                            footer.insertBefore(statusSpan, textNodes[0]);
-                            textNodes.forEach(node => footer.removeChild(node));
-                        } else {
-                            footer.insertBefore(statusSpan, footer.firstChild);
-                        }
-                        statusSpan.textContent = baselineText;
-                    } else if (statusSpan.dataset.baselineText === undefined) {
-                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                        statusSpan.setAttribute('aria-live', 'polite');
+                        footer.appendChild(statusSpan);
                     }
-                    const baselineText = statusSpan.dataset.baselineText ?? '';
                     statusSpan.textContent = message;
-                    statusSpan.classList.remove('success', 'error', 'info');
-                    statusSpan.classList.add(type);
-                    return { statusSpan, baselineText };
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                    statusSpan.classList.add('active', type);
+                    statusElements.push(statusSpan);
                 });
+                if (statusElements.length === 0) {
+                    return;
+                }
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    toast.classList.remove('show');
-                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
-                        statusSpan.textContent = baselineText;
-                        statusSpan.classList.remove('success', 'error', 'info');
+                    statusElements.forEach(statusSpan => {
+                        statusSpan.textContent = '';
+                        statusSpan.classList.remove('active', 'success', 'error', 'info');
                     });
                     this._toastHideTimer = null;
                 }, 3000);
@@ -1317,6 +1300,17 @@
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
+            },
+
+            clearFooterToasts() {
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                    this._toastHideTimer = null;
+                }
+                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
+                    statusSpan.textContent = '';
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                });
             },
             
             async setImageSrc(img, file) {
@@ -4847,8 +4841,7 @@
                     const folderName = state.currentFolder?.name || '';
                     const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
                     const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-                    if (Utils.elements.filenameOverlay) {
-                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+/ ${filenameWithoutExtension}`;
                         const directUrl = state.export?.getDirectImageURL?.(currentFile);
                         Utils.elements.filenameOverlay.href = directUrl || '#';
                         Utils.elements.filenameOverlay.classList.add('visible');
@@ -5062,10 +5055,7 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
-                if (Utils.elements.filenameOverlay) {
-                    Utils.elements.filenameOverlay.classList.remove('visible');
-                }
-                this.updateImageCounters();
+this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -5166,11 +5156,7 @@
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    const overlay = document.createElement('div');
-                    overlay.className = 'grid-filename-overlay';
-                    overlay.textContent = file.name;
                     div.appendChild(img);
-                    div.appendChild(overlay);
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
@@ -6573,8 +6559,29 @@
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
                 });
-                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+                const hapticToggle = document.getElementById('haptic-enabled');
+                if (hapticToggle) {
+                    hapticToggle.addEventListener('change', (e) => {
+                        if (state.haptic) {
+                            state.haptic.setEnabled(e.target.checked);
+                        }
+                    });
+                }
+                const debugToggle = document.getElementById('debug-toasts-enabled');
+                state.showDebugToasts = debugToggle ? debugToggle.checked : true;
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                }
+                if (debugToggle) {
+                    debugToggle.addEventListener('change', (e) => {
+                        state.showDebugToasts = e.target.checked;
+                        if (!state.showDebugToasts) {
+                            Utils.clearFooterToasts();
+                        }
+                    });
+                }
             },
+
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
                 Utils.elements.authBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -127,18 +127,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
-        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+.folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
             background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
@@ -184,36 +173,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
-
-        
-        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+.edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
             bottom: 0; left: 0; right: 0; height: 8px; 
@@ -409,27 +369,7 @@
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-
-        .grid-filename-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.7);
-            color: white;
-            padding: 8px;
-            font-size: 14px;
-            text-align: center;
-            opacity: 0;
-            transition: opacity 0.3s;
-            pointer-events: none;
-        }
-
-        .grid-item:hover .grid-filename-overlay {
-            opacity: 1;
-        }
-        
-        .details-modal-content { 
+.details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
@@ -496,18 +436,58 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
-        .app-footer {
-            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
-            color: rgba(255, 255, 255, 0.6); text-align: center;
-            padding: 4px 8px;
-            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+.app-footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6);
+            text-align: center;
+            padding: 8px 12px;
+            font-size: 10px;
+            z-index: 5;
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .app-footer .footer-baseline {
+            color: rgba(255, 255, 255, 0.6);
         }
         .app-footer .footer-status {
-            color: inherit;
+            position: absolute;
+            inset: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 14px;
+            border-radius: 9999px;
+            background: rgba(0, 0, 0, 0.85);
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: nowrap;
+            max-width: calc(100% - 24px);
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-        .app-footer .footer-status:not(:empty) {
-            margin-right: 8px;
+        .app-footer .footer-status.active {
+            opacity: 1;
+        }
+        .app-footer .footer-status.success {
+            background: rgba(16, 185, 129, 0.9);
+        }
+        .app-footer .footer-status.info {
+            background: rgba(59, 130, 246, 0.9);
+        }
+        .app-footer .footer-status.error {
+            background: rgba(239, 68, 68, 0.9);
         }
         .app-footer .footer-link {
             background: transparent;
@@ -520,12 +500,10 @@
             text-decoration: none;
             transition: color 0.2s ease;
         }
-        .app-footer .footer-link:hover,
-        .app-footer .footer-link:focus-visible {
-            color: #f59e0b;
-            text-decoration: underline;
+        .app-footer .footer-link:hover,        .app-footer .footer-link:focus-visible {
+            outline: none;
         }
-        .app-footer .footer-link:focus-visible {
+.app-footer .footer-link:focus-visible {
             outline: none;
         }
 
@@ -587,9 +565,7 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #center-trash-btn,
-        .app-container.focus-mode .filename-overlay { display: none; }
-
-        .app-container.focus-mode .focus-mode-ui { display: flex; }
+.app-container.focus-mode .focus-mode-ui { display: flex; }
         
         .hidden { display: none !important; }
         
@@ -731,10 +707,19 @@
                         Enable Haptic Feedback (Mobile)
                     </label>
                 </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="debug-toasts-enabled" checked style="margin: 0;">
+                        Enable Debug Toasts
+                    </label>
+                </div>
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -749,7 +734,10 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -764,7 +752,10 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Loading Screen -->
@@ -778,7 +769,10 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Main App Container -->
@@ -825,10 +819,7 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
-
-        
-        <!-- Center Stage UI -->
+<!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -848,8 +839,10 @@
             </svg>
         </button>
         
-        <div id="toast" class="toast"></div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -1040,7 +1033,8 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
-            pendingBackgroundProbe: null
+            pendingBackgroundProbe: null,
+            showDebugToasts: true
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -1149,6 +1143,7 @@
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
+                    debugToastToggle: document.getElementById('debug-toasts-enabled'),
                     
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
@@ -1173,11 +1168,9 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1271,45 +1264,35 @@
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
+                if (!state.showDebugToasts) {
+                    this.clearFooterToasts();
+                    return;
+                }
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                const footers = Array.from(document.querySelectorAll('.app-footer'));
-                const footerStatuses = footers.map(footer => {
+                const statusElements = [];
+                document.querySelectorAll('.app-footer').forEach(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
                     if (!statusSpan) {
                         statusSpan = document.createElement('span');
                         statusSpan.className = 'footer-status';
-                        const baselineAttr = footer.dataset.baselineText;
-                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
-                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
-                        statusSpan.dataset.baselineText = baselineText;
-                        if (textNodes.length) {
-                            footer.insertBefore(statusSpan, textNodes[0]);
-                            textNodes.forEach(node => footer.removeChild(node));
-                        } else {
-                            footer.insertBefore(statusSpan, footer.firstChild);
-                        }
-                        statusSpan.textContent = baselineText;
-                    } else if (statusSpan.dataset.baselineText === undefined) {
-                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                        statusSpan.setAttribute('aria-live', 'polite');
+                        footer.appendChild(statusSpan);
                     }
-                    const baselineText = statusSpan.dataset.baselineText ?? '';
                     statusSpan.textContent = message;
-                    statusSpan.classList.remove('success', 'error', 'info');
-                    statusSpan.classList.add(type);
-                    return { statusSpan, baselineText };
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                    statusSpan.classList.add('active', type);
+                    statusElements.push(statusSpan);
                 });
+                if (statusElements.length === 0) {
+                    return;
+                }
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    toast.classList.remove('show');
-                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
-                        statusSpan.textContent = baselineText;
-                        statusSpan.classList.remove('success', 'error', 'info');
+                    statusElements.forEach(statusSpan => {
+                        statusSpan.textContent = '';
+                        statusSpan.classList.remove('active', 'success', 'error', 'info');
                     });
                     this._toastHideTimer = null;
                 }, 3000);
@@ -1317,6 +1300,17 @@
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
+            },
+
+            clearFooterToasts() {
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                    this._toastHideTimer = null;
+                }
+                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
+                    statusSpan.textContent = '';
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                });
             },
             
             async setImageSrc(img, file) {
@@ -4847,8 +4841,7 @@
                     const folderName = state.currentFolder?.name || '';
                     const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
                     const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-                    if (Utils.elements.filenameOverlay) {
-                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+/ ${filenameWithoutExtension}`;
                         const directUrl = state.export?.getDirectImageURL?.(currentFile);
                         Utils.elements.filenameOverlay.href = directUrl || '#';
                         Utils.elements.filenameOverlay.classList.add('visible');
@@ -5062,10 +5055,7 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
-                if (Utils.elements.filenameOverlay) {
-                    Utils.elements.filenameOverlay.classList.remove('visible');
-                }
-                this.updateImageCounters();
+this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -5166,11 +5156,7 @@
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    const overlay = document.createElement('div');
-                    overlay.className = 'grid-filename-overlay';
-                    overlay.textContent = file.name;
                     div.appendChild(img);
-                    div.appendChild(overlay);
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
@@ -6573,8 +6559,29 @@
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
                 });
-                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+                const hapticToggle = document.getElementById('haptic-enabled');
+                if (hapticToggle) {
+                    hapticToggle.addEventListener('change', (e) => {
+                        if (state.haptic) {
+                            state.haptic.setEnabled(e.target.checked);
+                        }
+                    });
+                }
+                const debugToggle = document.getElementById('debug-toasts-enabled');
+                state.showDebugToasts = debugToggle ? debugToggle.checked : true;
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                }
+                if (debugToggle) {
+                    debugToggle.addEventListener('change', (e) => {
+                        state.showDebugToasts = e.target.checked;
+                        if (!state.showDebugToasts) {
+                            Utils.clearFooterToasts();
+                        }
+                    });
+                }
             },
+
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
                 Utils.elements.authBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -127,18 +127,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
-        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+.folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
             background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
@@ -184,36 +173,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
-
-        
-        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+.edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
             bottom: 0; left: 0; right: 0; height: 8px; 
@@ -409,27 +369,7 @@
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-
-        .grid-filename-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.7);
-            color: white;
-            padding: 8px;
-            font-size: 14px;
-            text-align: center;
-            opacity: 0;
-            transition: opacity 0.3s;
-            pointer-events: none;
-        }
-
-        .grid-item:hover .grid-filename-overlay {
-            opacity: 1;
-        }
-        
-        .details-modal-content { 
+.details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
@@ -496,18 +436,58 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
-        .app-footer {
-            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
-            color: rgba(255, 255, 255, 0.6); text-align: center;
-            padding: 4px 8px;
-            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+.app-footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6);
+            text-align: center;
+            padding: 8px 12px;
+            font-size: 10px;
+            z-index: 5;
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .app-footer .footer-baseline {
+            color: rgba(255, 255, 255, 0.6);
         }
         .app-footer .footer-status {
-            color: inherit;
+            position: absolute;
+            inset: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 14px;
+            border-radius: 9999px;
+            background: rgba(0, 0, 0, 0.85);
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: nowrap;
+            max-width: calc(100% - 24px);
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-        .app-footer .footer-status:not(:empty) {
-            margin-right: 8px;
+        .app-footer .footer-status.active {
+            opacity: 1;
+        }
+        .app-footer .footer-status.success {
+            background: rgba(16, 185, 129, 0.9);
+        }
+        .app-footer .footer-status.info {
+            background: rgba(59, 130, 246, 0.9);
+        }
+        .app-footer .footer-status.error {
+            background: rgba(239, 68, 68, 0.9);
         }
         .app-footer .footer-link {
             background: transparent;
@@ -520,12 +500,10 @@
             text-decoration: none;
             transition: color 0.2s ease;
         }
-        .app-footer .footer-link:hover,
-        .app-footer .footer-link:focus-visible {
-            color: #f59e0b;
-            text-decoration: underline;
+        .app-footer .footer-link:hover,        .app-footer .footer-link:focus-visible {
+            outline: none;
         }
-        .app-footer .footer-link:focus-visible {
+.app-footer .footer-link:focus-visible {
             outline: none;
         }
 
@@ -587,9 +565,7 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #center-trash-btn,
-        .app-container.focus-mode .filename-overlay { display: none; }
-
-        .app-container.focus-mode .focus-mode-ui { display: flex; }
+.app-container.focus-mode .focus-mode-ui { display: flex; }
         
         .hidden { display: none !important; }
         
@@ -731,10 +707,19 @@
                         Enable Haptic Feedback (Mobile)
                     </label>
                 </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="debug-toasts-enabled" checked style="margin: 0;">
+                        Enable Debug Toasts
+                    </label>
+                </div>
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -749,7 +734,10 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -764,7 +752,10 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Loading Screen -->
@@ -778,7 +769,10 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Main App Container -->
@@ -825,10 +819,7 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
-
-        
-        <!-- Center Stage UI -->
+<!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -848,8 +839,10 @@
             </svg>
         </button>
         
-        <div id="toast" class="toast"></div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -1040,7 +1033,8 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
-            pendingBackgroundProbe: null
+            pendingBackgroundProbe: null,
+            showDebugToasts: true
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -1149,6 +1143,7 @@
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
+                    debugToastToggle: document.getElementById('debug-toasts-enabled'),
                     
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
@@ -1173,11 +1168,9 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1271,45 +1264,35 @@
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
+                if (!state.showDebugToasts) {
+                    this.clearFooterToasts();
+                    return;
+                }
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                const footers = Array.from(document.querySelectorAll('.app-footer'));
-                const footerStatuses = footers.map(footer => {
+                const statusElements = [];
+                document.querySelectorAll('.app-footer').forEach(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
                     if (!statusSpan) {
                         statusSpan = document.createElement('span');
                         statusSpan.className = 'footer-status';
-                        const baselineAttr = footer.dataset.baselineText;
-                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
-                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
-                        statusSpan.dataset.baselineText = baselineText;
-                        if (textNodes.length) {
-                            footer.insertBefore(statusSpan, textNodes[0]);
-                            textNodes.forEach(node => footer.removeChild(node));
-                        } else {
-                            footer.insertBefore(statusSpan, footer.firstChild);
-                        }
-                        statusSpan.textContent = baselineText;
-                    } else if (statusSpan.dataset.baselineText === undefined) {
-                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                        statusSpan.setAttribute('aria-live', 'polite');
+                        footer.appendChild(statusSpan);
                     }
-                    const baselineText = statusSpan.dataset.baselineText ?? '';
                     statusSpan.textContent = message;
-                    statusSpan.classList.remove('success', 'error', 'info');
-                    statusSpan.classList.add(type);
-                    return { statusSpan, baselineText };
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                    statusSpan.classList.add('active', type);
+                    statusElements.push(statusSpan);
                 });
+                if (statusElements.length === 0) {
+                    return;
+                }
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    toast.classList.remove('show');
-                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
-                        statusSpan.textContent = baselineText;
-                        statusSpan.classList.remove('success', 'error', 'info');
+                    statusElements.forEach(statusSpan => {
+                        statusSpan.textContent = '';
+                        statusSpan.classList.remove('active', 'success', 'error', 'info');
                     });
                     this._toastHideTimer = null;
                 }, 3000);
@@ -1317,6 +1300,17 @@
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
+            },
+
+            clearFooterToasts() {
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                    this._toastHideTimer = null;
+                }
+                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
+                    statusSpan.textContent = '';
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                });
             },
             
             async setImageSrc(img, file) {
@@ -4847,8 +4841,7 @@
                     const folderName = state.currentFolder?.name || '';
                     const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
                     const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-                    if (Utils.elements.filenameOverlay) {
-                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+/ ${filenameWithoutExtension}`;
                         const directUrl = state.export?.getDirectImageURL?.(currentFile);
                         Utils.elements.filenameOverlay.href = directUrl || '#';
                         Utils.elements.filenameOverlay.classList.add('visible');
@@ -5062,10 +5055,7 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
-                if (Utils.elements.filenameOverlay) {
-                    Utils.elements.filenameOverlay.classList.remove('visible');
-                }
-                this.updateImageCounters();
+this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -5166,11 +5156,7 @@
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    const overlay = document.createElement('div');
-                    overlay.className = 'grid-filename-overlay';
-                    overlay.textContent = file.name;
                     div.appendChild(img);
-                    div.appendChild(overlay);
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
@@ -6573,8 +6559,29 @@
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
                 });
-                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+                const hapticToggle = document.getElementById('haptic-enabled');
+                if (hapticToggle) {
+                    hapticToggle.addEventListener('change', (e) => {
+                        if (state.haptic) {
+                            state.haptic.setEnabled(e.target.checked);
+                        }
+                    });
+                }
+                const debugToggle = document.getElementById('debug-toasts-enabled');
+                state.showDebugToasts = debugToggle ? debugToggle.checked : true;
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                }
+                if (debugToggle) {
+                    debugToggle.addEventListener('change', (e) => {
+                        state.showDebugToasts = e.target.checked;
+                        if (!state.showDebugToasts) {
+                            Utils.clearFooterToasts();
+                        }
+                    });
+                }
             },
+
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
                 Utils.elements.authBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -127,18 +127,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
-        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+.folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
             background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
@@ -184,36 +173,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
-
-        
-        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+.edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
             bottom: 0; left: 0; right: 0; height: 8px; 
@@ -409,27 +369,7 @@
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-
-        .grid-filename-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.7);
-            color: white;
-            padding: 8px;
-            font-size: 14px;
-            text-align: center;
-            opacity: 0;
-            transition: opacity 0.3s;
-            pointer-events: none;
-        }
-
-        .grid-item:hover .grid-filename-overlay {
-            opacity: 1;
-        }
-        
-        .details-modal-content { 
+.details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
@@ -496,18 +436,58 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
-        .app-footer {
-            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
-            color: rgba(255, 255, 255, 0.6); text-align: center;
-            padding: 4px 8px;
-            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+.app-footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6);
+            text-align: center;
+            padding: 8px 12px;
+            font-size: 10px;
+            z-index: 5;
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .app-footer .footer-baseline {
+            color: rgba(255, 255, 255, 0.6);
         }
         .app-footer .footer-status {
-            color: inherit;
+            position: absolute;
+            inset: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 14px;
+            border-radius: 9999px;
+            background: rgba(0, 0, 0, 0.85);
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: nowrap;
+            max-width: calc(100% - 24px);
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-        .app-footer .footer-status:not(:empty) {
-            margin-right: 8px;
+        .app-footer .footer-status.active {
+            opacity: 1;
+        }
+        .app-footer .footer-status.success {
+            background: rgba(16, 185, 129, 0.9);
+        }
+        .app-footer .footer-status.info {
+            background: rgba(59, 130, 246, 0.9);
+        }
+        .app-footer .footer-status.error {
+            background: rgba(239, 68, 68, 0.9);
         }
         .app-footer .footer-link {
             background: transparent;
@@ -520,12 +500,10 @@
             text-decoration: none;
             transition: color 0.2s ease;
         }
-        .app-footer .footer-link:hover,
-        .app-footer .footer-link:focus-visible {
-            color: #f59e0b;
-            text-decoration: underline;
+        .app-footer .footer-link:hover,        .app-footer .footer-link:focus-visible {
+            outline: none;
         }
-        .app-footer .footer-link:focus-visible {
+.app-footer .footer-link:focus-visible {
             outline: none;
         }
 
@@ -587,9 +565,7 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #center-trash-btn,
-        .app-container.focus-mode .filename-overlay { display: none; }
-
-        .app-container.focus-mode .focus-mode-ui { display: flex; }
+.app-container.focus-mode .focus-mode-ui { display: flex; }
         
         .hidden { display: none !important; }
         
@@ -731,10 +707,19 @@
                         Enable Haptic Feedback (Mobile)
                     </label>
                 </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="debug-toasts-enabled" checked style="margin: 0;">
+                        Enable Debug Toasts
+                    </label>
+                </div>
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -749,7 +734,10 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -764,7 +752,10 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Loading Screen -->
@@ -778,7 +769,10 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Main App Container -->
@@ -825,10 +819,7 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
-
-        
-        <!-- Center Stage UI -->
+<!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -848,8 +839,10 @@
             </svg>
         </button>
         
-        <div id="toast" class="toast"></div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -1040,7 +1033,8 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
-            pendingBackgroundProbe: null
+            pendingBackgroundProbe: null,
+            showDebugToasts: true
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -1149,6 +1143,7 @@
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
+                    debugToastToggle: document.getElementById('debug-toasts-enabled'),
                     
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
@@ -1173,11 +1168,9 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1271,45 +1264,35 @@
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
+                if (!state.showDebugToasts) {
+                    this.clearFooterToasts();
+                    return;
+                }
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                const footers = Array.from(document.querySelectorAll('.app-footer'));
-                const footerStatuses = footers.map(footer => {
+                const statusElements = [];
+                document.querySelectorAll('.app-footer').forEach(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
                     if (!statusSpan) {
                         statusSpan = document.createElement('span');
                         statusSpan.className = 'footer-status';
-                        const baselineAttr = footer.dataset.baselineText;
-                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
-                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
-                        statusSpan.dataset.baselineText = baselineText;
-                        if (textNodes.length) {
-                            footer.insertBefore(statusSpan, textNodes[0]);
-                            textNodes.forEach(node => footer.removeChild(node));
-                        } else {
-                            footer.insertBefore(statusSpan, footer.firstChild);
-                        }
-                        statusSpan.textContent = baselineText;
-                    } else if (statusSpan.dataset.baselineText === undefined) {
-                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                        statusSpan.setAttribute('aria-live', 'polite');
+                        footer.appendChild(statusSpan);
                     }
-                    const baselineText = statusSpan.dataset.baselineText ?? '';
                     statusSpan.textContent = message;
-                    statusSpan.classList.remove('success', 'error', 'info');
-                    statusSpan.classList.add(type);
-                    return { statusSpan, baselineText };
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                    statusSpan.classList.add('active', type);
+                    statusElements.push(statusSpan);
                 });
+                if (statusElements.length === 0) {
+                    return;
+                }
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    toast.classList.remove('show');
-                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
-                        statusSpan.textContent = baselineText;
-                        statusSpan.classList.remove('success', 'error', 'info');
+                    statusElements.forEach(statusSpan => {
+                        statusSpan.textContent = '';
+                        statusSpan.classList.remove('active', 'success', 'error', 'info');
                     });
                     this._toastHideTimer = null;
                 }, 3000);
@@ -1317,6 +1300,17 @@
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
+            },
+
+            clearFooterToasts() {
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                    this._toastHideTimer = null;
+                }
+                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
+                    statusSpan.textContent = '';
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                });
             },
             
             async setImageSrc(img, file) {
@@ -4847,8 +4841,7 @@
                     const folderName = state.currentFolder?.name || '';
                     const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
                     const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-                    if (Utils.elements.filenameOverlay) {
-                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+/ ${filenameWithoutExtension}`;
                         const directUrl = state.export?.getDirectImageURL?.(currentFile);
                         Utils.elements.filenameOverlay.href = directUrl || '#';
                         Utils.elements.filenameOverlay.classList.add('visible');
@@ -5062,10 +5055,7 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
-                if (Utils.elements.filenameOverlay) {
-                    Utils.elements.filenameOverlay.classList.remove('visible');
-                }
-                this.updateImageCounters();
+this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -5166,11 +5156,7 @@
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    const overlay = document.createElement('div');
-                    overlay.className = 'grid-filename-overlay';
-                    overlay.textContent = file.name;
                     div.appendChild(img);
-                    div.appendChild(overlay);
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
@@ -6573,8 +6559,29 @@
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
                 });
-                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+                const hapticToggle = document.getElementById('haptic-enabled');
+                if (hapticToggle) {
+                    hapticToggle.addEventListener('change', (e) => {
+                        if (state.haptic) {
+                            state.haptic.setEnabled(e.target.checked);
+                        }
+                    });
+                }
+                const debugToggle = document.getElementById('debug-toasts-enabled');
+                state.showDebugToasts = debugToggle ? debugToggle.checked : true;
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                }
+                if (debugToggle) {
+                    debugToggle.addEventListener('change', (e) => {
+                        state.showDebugToasts = e.target.checked;
+                        if (!state.showDebugToasts) {
+                            Utils.clearFooterToasts();
+                        }
+                    });
+                }
             },
+
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
                 Utils.elements.authBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -127,18 +127,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
-        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+.folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
             background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
@@ -184,36 +173,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
-
-        
-        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+.edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
             bottom: 0; left: 0; right: 0; height: 8px; 
@@ -409,27 +369,7 @@
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-
-        .grid-filename-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.7);
-            color: white;
-            padding: 8px;
-            font-size: 14px;
-            text-align: center;
-            opacity: 0;
-            transition: opacity 0.3s;
-            pointer-events: none;
-        }
-
-        .grid-item:hover .grid-filename-overlay {
-            opacity: 1;
-        }
-        
-        .details-modal-content { 
+.details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
@@ -496,18 +436,58 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
-        .app-footer {
-            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
-            color: rgba(255, 255, 255, 0.6); text-align: center;
-            padding: 4px 8px;
-            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+.app-footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6);
+            text-align: center;
+            padding: 8px 12px;
+            font-size: 10px;
+            z-index: 5;
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .app-footer .footer-baseline {
+            color: rgba(255, 255, 255, 0.6);
         }
         .app-footer .footer-status {
-            color: inherit;
+            position: absolute;
+            inset: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 14px;
+            border-radius: 9999px;
+            background: rgba(0, 0, 0, 0.85);
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: nowrap;
+            max-width: calc(100% - 24px);
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-        .app-footer .footer-status:not(:empty) {
-            margin-right: 8px;
+        .app-footer .footer-status.active {
+            opacity: 1;
+        }
+        .app-footer .footer-status.success {
+            background: rgba(16, 185, 129, 0.9);
+        }
+        .app-footer .footer-status.info {
+            background: rgba(59, 130, 246, 0.9);
+        }
+        .app-footer .footer-status.error {
+            background: rgba(239, 68, 68, 0.9);
         }
         .app-footer .footer-link {
             background: transparent;
@@ -520,12 +500,10 @@
             text-decoration: none;
             transition: color 0.2s ease;
         }
-        .app-footer .footer-link:hover,
-        .app-footer .footer-link:focus-visible {
-            color: #f59e0b;
-            text-decoration: underline;
+        .app-footer .footer-link:hover,        .app-footer .footer-link:focus-visible {
+            outline: none;
         }
-        .app-footer .footer-link:focus-visible {
+.app-footer .footer-link:focus-visible {
             outline: none;
         }
 
@@ -587,9 +565,7 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #center-trash-btn,
-        .app-container.focus-mode .filename-overlay { display: none; }
-
-        .app-container.focus-mode .focus-mode-ui { display: flex; }
+.app-container.focus-mode .focus-mode-ui { display: flex; }
         
         .hidden { display: none !important; }
         
@@ -731,10 +707,19 @@
                         Enable Haptic Feedback (Mobile)
                     </label>
                 </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="debug-toasts-enabled" checked style="margin: 0;">
+                        Enable Debug Toasts
+                    </label>
+                </div>
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -749,7 +734,10 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -764,7 +752,10 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Loading Screen -->
@@ -778,7 +769,10 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Main App Container -->
@@ -825,10 +819,7 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
-
-        
-        <!-- Center Stage UI -->
+<!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -848,8 +839,10 @@
             </svg>
         </button>
         
-        <div id="toast" class="toast"></div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -1040,7 +1033,8 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
-            pendingBackgroundProbe: null
+            pendingBackgroundProbe: null,
+            showDebugToasts: true
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -1149,6 +1143,7 @@
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
+                    debugToastToggle: document.getElementById('debug-toasts-enabled'),
                     
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
@@ -1173,11 +1168,9 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1271,45 +1264,35 @@
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
+                if (!state.showDebugToasts) {
+                    this.clearFooterToasts();
+                    return;
+                }
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                const footers = Array.from(document.querySelectorAll('.app-footer'));
-                const footerStatuses = footers.map(footer => {
+                const statusElements = [];
+                document.querySelectorAll('.app-footer').forEach(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
                     if (!statusSpan) {
                         statusSpan = document.createElement('span');
                         statusSpan.className = 'footer-status';
-                        const baselineAttr = footer.dataset.baselineText;
-                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
-                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
-                        statusSpan.dataset.baselineText = baselineText;
-                        if (textNodes.length) {
-                            footer.insertBefore(statusSpan, textNodes[0]);
-                            textNodes.forEach(node => footer.removeChild(node));
-                        } else {
-                            footer.insertBefore(statusSpan, footer.firstChild);
-                        }
-                        statusSpan.textContent = baselineText;
-                    } else if (statusSpan.dataset.baselineText === undefined) {
-                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                        statusSpan.setAttribute('aria-live', 'polite');
+                        footer.appendChild(statusSpan);
                     }
-                    const baselineText = statusSpan.dataset.baselineText ?? '';
                     statusSpan.textContent = message;
-                    statusSpan.classList.remove('success', 'error', 'info');
-                    statusSpan.classList.add(type);
-                    return { statusSpan, baselineText };
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                    statusSpan.classList.add('active', type);
+                    statusElements.push(statusSpan);
                 });
+                if (statusElements.length === 0) {
+                    return;
+                }
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    toast.classList.remove('show');
-                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
-                        statusSpan.textContent = baselineText;
-                        statusSpan.classList.remove('success', 'error', 'info');
+                    statusElements.forEach(statusSpan => {
+                        statusSpan.textContent = '';
+                        statusSpan.classList.remove('active', 'success', 'error', 'info');
                     });
                     this._toastHideTimer = null;
                 }, 3000);
@@ -1317,6 +1300,17 @@
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
+            },
+
+            clearFooterToasts() {
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                    this._toastHideTimer = null;
+                }
+                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
+                    statusSpan.textContent = '';
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                });
             },
             
             async setImageSrc(img, file) {
@@ -4847,8 +4841,7 @@
                     const folderName = state.currentFolder?.name || '';
                     const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
                     const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-                    if (Utils.elements.filenameOverlay) {
-                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+/ ${filenameWithoutExtension}`;
                         const directUrl = state.export?.getDirectImageURL?.(currentFile);
                         Utils.elements.filenameOverlay.href = directUrl || '#';
                         Utils.elements.filenameOverlay.classList.add('visible');
@@ -5062,10 +5055,7 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
-                if (Utils.elements.filenameOverlay) {
-                    Utils.elements.filenameOverlay.classList.remove('visible');
-                }
-                this.updateImageCounters();
+this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -5166,11 +5156,7 @@
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    const overlay = document.createElement('div');
-                    overlay.className = 'grid-filename-overlay';
-                    overlay.textContent = file.name;
                     div.appendChild(img);
-                    div.appendChild(overlay);
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
@@ -6573,8 +6559,29 @@
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
                 });
-                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+                const hapticToggle = document.getElementById('haptic-enabled');
+                if (hapticToggle) {
+                    hapticToggle.addEventListener('change', (e) => {
+                        if (state.haptic) {
+                            state.haptic.setEnabled(e.target.checked);
+                        }
+                    });
+                }
+                const debugToggle = document.getElementById('debug-toasts-enabled');
+                state.showDebugToasts = debugToggle ? debugToggle.checked : true;
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                }
+                if (debugToggle) {
+                    debugToggle.addEventListener('change', (e) => {
+                        state.showDebugToasts = e.target.checked;
+                        if (!state.showDebugToasts) {
+                            Utils.clearFooterToasts();
+                        }
+                    });
+                }
             },
+
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
                 Utils.elements.authBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -127,18 +127,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
-        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+.folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
             background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
@@ -184,36 +173,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
-
-        
-        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+.edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
             bottom: 0; left: 0; right: 0; height: 8px; 
@@ -409,27 +369,7 @@
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-
-        .grid-filename-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.7);
-            color: white;
-            padding: 8px;
-            font-size: 14px;
-            text-align: center;
-            opacity: 0;
-            transition: opacity 0.3s;
-            pointer-events: none;
-        }
-
-        .grid-item:hover .grid-filename-overlay {
-            opacity: 1;
-        }
-        
-        .details-modal-content { 
+.details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
@@ -496,18 +436,58 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
-        .app-footer {
-            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
-            color: rgba(255, 255, 255, 0.6); text-align: center;
-            padding: 4px 8px;
-            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+.app-footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6);
+            text-align: center;
+            padding: 8px 12px;
+            font-size: 10px;
+            z-index: 5;
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .app-footer .footer-baseline {
+            color: rgba(255, 255, 255, 0.6);
         }
         .app-footer .footer-status {
-            color: inherit;
+            position: absolute;
+            inset: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 14px;
+            border-radius: 9999px;
+            background: rgba(0, 0, 0, 0.85);
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: nowrap;
+            max-width: calc(100% - 24px);
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-        .app-footer .footer-status:not(:empty) {
-            margin-right: 8px;
+        .app-footer .footer-status.active {
+            opacity: 1;
+        }
+        .app-footer .footer-status.success {
+            background: rgba(16, 185, 129, 0.9);
+        }
+        .app-footer .footer-status.info {
+            background: rgba(59, 130, 246, 0.9);
+        }
+        .app-footer .footer-status.error {
+            background: rgba(239, 68, 68, 0.9);
         }
         .app-footer .footer-link {
             background: transparent;
@@ -520,12 +500,10 @@
             text-decoration: none;
             transition: color 0.2s ease;
         }
-        .app-footer .footer-link:hover,
-        .app-footer .footer-link:focus-visible {
-            color: #f59e0b;
-            text-decoration: underline;
+        .app-footer .footer-link:hover,        .app-footer .footer-link:focus-visible {
+            outline: none;
         }
-        .app-footer .footer-link:focus-visible {
+.app-footer .footer-link:focus-visible {
             outline: none;
         }
 
@@ -587,9 +565,7 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #center-trash-btn,
-        .app-container.focus-mode .filename-overlay { display: none; }
-
-        .app-container.focus-mode .focus-mode-ui { display: flex; }
+.app-container.focus-mode .focus-mode-ui { display: flex; }
         
         .hidden { display: none !important; }
         
@@ -731,10 +707,19 @@
                         Enable Haptic Feedback (Mobile)
                     </label>
                 </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="debug-toasts-enabled" checked style="margin: 0;">
+                        Enable Debug Toasts
+                    </label>
+                </div>
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -749,7 +734,10 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -764,7 +752,10 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Loading Screen -->
@@ -778,7 +769,10 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Main App Container -->
@@ -825,10 +819,7 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
-
-        
-        <!-- Center Stage UI -->
+<!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -848,8 +839,10 @@
             </svg>
         </button>
         
-        <div id="toast" class="toast"></div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -1040,7 +1033,8 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
-            pendingBackgroundProbe: null
+            pendingBackgroundProbe: null,
+            showDebugToasts: true
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -1149,6 +1143,7 @@
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
+                    debugToastToggle: document.getElementById('debug-toasts-enabled'),
                     
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
@@ -1173,11 +1168,9 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1271,45 +1264,35 @@
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
+                if (!state.showDebugToasts) {
+                    this.clearFooterToasts();
+                    return;
+                }
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                const footers = Array.from(document.querySelectorAll('.app-footer'));
-                const footerStatuses = footers.map(footer => {
+                const statusElements = [];
+                document.querySelectorAll('.app-footer').forEach(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
                     if (!statusSpan) {
                         statusSpan = document.createElement('span');
                         statusSpan.className = 'footer-status';
-                        const baselineAttr = footer.dataset.baselineText;
-                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
-                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
-                        statusSpan.dataset.baselineText = baselineText;
-                        if (textNodes.length) {
-                            footer.insertBefore(statusSpan, textNodes[0]);
-                            textNodes.forEach(node => footer.removeChild(node));
-                        } else {
-                            footer.insertBefore(statusSpan, footer.firstChild);
-                        }
-                        statusSpan.textContent = baselineText;
-                    } else if (statusSpan.dataset.baselineText === undefined) {
-                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                        statusSpan.setAttribute('aria-live', 'polite');
+                        footer.appendChild(statusSpan);
                     }
-                    const baselineText = statusSpan.dataset.baselineText ?? '';
                     statusSpan.textContent = message;
-                    statusSpan.classList.remove('success', 'error', 'info');
-                    statusSpan.classList.add(type);
-                    return { statusSpan, baselineText };
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                    statusSpan.classList.add('active', type);
+                    statusElements.push(statusSpan);
                 });
+                if (statusElements.length === 0) {
+                    return;
+                }
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    toast.classList.remove('show');
-                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
-                        statusSpan.textContent = baselineText;
-                        statusSpan.classList.remove('success', 'error', 'info');
+                    statusElements.forEach(statusSpan => {
+                        statusSpan.textContent = '';
+                        statusSpan.classList.remove('active', 'success', 'error', 'info');
                     });
                     this._toastHideTimer = null;
                 }, 3000);
@@ -1317,6 +1300,17 @@
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
+            },
+
+            clearFooterToasts() {
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                    this._toastHideTimer = null;
+                }
+                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
+                    statusSpan.textContent = '';
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                });
             },
             
             async setImageSrc(img, file) {
@@ -4847,8 +4841,7 @@
                     const folderName = state.currentFolder?.name || '';
                     const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
                     const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-                    if (Utils.elements.filenameOverlay) {
-                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+/ ${filenameWithoutExtension}`;
                         const directUrl = state.export?.getDirectImageURL?.(currentFile);
                         Utils.elements.filenameOverlay.href = directUrl || '#';
                         Utils.elements.filenameOverlay.classList.add('visible');
@@ -5062,10 +5055,7 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
-                if (Utils.elements.filenameOverlay) {
-                    Utils.elements.filenameOverlay.classList.remove('visible');
-                }
-                this.updateImageCounters();
+this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -5166,11 +5156,7 @@
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    const overlay = document.createElement('div');
-                    overlay.className = 'grid-filename-overlay';
-                    overlay.textContent = file.name;
                     div.appendChild(img);
-                    div.appendChild(overlay);
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
@@ -6573,8 +6559,29 @@
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
                 });
-                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+                const hapticToggle = document.getElementById('haptic-enabled');
+                if (hapticToggle) {
+                    hapticToggle.addEventListener('change', (e) => {
+                        if (state.haptic) {
+                            state.haptic.setEnabled(e.target.checked);
+                        }
+                    });
+                }
+                const debugToggle = document.getElementById('debug-toasts-enabled');
+                state.showDebugToasts = debugToggle ? debugToggle.checked : true;
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                }
+                if (debugToggle) {
+                    debugToggle.addEventListener('change', (e) => {
+                        state.showDebugToasts = e.target.checked;
+                        if (!state.showDebugToasts) {
+                            Utils.clearFooterToasts();
+                        }
+                    });
+                }
             },
+
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
                 Utils.elements.authBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -127,18 +127,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
-        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+.folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
             background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
@@ -184,36 +173,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
-
-        
-        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+.edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
             bottom: 0; left: 0; right: 0; height: 8px; 
@@ -409,27 +369,7 @@
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-
-        .grid-filename-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.7);
-            color: white;
-            padding: 8px;
-            font-size: 14px;
-            text-align: center;
-            opacity: 0;
-            transition: opacity 0.3s;
-            pointer-events: none;
-        }
-
-        .grid-item:hover .grid-filename-overlay {
-            opacity: 1;
-        }
-        
-        .details-modal-content { 
+.details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
@@ -496,18 +436,58 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
-        .app-footer {
-            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
-            color: rgba(255, 255, 255, 0.6); text-align: center;
-            padding: 4px 8px;
-            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+.app-footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6);
+            text-align: center;
+            padding: 8px 12px;
+            font-size: 10px;
+            z-index: 5;
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .app-footer .footer-baseline {
+            color: rgba(255, 255, 255, 0.6);
         }
         .app-footer .footer-status {
-            color: inherit;
+            position: absolute;
+            inset: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 14px;
+            border-radius: 9999px;
+            background: rgba(0, 0, 0, 0.85);
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: nowrap;
+            max-width: calc(100% - 24px);
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-        .app-footer .footer-status:not(:empty) {
-            margin-right: 8px;
+        .app-footer .footer-status.active {
+            opacity: 1;
+        }
+        .app-footer .footer-status.success {
+            background: rgba(16, 185, 129, 0.9);
+        }
+        .app-footer .footer-status.info {
+            background: rgba(59, 130, 246, 0.9);
+        }
+        .app-footer .footer-status.error {
+            background: rgba(239, 68, 68, 0.9);
         }
         .app-footer .footer-link {
             background: transparent;
@@ -520,12 +500,10 @@
             text-decoration: none;
             transition: color 0.2s ease;
         }
-        .app-footer .footer-link:hover,
-        .app-footer .footer-link:focus-visible {
-            color: #f59e0b;
-            text-decoration: underline;
+        .app-footer .footer-link:hover,        .app-footer .footer-link:focus-visible {
+            outline: none;
         }
-        .app-footer .footer-link:focus-visible {
+.app-footer .footer-link:focus-visible {
             outline: none;
         }
 
@@ -587,9 +565,7 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #center-trash-btn,
-        .app-container.focus-mode .filename-overlay { display: none; }
-
-        .app-container.focus-mode .focus-mode-ui { display: flex; }
+.app-container.focus-mode .focus-mode-ui { display: flex; }
         
         .hidden { display: none !important; }
         
@@ -731,10 +707,19 @@
                         Enable Haptic Feedback (Mobile)
                     </label>
                 </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="debug-toasts-enabled" checked style="margin: 0;">
+                        Enable Debug Toasts
+                    </label>
+                </div>
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -749,7 +734,10 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -764,7 +752,10 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Loading Screen -->
@@ -778,7 +769,10 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Main App Container -->
@@ -825,10 +819,7 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
-
-        
-        <!-- Center Stage UI -->
+<!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -848,8 +839,10 @@
             </svg>
         </button>
         
-        <div id="toast" class="toast"></div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -1040,7 +1033,8 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
-            pendingBackgroundProbe: null
+            pendingBackgroundProbe: null,
+            showDebugToasts: true
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -1149,6 +1143,7 @@
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
+                    debugToastToggle: document.getElementById('debug-toasts-enabled'),
                     
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
@@ -1173,11 +1168,9 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1271,45 +1264,35 @@
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
+                if (!state.showDebugToasts) {
+                    this.clearFooterToasts();
+                    return;
+                }
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                const footers = Array.from(document.querySelectorAll('.app-footer'));
-                const footerStatuses = footers.map(footer => {
+                const statusElements = [];
+                document.querySelectorAll('.app-footer').forEach(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
                     if (!statusSpan) {
                         statusSpan = document.createElement('span');
                         statusSpan.className = 'footer-status';
-                        const baselineAttr = footer.dataset.baselineText;
-                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
-                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
-                        statusSpan.dataset.baselineText = baselineText;
-                        if (textNodes.length) {
-                            footer.insertBefore(statusSpan, textNodes[0]);
-                            textNodes.forEach(node => footer.removeChild(node));
-                        } else {
-                            footer.insertBefore(statusSpan, footer.firstChild);
-                        }
-                        statusSpan.textContent = baselineText;
-                    } else if (statusSpan.dataset.baselineText === undefined) {
-                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                        statusSpan.setAttribute('aria-live', 'polite');
+                        footer.appendChild(statusSpan);
                     }
-                    const baselineText = statusSpan.dataset.baselineText ?? '';
                     statusSpan.textContent = message;
-                    statusSpan.classList.remove('success', 'error', 'info');
-                    statusSpan.classList.add(type);
-                    return { statusSpan, baselineText };
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                    statusSpan.classList.add('active', type);
+                    statusElements.push(statusSpan);
                 });
+                if (statusElements.length === 0) {
+                    return;
+                }
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    toast.classList.remove('show');
-                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
-                        statusSpan.textContent = baselineText;
-                        statusSpan.classList.remove('success', 'error', 'info');
+                    statusElements.forEach(statusSpan => {
+                        statusSpan.textContent = '';
+                        statusSpan.classList.remove('active', 'success', 'error', 'info');
                     });
                     this._toastHideTimer = null;
                 }, 3000);
@@ -1317,6 +1300,17 @@
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
+            },
+
+            clearFooterToasts() {
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                    this._toastHideTimer = null;
+                }
+                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
+                    statusSpan.textContent = '';
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                });
             },
             
             async setImageSrc(img, file) {
@@ -4847,8 +4841,7 @@
                     const folderName = state.currentFolder?.name || '';
                     const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
                     const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-                    if (Utils.elements.filenameOverlay) {
-                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+/ ${filenameWithoutExtension}`;
                         const directUrl = state.export?.getDirectImageURL?.(currentFile);
                         Utils.elements.filenameOverlay.href = directUrl || '#';
                         Utils.elements.filenameOverlay.classList.add('visible');
@@ -5062,10 +5055,7 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
-                if (Utils.elements.filenameOverlay) {
-                    Utils.elements.filenameOverlay.classList.remove('visible');
-                }
-                this.updateImageCounters();
+this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -5166,11 +5156,7 @@
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    const overlay = document.createElement('div');
-                    overlay.className = 'grid-filename-overlay';
-                    overlay.textContent = file.name;
                     div.appendChild(img);
-                    div.appendChild(overlay);
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
@@ -6601,8 +6587,29 @@
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
                 });
-                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+                const hapticToggle = document.getElementById('haptic-enabled');
+                if (hapticToggle) {
+                    hapticToggle.addEventListener('change', (e) => {
+                        if (state.haptic) {
+                            state.haptic.setEnabled(e.target.checked);
+                        }
+                    });
+                }
+                const debugToggle = document.getElementById('debug-toasts-enabled');
+                state.showDebugToasts = debugToggle ? debugToggle.checked : true;
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                }
+                if (debugToggle) {
+                    debugToggle.addEventListener('change', (e) => {
+                        state.showDebugToasts = e.target.checked;
+                        if (!state.showDebugToasts) {
+                            Utils.clearFooterToasts();
+                        }
+                    });
+                }
             },
+
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
                 Utils.elements.authBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -127,18 +127,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
-        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+.folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
             background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
@@ -184,36 +173,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
-
-        
-        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+.edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
             bottom: 0; left: 0; right: 0; height: 8px; 
@@ -409,27 +369,7 @@
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-
-        .grid-filename-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.7);
-            color: white;
-            padding: 8px;
-            font-size: 14px;
-            text-align: center;
-            opacity: 0;
-            transition: opacity 0.3s;
-            pointer-events: none;
-        }
-
-        .grid-item:hover .grid-filename-overlay {
-            opacity: 1;
-        }
-        
-        .details-modal-content { 
+.details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
@@ -496,18 +436,58 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
-        .app-footer {
-            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
-            color: rgba(255, 255, 255, 0.6); text-align: center;
-            padding: 4px 8px;
-            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+.app-footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6);
+            text-align: center;
+            padding: 8px 12px;
+            font-size: 10px;
+            z-index: 5;
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .app-footer .footer-baseline {
+            color: rgba(255, 255, 255, 0.6);
         }
         .app-footer .footer-status {
-            color: inherit;
+            position: absolute;
+            inset: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 14px;
+            border-radius: 9999px;
+            background: rgba(0, 0, 0, 0.85);
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: nowrap;
+            max-width: calc(100% - 24px);
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-        .app-footer .footer-status:not(:empty) {
-            margin-right: 8px;
+        .app-footer .footer-status.active {
+            opacity: 1;
+        }
+        .app-footer .footer-status.success {
+            background: rgba(16, 185, 129, 0.9);
+        }
+        .app-footer .footer-status.info {
+            background: rgba(59, 130, 246, 0.9);
+        }
+        .app-footer .footer-status.error {
+            background: rgba(239, 68, 68, 0.9);
         }
         .app-footer .footer-link {
             background: transparent;
@@ -520,12 +500,10 @@
             text-decoration: none;
             transition: color 0.2s ease;
         }
-        .app-footer .footer-link:hover,
-        .app-footer .footer-link:focus-visible {
-            color: #f59e0b;
-            text-decoration: underline;
+        .app-footer .footer-link:hover,        .app-footer .footer-link:focus-visible {
+            outline: none;
         }
-        .app-footer .footer-link:focus-visible {
+.app-footer .footer-link:focus-visible {
             outline: none;
         }
 
@@ -587,9 +565,7 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #center-trash-btn,
-        .app-container.focus-mode .filename-overlay { display: none; }
-
-        .app-container.focus-mode .focus-mode-ui { display: flex; }
+.app-container.focus-mode .focus-mode-ui { display: flex; }
         
         .hidden { display: none !important; }
         
@@ -731,10 +707,19 @@
                         Enable Haptic Feedback (Mobile)
                     </label>
                 </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="debug-toasts-enabled" checked style="margin: 0;">
+                        Enable Debug Toasts
+                    </label>
+                </div>
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -749,7 +734,10 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -764,7 +752,10 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Loading Screen -->
@@ -778,7 +769,10 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Main App Container -->
@@ -825,10 +819,7 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
-
-        
-        <!-- Center Stage UI -->
+<!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -848,8 +839,10 @@
             </svg>
         </button>
         
-        <div id="toast" class="toast"></div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -1040,7 +1033,8 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
-            pendingBackgroundProbe: null
+            pendingBackgroundProbe: null,
+            showDebugToasts: true
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -1149,6 +1143,7 @@
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
+                    debugToastToggle: document.getElementById('debug-toasts-enabled'),
                     
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
@@ -1173,11 +1168,9 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1271,45 +1264,35 @@
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
+                if (!state.showDebugToasts) {
+                    this.clearFooterToasts();
+                    return;
+                }
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                const footers = Array.from(document.querySelectorAll('.app-footer'));
-                const footerStatuses = footers.map(footer => {
+                const statusElements = [];
+                document.querySelectorAll('.app-footer').forEach(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
                     if (!statusSpan) {
                         statusSpan = document.createElement('span');
                         statusSpan.className = 'footer-status';
-                        const baselineAttr = footer.dataset.baselineText;
-                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
-                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
-                        statusSpan.dataset.baselineText = baselineText;
-                        if (textNodes.length) {
-                            footer.insertBefore(statusSpan, textNodes[0]);
-                            textNodes.forEach(node => footer.removeChild(node));
-                        } else {
-                            footer.insertBefore(statusSpan, footer.firstChild);
-                        }
-                        statusSpan.textContent = baselineText;
-                    } else if (statusSpan.dataset.baselineText === undefined) {
-                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                        statusSpan.setAttribute('aria-live', 'polite');
+                        footer.appendChild(statusSpan);
                     }
-                    const baselineText = statusSpan.dataset.baselineText ?? '';
                     statusSpan.textContent = message;
-                    statusSpan.classList.remove('success', 'error', 'info');
-                    statusSpan.classList.add(type);
-                    return { statusSpan, baselineText };
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                    statusSpan.classList.add('active', type);
+                    statusElements.push(statusSpan);
                 });
+                if (statusElements.length === 0) {
+                    return;
+                }
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    toast.classList.remove('show');
-                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
-                        statusSpan.textContent = baselineText;
-                        statusSpan.classList.remove('success', 'error', 'info');
+                    statusElements.forEach(statusSpan => {
+                        statusSpan.textContent = '';
+                        statusSpan.classList.remove('active', 'success', 'error', 'info');
                     });
                     this._toastHideTimer = null;
                 }, 3000);
@@ -1317,6 +1300,17 @@
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
+            },
+
+            clearFooterToasts() {
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                    this._toastHideTimer = null;
+                }
+                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
+                    statusSpan.textContent = '';
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                });
             },
             
             async setImageSrc(img, file) {
@@ -4847,8 +4841,7 @@
                     const folderName = state.currentFolder?.name || '';
                     const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
                     const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-                    if (Utils.elements.filenameOverlay) {
-                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+/ ${filenameWithoutExtension}`;
                         const directUrl = state.export?.getDirectImageURL?.(currentFile);
                         Utils.elements.filenameOverlay.href = directUrl || '#';
                         Utils.elements.filenameOverlay.classList.add('visible');
@@ -5062,10 +5055,7 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
-                if (Utils.elements.filenameOverlay) {
-                    Utils.elements.filenameOverlay.classList.remove('visible');
-                }
-                this.updateImageCounters();
+this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -5166,11 +5156,7 @@
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    const overlay = document.createElement('div');
-                    overlay.className = 'grid-filename-overlay';
-                    overlay.textContent = file.name;
                     div.appendChild(img);
-                    div.appendChild(overlay);
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
@@ -6601,8 +6587,29 @@
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
                 });
-                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+                const hapticToggle = document.getElementById('haptic-enabled');
+                if (hapticToggle) {
+                    hapticToggle.addEventListener('change', (e) => {
+                        if (state.haptic) {
+                            state.haptic.setEnabled(e.target.checked);
+                        }
+                    });
+                }
+                const debugToggle = document.getElementById('debug-toasts-enabled');
+                state.showDebugToasts = debugToggle ? debugToggle.checked : true;
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                }
+                if (debugToggle) {
+                    debugToggle.addEventListener('change', (e) => {
+                        state.showDebugToasts = e.target.checked;
+                        if (!state.showDebugToasts) {
+                            Utils.clearFooterToasts();
+                        }
+                    });
+                }
             },
+
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
                 Utils.elements.authBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -127,18 +127,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
-        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+.folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
             background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
@@ -184,36 +173,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
-
-        
-        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+.edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
             bottom: 0; left: 0; right: 0; height: 8px; 
@@ -409,27 +369,7 @@
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-
-        .grid-filename-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.7);
-            color: white;
-            padding: 8px;
-            font-size: 14px;
-            text-align: center;
-            opacity: 0;
-            transition: opacity 0.3s;
-            pointer-events: none;
-        }
-
-        .grid-item:hover .grid-filename-overlay {
-            opacity: 1;
-        }
-        
-        .details-modal-content { 
+.details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
@@ -496,18 +436,58 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
-        .app-footer {
-            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
-            color: rgba(255, 255, 255, 0.6); text-align: center;
-            padding: 4px 8px;
-            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+.app-footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6);
+            text-align: center;
+            padding: 8px 12px;
+            font-size: 10px;
+            z-index: 5;
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .app-footer .footer-baseline {
+            color: rgba(255, 255, 255, 0.6);
         }
         .app-footer .footer-status {
-            color: inherit;
+            position: absolute;
+            inset: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 14px;
+            border-radius: 9999px;
+            background: rgba(0, 0, 0, 0.85);
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: nowrap;
+            max-width: calc(100% - 24px);
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-        .app-footer .footer-status:not(:empty) {
-            margin-right: 8px;
+        .app-footer .footer-status.active {
+            opacity: 1;
+        }
+        .app-footer .footer-status.success {
+            background: rgba(16, 185, 129, 0.9);
+        }
+        .app-footer .footer-status.info {
+            background: rgba(59, 130, 246, 0.9);
+        }
+        .app-footer .footer-status.error {
+            background: rgba(239, 68, 68, 0.9);
         }
         .app-footer .footer-link {
             background: transparent;
@@ -520,12 +500,10 @@
             text-decoration: none;
             transition: color 0.2s ease;
         }
-        .app-footer .footer-link:hover,
-        .app-footer .footer-link:focus-visible {
-            color: #f59e0b;
-            text-decoration: underline;
+        .app-footer .footer-link:hover,        .app-footer .footer-link:focus-visible {
+            outline: none;
         }
-        .app-footer .footer-link:focus-visible {
+.app-footer .footer-link:focus-visible {
             outline: none;
         }
 
@@ -587,9 +565,7 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #center-trash-btn,
-        .app-container.focus-mode .filename-overlay { display: none; }
-
-        .app-container.focus-mode .focus-mode-ui { display: flex; }
+.app-container.focus-mode .focus-mode-ui { display: flex; }
         
         .hidden { display: none !important; }
         
@@ -731,10 +707,19 @@
                         Enable Haptic Feedback (Mobile)
                     </label>
                 </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="debug-toasts-enabled" checked style="margin: 0;">
+                        Enable Debug Toasts
+                    </label>
+                </div>
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -749,7 +734,10 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -764,7 +752,10 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Loading Screen -->
@@ -778,7 +769,10 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Main App Container -->
@@ -825,10 +819,7 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
-
-        
-        <!-- Center Stage UI -->
+<!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -848,8 +839,10 @@
             </svg>
         </button>
         
-        <div id="toast" class="toast"></div>
-        <div class="app-footer">baseline: 2025-10-12/02-Oct-25</div>
+        <div class="app-footer">
+            <span class="footer-baseline">baseline: 2025-10-12/02-Oct-25</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -1040,7 +1033,8 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
-            pendingBackgroundProbe: null
+            pendingBackgroundProbe: null,
+            showDebugToasts: true
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -1149,6 +1143,7 @@
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
+                    debugToastToggle: document.getElementById('debug-toasts-enabled'),
                     
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
@@ -1173,11 +1168,9 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1271,45 +1264,35 @@
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
+                if (!state.showDebugToasts) {
+                    this.clearFooterToasts();
+                    return;
+                }
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                const footers = Array.from(document.querySelectorAll('.app-footer'));
-                const footerStatuses = footers.map(footer => {
+                const statusElements = [];
+                document.querySelectorAll('.app-footer').forEach(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
                     if (!statusSpan) {
                         statusSpan = document.createElement('span');
                         statusSpan.className = 'footer-status';
-                        const baselineAttr = footer.dataset.baselineText;
-                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
-                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
-                        statusSpan.dataset.baselineText = baselineText;
-                        if (textNodes.length) {
-                            footer.insertBefore(statusSpan, textNodes[0]);
-                            textNodes.forEach(node => footer.removeChild(node));
-                        } else {
-                            footer.insertBefore(statusSpan, footer.firstChild);
-                        }
-                        statusSpan.textContent = baselineText;
-                    } else if (statusSpan.dataset.baselineText === undefined) {
-                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                        statusSpan.setAttribute('aria-live', 'polite');
+                        footer.appendChild(statusSpan);
                     }
-                    const baselineText = statusSpan.dataset.baselineText ?? '';
                     statusSpan.textContent = message;
-                    statusSpan.classList.remove('success', 'error', 'info');
-                    statusSpan.classList.add(type);
-                    return { statusSpan, baselineText };
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                    statusSpan.classList.add('active', type);
+                    statusElements.push(statusSpan);
                 });
+                if (statusElements.length === 0) {
+                    return;
+                }
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    toast.classList.remove('show');
-                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
-                        statusSpan.textContent = baselineText;
-                        statusSpan.classList.remove('success', 'error', 'info');
+                    statusElements.forEach(statusSpan => {
+                        statusSpan.textContent = '';
+                        statusSpan.classList.remove('active', 'success', 'error', 'info');
                     });
                     this._toastHideTimer = null;
                 }, 3000);
@@ -1317,6 +1300,17 @@
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
+            },
+
+            clearFooterToasts() {
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                    this._toastHideTimer = null;
+                }
+                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
+                    statusSpan.textContent = '';
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                });
             },
             
             async setImageSrc(img, file) {
@@ -4847,8 +4841,7 @@
                     const folderName = state.currentFolder?.name || '';
                     const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
                     const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-                    if (Utils.elements.filenameOverlay) {
-                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+/ ${filenameWithoutExtension}`;
                         const directUrl = state.export?.getDirectImageURL?.(currentFile);
                         Utils.elements.filenameOverlay.href = directUrl || '#';
                         Utils.elements.filenameOverlay.classList.add('visible');
@@ -5062,10 +5055,7 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
-                if (Utils.elements.filenameOverlay) {
-                    Utils.elements.filenameOverlay.classList.remove('visible');
-                }
-                this.updateImageCounters();
+this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -5166,11 +5156,7 @@
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    const overlay = document.createElement('div');
-                    overlay.className = 'grid-filename-overlay';
-                    overlay.textContent = file.name;
                     div.appendChild(img);
-                    div.appendChild(overlay);
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
@@ -6590,8 +6576,29 @@
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
                 });
-                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+                const hapticToggle = document.getElementById('haptic-enabled');
+                if (hapticToggle) {
+                    hapticToggle.addEventListener('change', (e) => {
+                        if (state.haptic) {
+                            state.haptic.setEnabled(e.target.checked);
+                        }
+                    });
+                }
+                const debugToggle = document.getElementById('debug-toasts-enabled');
+                state.showDebugToasts = debugToggle ? debugToggle.checked : true;
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                }
+                if (debugToggle) {
+                    debugToggle.addEventListener('change', (e) => {
+                        state.showDebugToasts = e.target.checked;
+                        if (!state.showDebugToasts) {
+                            Utils.clearFooterToasts();
+                        }
+                    });
+                }
             },
+
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
                 Utils.elements.authBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -127,18 +127,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
-        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+.folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
             background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
@@ -184,36 +173,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
-
-        
-        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+.edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
             bottom: 0; left: 0; right: 0; height: 8px; 
@@ -409,27 +369,7 @@
         .grid-image[data-src] { opacity: 0; }
         .grid-image.loaded { opacity: 1; }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
-
-        .grid-filename-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.7);
-            color: white;
-            padding: 8px;
-            font-size: 14px;
-            text-align: center;
-            opacity: 0;
-            transition: opacity 0.3s;
-            pointer-events: none;
-        }
-
-        .grid-item:hover .grid-filename-overlay {
-            opacity: 1;
-        }
-        
-        .details-modal-content { 
+.details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
@@ -496,18 +436,58 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
-        .app-footer {
-            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
-            color: rgba(255, 255, 255, 0.6); text-align: center;
-            padding: 4px 8px;
-            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+.app-footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6);
+            text-align: center;
+            padding: 8px 12px;
+            font-size: 10px;
+            z-index: 5;
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .app-footer .footer-baseline {
+            color: rgba(255, 255, 255, 0.6);
         }
         .app-footer .footer-status {
-            color: inherit;
+            position: absolute;
+            inset: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 14px;
+            border-radius: 9999px;
+            background: rgba(0, 0, 0, 0.85);
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: nowrap;
+            max-width: calc(100% - 24px);
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-        .app-footer .footer-status:not(:empty) {
-            margin-right: 8px;
+        .app-footer .footer-status.active {
+            opacity: 1;
+        }
+        .app-footer .footer-status.success {
+            background: rgba(16, 185, 129, 0.9);
+        }
+        .app-footer .footer-status.info {
+            background: rgba(59, 130, 246, 0.9);
+        }
+        .app-footer .footer-status.error {
+            background: rgba(239, 68, 68, 0.9);
         }
         .app-footer .footer-link {
             background: transparent;
@@ -520,12 +500,10 @@
             text-decoration: none;
             transition: color 0.2s ease;
         }
-        .app-footer .footer-link:hover,
-        .app-footer .footer-link:focus-visible {
-            color: #f59e0b;
-            text-decoration: underline;
+        .app-footer .footer-link:hover,        .app-footer .footer-link:focus-visible {
+            outline: none;
         }
-        .app-footer .footer-link:focus-visible {
+.app-footer .footer-link:focus-visible {
             outline: none;
         }
 
@@ -587,9 +565,7 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #center-trash-btn,
-        .app-container.focus-mode .filename-overlay { display: none; }
-
-        .app-container.focus-mode .focus-mode-ui { display: flex; }
+.app-container.focus-mode .focus-mode-ui { display: flex; }
         
         .hidden { display: none !important; }
         
@@ -731,10 +707,19 @@
                         Enable Haptic Feedback (Mobile)
                     </label>
                 </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="debug-toasts-enabled" checked style="margin: 0;">
+                        Enable Debug Toasts
+                    </label>
+                </div>
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -749,7 +734,10 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -764,7 +752,10 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Loading Screen -->
@@ -778,7 +769,10 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Main App Container -->
@@ -825,10 +819,7 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
-
-        
-        <!-- Center Stage UI -->
+<!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -848,8 +839,10 @@
             </svg>
         </button>
         
-        <div id="toast" class="toast"></div>
-        <div class="app-footer">Orbital8-O-2025-10-12 09:30 AM · v9</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -1040,7 +1033,8 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
-            pendingBackgroundProbe: null
+            pendingBackgroundProbe: null,
+            showDebugToasts: true
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -1149,6 +1143,7 @@
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
+                    debugToastToggle: document.getElementById('debug-toasts-enabled'),
                     
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
@@ -1173,11 +1168,9 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1271,45 +1264,35 @@
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
+                if (!state.showDebugToasts) {
+                    this.clearFooterToasts();
+                    return;
+                }
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                const footers = Array.from(document.querySelectorAll('.app-footer'));
-                const footerStatuses = footers.map(footer => {
+                const statusElements = [];
+                document.querySelectorAll('.app-footer').forEach(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
                     if (!statusSpan) {
                         statusSpan = document.createElement('span');
                         statusSpan.className = 'footer-status';
-                        const baselineAttr = footer.dataset.baselineText;
-                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
-                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
-                        statusSpan.dataset.baselineText = baselineText;
-                        if (textNodes.length) {
-                            footer.insertBefore(statusSpan, textNodes[0]);
-                            textNodes.forEach(node => footer.removeChild(node));
-                        } else {
-                            footer.insertBefore(statusSpan, footer.firstChild);
-                        }
-                        statusSpan.textContent = baselineText;
-                    } else if (statusSpan.dataset.baselineText === undefined) {
-                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                        statusSpan.setAttribute('aria-live', 'polite');
+                        footer.appendChild(statusSpan);
                     }
-                    const baselineText = statusSpan.dataset.baselineText ?? '';
                     statusSpan.textContent = message;
-                    statusSpan.classList.remove('success', 'error', 'info');
-                    statusSpan.classList.add(type);
-                    return { statusSpan, baselineText };
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                    statusSpan.classList.add('active', type);
+                    statusElements.push(statusSpan);
                 });
+                if (statusElements.length === 0) {
+                    return;
+                }
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    toast.classList.remove('show');
-                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
-                        statusSpan.textContent = baselineText;
-                        statusSpan.classList.remove('success', 'error', 'info');
+                    statusElements.forEach(statusSpan => {
+                        statusSpan.textContent = '';
+                        statusSpan.classList.remove('active', 'success', 'error', 'info');
                     });
                     this._toastHideTimer = null;
                 }, 3000);
@@ -1317,6 +1300,17 @@
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
+            },
+
+            clearFooterToasts() {
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                    this._toastHideTimer = null;
+                }
+                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
+                    statusSpan.textContent = '';
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                });
             },
             
             async setImageSrc(img, file) {
@@ -4847,8 +4841,7 @@
                     const folderName = state.currentFolder?.name || '';
                     const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
                     const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-                    if (Utils.elements.filenameOverlay) {
-                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+/ ${filenameWithoutExtension}`;
                         const directUrl = state.export?.getDirectImageURL?.(currentFile);
                         Utils.elements.filenameOverlay.href = directUrl || '#';
                         Utils.elements.filenameOverlay.classList.add('visible');
@@ -5062,10 +5055,7 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
-                if (Utils.elements.filenameOverlay) {
-                    Utils.elements.filenameOverlay.classList.remove('visible');
-                }
-                this.updateImageCounters();
+this.updateImageCounters();
                 const skipEmptyState = state.isReturningToFolders;
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
@@ -5166,11 +5156,7 @@
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    const overlay = document.createElement('div');
-                    overlay.className = 'grid-filename-overlay';
-                    overlay.textContent = file.name;
                     div.appendChild(img);
-                    div.appendChild(overlay);
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
@@ -6590,8 +6576,29 @@
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
                 });
-                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+                const hapticToggle = document.getElementById('haptic-enabled');
+                if (hapticToggle) {
+                    hapticToggle.addEventListener('change', (e) => {
+                        if (state.haptic) {
+                            state.haptic.setEnabled(e.target.checked);
+                        }
+                    });
+                }
+                const debugToggle = document.getElementById('debug-toasts-enabled');
+                state.showDebugToasts = debugToggle ? debugToggle.checked : true;
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                }
+                if (debugToggle) {
+                    debugToggle.addEventListener('change', (e) => {
+                        state.showDebugToasts = e.target.checked;
+                        if (!state.showDebugToasts) {
+                            Utils.clearFooterToasts();
+                        }
+                    });
+                }
             },
+
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
                 Utils.elements.authBackButton.addEventListener('click', async () => { await App.backToProviderSelection(); });

--- a/ui.html
+++ b/ui.html
@@ -127,18 +127,7 @@
         .status.success { background: rgba(16, 185, 129, 0.2); color: #10b981; border: 1px solid rgba(16, 185, 129, 0.3); }
         .status.error { background: rgba(239, 68, 68, 0.2); color: #ef4444; border: 1px solid rgba(239, 68, 68, 0.3); }
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
-        
-        .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
-            font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
-        }
-        .toast.show { opacity: 1; }
-        .toast.success { background: rgba(16, 185, 129, 0.9); }
-        .toast.info { background: rgba(59, 130, 246, 0.9); }
-        .toast.error { background: rgba(239, 68, 68, 0.9); }
-        
-        .folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
+.folder-list { flex: 1; overflow-y: auto; margin-bottom: 20px; max-height: 400px; }
         .folder-item {
             display: flex; align-items: center; padding: 12px 16px; margin-bottom: 8px;
             background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.1);
@@ -184,36 +173,7 @@
         }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
         .center-image.zoomable { pointer-events: auto; }
-
-        .filename-overlay {
-            position: absolute;
-            bottom: 25px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: rgba(0, 0, 0, 0.6);
-            color: white;
-            padding: 6px 14px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 500;
-            z-index: 5;
-            max-width: 90%;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: auto;
-            text-decoration: none;
-        }
-        .filename-overlay:hover {
-            background-color: rgba(0, 0, 0, 0.8);
-            color: var(--app-accent);
-        }
-        .filename-overlay.visible { opacity: 1; }
-
-        
-        .edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
+.edge-glow { position: absolute; opacity: 0; transition: opacity 0.2s ease; z-index: 2; pointer-events: none; }
         .edge-glow.top { top: 0; left: 0; right: 0; height: 8px; background: linear-gradient(180deg, rgba(245, 158, 11, var(--glow)) 0%, transparent 100%); }
         .edge-glow.bottom { 
             bottom: 0; left: 0; right: 0; height: 8px; 
@@ -408,27 +368,7 @@
             border-radius: 8px; overflow: hidden;
         }
         .grid-drag-ghost .grid-drag-handle { display: none; }
-
-        .grid-filename-overlay {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: rgba(0, 0, 0, 0.7);
-            color: white;
-            padding: 8px;
-            font-size: 14px;
-            text-align: center;
-            opacity: 0;
-            transition: opacity 0.3s;
-            pointer-events: none;
-        }
-
-        .grid-item:hover .grid-filename-overlay {
-            opacity: 1;
-        }
-        
-        .details-modal-content { 
+.details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
         }
@@ -493,21 +433,79 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-        
-        .app-footer {
-            position: fixed; bottom: 0; left: 0; right: 0; background: rgba(0, 0, 0, 0.8);
-            color: rgba(255, 255, 255, 0.6); text-align: center;
-            padding: 4px 8px;
-            font-size: 10px; z-index: 5; backdrop-filter: blur(10px);
+.app-footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: rgba(0, 0, 0, 0.8);
+            color: rgba(255, 255, 255, 0.6);
+            text-align: center;
+            padding: 8px 12px;
+            font-size: 10px;
+            z-index: 5;
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .app-footer .footer-baseline {
+            color: rgba(255, 255, 255, 0.6);
         }
         .app-footer .footer-status {
-            color: inherit;
+            position: absolute;
+            inset: 4px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 14px;
+            border-radius: 9999px;
+            background: rgba(0, 0, 0, 0.85);
+            color: rgba(255, 255, 255, 0.95);
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            white-space: nowrap;
+            max-width: calc(100% - 24px);
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-        .app-footer .footer-status:not(:empty) {
-            margin-right: 8px;
+        .app-footer .footer-status.active {
+            opacity: 1;
         }
-
-        /* NEW: Standardized UI Button */
+        .app-footer .footer-status.success {
+            background: rgba(16, 185, 129, 0.9);
+        }
+        .app-footer .footer-status.info {
+            background: rgba(59, 130, 246, 0.9);
+        }
+        .app-footer .footer-status.error {
+            background: rgba(239, 68, 68, 0.9);
+        }
+        .app-footer .footer-link {
+            background: transparent;
+            border: none;
+            color: rgba(255, 255, 255, 0.65);
+            cursor: pointer;
+            font: inherit;
+            margin-left: 8px;
+            padding: 0;
+            text-decoration: none;
+            transition: color 0.2s ease;
+        }
+        .app-footer .footer-link:hover,
+        .app-footer .footer-link:focus-visible {
+            color: #f59e0b;
+            text-decoration: underline;
+        }
+        .app-footer .footer-link:focus-visible {
+            outline: none;
+        }
+/* NEW: Standardized UI Button */
         .ui-button {
             background: rgba(0, 0, 0, 0.4);
             color: #e5e7eb; /* light grey */
@@ -565,9 +563,7 @@
         .app-container.focus-mode .pill-counter,
         .app-container.focus-mode #back-button,
         .app-container.focus-mode #center-trash-btn,
-        .app-container.focus-mode .filename-overlay { display: none; }
-
-        .app-container.focus-mode .focus-mode-ui { display: flex; }
+.app-container.focus-mode .focus-mode-ui { display: flex; }
         
         .hidden { display: none !important; }
         
@@ -709,10 +705,19 @@
                         Enable Haptic Feedback (Mobile)
                     </label>
                 </div>
+                <div>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="debug-toasts-enabled" checked style="margin: 0;">
+                        Enable Debug Toasts
+                    </label>
+                </div>
             </div>
             <div id="provider-status" class="status info">Choose your preferred cloud storage</div>
         </div>
-        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-M-2025-09-18 04:16 AM</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Auth Screen -->
@@ -727,7 +732,10 @@
             <button class="button" id="auth-back-button" style="background: rgba(128,128,128,0.3);">← Back</button>
             <div id="auth-status" class="status info"></div>
         </div>
-        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-M-2025-09-18 04:16 AM</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Unified Folder Screen -->
@@ -742,7 +750,10 @@
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
             </div>
         </div>
-        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-M-2025-09-18 04:16 AM</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Loading Screen -->
@@ -756,7 +767,10 @@
             </div>
             <button class="button" id="cancel-loading" style="background: rgba(239, 68, 68, 0.8); margin-top: 16px;">Cancel</button>
         </div>
-        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-M-2025-09-18 04:16 AM</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Main App Container -->
@@ -803,10 +817,7 @@
             <button class="new-images-button" id="select-another-stack-btn">Select Another Stack</button>
             <button class="new-images-button" id="select-another-folder-btn" style="margin-top: 12px;">Choose Different Folder</button>
         </div>
-        <a id="filename-overlay" class="filename-overlay" href="#" target="_blank"></a>
-
-        
-        <!-- Center Stage UI -->
+<!-- Center Stage UI -->
         <div id="normal-image-count" class="ui-button"></div>
         <button id="center-trash-btn" class="ui-button">
             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -826,8 +837,10 @@
             </svg>
         </button>
         
-        <div id="toast" class="toast"></div>
-        <div class="app-footer">Orbital8-M-2025-09-18 04:16 AM</div>
+        <div class="app-footer">
+            <span class="footer-baseline">Orbital8-M-2025-09-18 04:16 AM</span>
+            <span class="footer-status" aria-live="polite"></span>
+        </div>
     </div>
     
     <!-- Enhanced Grid Modal -->
@@ -1018,7 +1031,8 @@
             tags: new Set(), loadingProgress: { current: 0, total: 0 },
             folderMoveMode: { active: false, files: [] },
             activeRequests: new AbortController(),
-            sessionVisitedFolders: new Set()
+            sessionVisitedFolders: new Set(),
+            showDebugToasts: true
         };
         const Utils = {
             elements: {},
@@ -1059,6 +1073,7 @@
                     googleDriveBtn: document.getElementById('google-drive-btn'),
                     onedriveBtn: document.getElementById('onedrive-btn'),
                     providerStatus: document.getElementById('provider-status'),
+                    debugToastToggle: document.getElementById('debug-toasts-enabled'),
                     
                     authTitle: document.getElementById('auth-title'),
                     authSubtitle: document.getElementById('auth-subtitle'),
@@ -1083,11 +1098,9 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
-                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
-                    filenameOverlay: document.getElementById('filename-overlay'),
                     focusImageCount: document.getElementById('focus-image-count'),
                     normalImageCount: document.getElementById('normal-image-count'),
                     focusDeleteBtn: document.getElementById('focus-delete-btn'),
@@ -1176,45 +1189,35 @@
             hideModal(id) { document.getElementById(id).classList.add('hidden'); },
             
             showToast(message, type = 'success', important = false) {
+                if (!state.showDebugToasts) {
+                    this.clearFooterToasts();
+                    return;
+                }
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
-                toast.textContent = message;
-                toast.className = `toast ${type} show`;
-                const footers = Array.from(document.querySelectorAll('.app-footer'));
-                const footerStatuses = footers.map(footer => {
+                const statusElements = [];
+                document.querySelectorAll('.app-footer').forEach(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
                     if (!statusSpan) {
                         statusSpan = document.createElement('span');
                         statusSpan.className = 'footer-status';
-                        const baselineAttr = footer.dataset.baselineText;
-                        const textNodes = Array.from(footer.childNodes).filter(node => node.nodeType === Node.TEXT_NODE);
-                        const baselineFromNodes = textNodes.map(node => node.textContent).join('').replace(/\s+/g, ' ').trim();
-                        const baselineText = baselineAttr !== undefined ? baselineAttr : baselineFromNodes;
-                        statusSpan.dataset.baselineText = baselineText;
-                        if (textNodes.length) {
-                            footer.insertBefore(statusSpan, textNodes[0]);
-                            textNodes.forEach(node => footer.removeChild(node));
-                        } else {
-                            footer.insertBefore(statusSpan, footer.firstChild);
-                        }
-                        statusSpan.textContent = baselineText;
-                    } else if (statusSpan.dataset.baselineText === undefined) {
-                        statusSpan.dataset.baselineText = (statusSpan.textContent || '').trim();
+                        statusSpan.setAttribute('aria-live', 'polite');
+                        footer.appendChild(statusSpan);
                     }
-                    const baselineText = statusSpan.dataset.baselineText ?? '';
                     statusSpan.textContent = message;
-                    statusSpan.classList.remove('success', 'error', 'info');
-                    statusSpan.classList.add(type);
-                    return { statusSpan, baselineText };
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                    statusSpan.classList.add('active', type);
+                    statusElements.push(statusSpan);
                 });
+                if (statusElements.length === 0) {
+                    return;
+                }
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    toast.classList.remove('show');
-                    footerStatuses.forEach(({ statusSpan, baselineText }) => {
-                        statusSpan.textContent = baselineText;
-                        statusSpan.classList.remove('success', 'error', 'info');
+                    statusElements.forEach(statusSpan => {
+                        statusSpan.textContent = '';
+                        statusSpan.classList.remove('active', 'success', 'error', 'info');
                     });
                     this._toastHideTimer = null;
                 }, 3000);
@@ -1222,6 +1225,17 @@
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
                 }
+            },
+
+            clearFooterToasts() {
+                if (this._toastHideTimer) {
+                    clearTimeout(this._toastHideTimer);
+                    this._toastHideTimer = null;
+                }
+                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
+                    statusSpan.textContent = '';
+                    statusSpan.classList.remove('active', 'success', 'error', 'info');
+                });
             },
             
             async setImageSrc(img, file) {
@@ -2348,8 +2362,7 @@
                     const folderName = state.currentFolder?.name || '';
                     const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
                     const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-                    if (Utils.elements.filenameOverlay) {
-                        Utils.elements.filenameOverlay.textContent = `${truncatedFolder} / ${filenameWithoutExtension}`;
+/ ${filenameWithoutExtension}`;
                         const directUrl = state.export?.getDirectImageURL?.(currentFile);
                         Utils.elements.filenameOverlay.href = directUrl || '#';
                         Utils.elements.filenameOverlay.classList.add('visible');
@@ -2470,10 +2483,7 @@
                 state.currentImageLoadId = null;
                 Utils.elements.centerImage.style.opacity = '0';
                 Utils.elements.detailsButton.style.display = 'none';
-                if (Utils.elements.filenameOverlay) {
-                    Utils.elements.filenameOverlay.classList.remove('visible');
-                }
-                this.updateImageCounters();
+this.updateImageCounters();
                 setTimeout(() => {
                     Utils.elements.centerImage.src = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
                     Utils.elements.centerImage.alt = 'No images in this stack';
@@ -2570,11 +2580,7 @@
                         img.classList.add('loaded');
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
-                    const overlay = document.createElement('div');
-                    overlay.className = 'grid-filename-overlay';
-                    overlay.textContent = file.name;
                     div.appendChild(img);
-                    div.appendChild(overlay);
                     div.appendChild(this.createDragHandle(div, file.id));
                     container.appendChild(div);
                 });
@@ -4063,8 +4069,29 @@
                 document.querySelectorAll('.intensity-btn').forEach(btn => {
                     btn.addEventListener('click', () => { state.visualCues.setIntensity(btn.dataset.level); });
                 });
-                document.getElementById('haptic-enabled').addEventListener('change', (e) => { state.haptic.setEnabled(e.target.checked); });
+                const hapticToggle = document.getElementById('haptic-enabled');
+                if (hapticToggle) {
+                    hapticToggle.addEventListener('change', (e) => {
+                        if (state.haptic) {
+                            state.haptic.setEnabled(e.target.checked);
+                        }
+                    });
+                }
+                const debugToggle = document.getElementById('debug-toasts-enabled');
+                state.showDebugToasts = debugToggle ? debugToggle.checked : true;
+                if (!state.showDebugToasts) {
+                    Utils.clearFooterToasts();
+                }
+                if (debugToggle) {
+                    debugToggle.addEventListener('change', (e) => {
+                        state.showDebugToasts = e.target.checked;
+                        if (!state.showDebugToasts) {
+                            Utils.clearFooterToasts();
+                        }
+                    });
+                }
             },
+
             setupAuth() {
                 Utils.elements.authButton.addEventListener('click', () => App.authenticateCurrentUser());
                 Utils.elements.authBackButton.addEventListener('click', () => App.backToProviderSelection());


### PR DESCRIPTION
## Summary
- remove the filename/link overlays and associated styling from the viewer and grid templates across index.html and every ui variant
- convert toast notifications into footer-only overlays controlled by a debug checkbox on the provider screen, including centralized cleanup logic
- update grid rendering after overlay removal so thumbnails render without the per-item filename layer

## Testing
- not run (HTML/JS refactor)


------
https://chatgpt.com/codex/tasks/task_e_68e14e85c538832d9d1116d92e524d94