### PR TITLE
Add Playwright suite for Google Drive URL regression coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ rg "downloadUrl: viewUrl"
 ```
 
 The command should produce no matches. Any future regression where a template assigns a `downloadUrl` directly to the `viewUrl` will show up in this search so it can be corrected immediately.
+
+## Playwright test suite
+
+Run the Playwright checks that load representative UI variants and assert they construct Google Drive asset URLs using the UC view form:
+
+```bash
+npm run test:playwright
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "pako": "^2.1.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.55.1",
         "@types/node": "^22.14.0",
         "typescript": "~5.8.2",
         "vite": "^6.2.0"
@@ -458,6 +459,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.52.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
@@ -901,6 +918,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:playwright": "playwright test"
   },
   "dependencies": {
     "pako": "^2.1.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.1",
     "@types/node": "^22.14.0",
     "typescript": "~5.8.2",
     "vite": "^6.2.0"

--- a/tests/google-drive-url.spec.ts
+++ b/tests/google-drive-url.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+
+const variants = [
+  { name: 'ui-v1', file: 'ui-v1.html' },
+  { name: 'ui-v4', file: 'ui-v4.html' },
+  { name: 'ui-v8', file: 'ui-v8.html' },
+  { name: 'ui-v10', file: 'ui-v10.html' },
+] as const;
+
+test.describe('Google Drive direct image URLs', () => {
+  for (const variant of variants) {
+    test(`constructs UC view URL for ${variant.name}`, async ({ page }) => {
+      const pageUrl = new URL(`../${variant.file}`, import.meta.url).href;
+      await page.goto(pageUrl);
+
+      await page.waitForTimeout(500);
+
+      const directUrl = await page.evaluate(() => {
+        const sampleFile = { id: 'sampleFileId123' };
+        const stateRef = typeof state !== 'undefined' ? state : (window as any).state;
+        const exportSystemRef = typeof ExportSystem !== 'undefined' ? ExportSystem : (window as any).ExportSystem;
+
+        if (!stateRef || typeof exportSystemRef !== 'function') {
+          throw new Error('Application globals not initialized');
+        }
+
+        stateRef.providerType = 'googledrive';
+        if (!stateRef.export) {
+          stateRef.export = new exportSystemRef();
+        }
+
+        return stateRef.export.getDirectImageURL(sampleFile);
+      });
+
+      expect(directUrl).toContain('https://drive.google.com/uc?id=sampleFileId123');
+      expect(directUrl).toContain('export=view');
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add the @playwright/test dev dependency and expose an npm script for the suite
- create playwright coverage that loads four UI variants and asserts Google Drive assets use UC view URLs
- document the new playwright command in the README

## Testing
- npm run test:playwright

------
https://chatgpt.com/codex/tasks/task_e_68e1518e97f0832db2ec005dfc882c86