### PR TITLE
Remove filename overlay logic from templates

### DIFF
--- a/index.html
+++ b/index.html
@@ -4836,14 +4836,6 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder?.name || '';
-                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-/ ${filenameWithoutExtension}`;
-                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
-                        Utils.elements.filenameOverlay.href = directUrl || '#';
-                        Utils.elements.filenameOverlay.classList.add('visible');
-                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -4838,14 +4838,6 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder?.name || '';
-                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-/ ${filenameWithoutExtension}`;
-                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
-                        Utils.elements.filenameOverlay.href = directUrl || '#';
-                        Utils.elements.filenameOverlay.classList.add('visible');
-                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -4677,14 +4677,6 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder?.name || '';
-                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-/ ${filenameWithoutExtension}`;
-                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
-                        Utils.elements.filenameOverlay.href = directUrl || '#';
-                        Utils.elements.filenameOverlay.classList.add('visible');
-                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -4678,14 +4678,6 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder?.name || '';
-                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-/ ${filenameWithoutExtension}`;
-                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
-                        Utils.elements.filenameOverlay.href = directUrl || '#';
-                        Utils.elements.filenameOverlay.classList.add('visible');
-                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };

--- a/ui-v2-old.html
+++ b/ui-v2-old.html
@@ -2823,14 +2823,6 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder?.name || '';
-                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-/ ${filenameWithoutExtension}`;
-                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
-                        Utils.elements.filenameOverlay.href = directUrl || '#';
-                        Utils.elements.filenameOverlay.classList.add('visible');
-                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -4838,14 +4838,6 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder?.name || '';
-                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-/ ${filenameWithoutExtension}`;
-                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
-                        Utils.elements.filenameOverlay.href = directUrl || '#';
-                        Utils.elements.filenameOverlay.classList.add('visible');
-                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -4838,14 +4838,6 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder?.name || '';
-                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-/ ${filenameWithoutExtension}`;
-                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
-                        Utils.elements.filenameOverlay.href = directUrl || '#';
-                        Utils.elements.filenameOverlay.classList.add('visible');
-                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -4838,14 +4838,6 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder?.name || '';
-                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-/ ${filenameWithoutExtension}`;
-                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
-                        Utils.elements.filenameOverlay.href = directUrl || '#';
-                        Utils.elements.filenameOverlay.classList.add('visible');
-                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -4838,14 +4838,6 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder?.name || '';
-                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-/ ${filenameWithoutExtension}`;
-                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
-                        Utils.elements.filenameOverlay.href = directUrl || '#';
-                        Utils.elements.filenameOverlay.classList.add('visible');
-                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -4838,14 +4838,6 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder?.name || '';
-                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-/ ${filenameWithoutExtension}`;
-                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
-                        Utils.elements.filenameOverlay.href = directUrl || '#';
-                        Utils.elements.filenameOverlay.classList.add('visible');
-                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -4838,14 +4838,6 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder?.name || '';
-                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-/ ${filenameWithoutExtension}`;
-                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
-                        Utils.elements.filenameOverlay.href = directUrl || '#';
-                        Utils.elements.filenameOverlay.classList.add('visible');
-                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -4838,14 +4838,6 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder?.name || '';
-                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-/ ${filenameWithoutExtension}`;
-                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
-                        Utils.elements.filenameOverlay.href = directUrl || '#';
-                        Utils.elements.filenameOverlay.classList.add('visible');
-                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -4838,14 +4838,6 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder?.name || '';
-                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-/ ${filenameWithoutExtension}`;
-                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
-                        Utils.elements.filenameOverlay.href = directUrl || '#';
-                        Utils.elements.filenameOverlay.classList.add('visible');
-                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -4838,14 +4838,6 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder?.name || '';
-                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-/ ${filenameWithoutExtension}`;
-                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
-                        Utils.elements.filenameOverlay.href = directUrl || '#';
-                        Utils.elements.filenameOverlay.classList.add('visible');
-                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -4838,14 +4838,6 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder?.name || '';
-                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-/ ${filenameWithoutExtension}`;
-                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
-                        Utils.elements.filenameOverlay.href = directUrl || '#';
-                        Utils.elements.filenameOverlay.classList.add('visible');
-                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -4838,14 +4838,6 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder?.name || '';
-                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-/ ${filenameWithoutExtension}`;
-                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
-                        Utils.elements.filenameOverlay.href = directUrl || '#';
-                        Utils.elements.filenameOverlay.classList.add('visible');
-                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };

--- a/ui.html
+++ b/ui.html
@@ -2359,14 +2359,6 @@
                     Utils.elements.detailsButton.style.display = 'flex';
                     await Utils.setImageSrc(Utils.elements.centerImage, currentFile);
                     
-                    const folderName = state.currentFolder?.name || '';
-                    const truncatedFolder = folderName.length > 12 ? folderName.substring(0, 12) + '...' : folderName;
-                    const filenameWithoutExtension = (currentFile.name || '').replace(/\.[^/.]+$/, '');
-/ ${filenameWithoutExtension}`;
-                        const directUrl = state.export?.getDirectImageURL?.(currentFile);
-                        Utils.elements.filenameOverlay.href = directUrl || '#';
-                        Utils.elements.filenameOverlay.classList.add('visible');
-                    }
 
                     state.currentScale = 1;
                     state.panOffset = { x: 0, y: 0 };


### PR DESCRIPTION
## Summary
- remove the obsolete filename overlay handling from index.html and every UI template variant now that the overlay element is gone
- clean up the dangling template string fragment left from the overlay text assignment

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e15f033dd4832dbb59bad07ccafa9e