### PR TITLE
Fix Google Drive download URLs across UI variants

### DIFF
--- a/index.html
+++ b/index.html
@@ -3535,7 +3535,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3659,7 +3659,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -3461,7 +3461,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3567,7 +3567,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -3462,7 +3462,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3568,7 +3568,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: this.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };


### PR DESCRIPTION
## Summary
- replace Google Drive provider calls to an undefined instance helper with the shared DriveUtils method across index.html and the ui-*.html variants

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e166391acc832da07459123e86be96