### PR TITLE
Use DriveLinkHelper for Drive download URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -3535,7 +3535,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3659,7 +3659,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -3461,7 +3461,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3567,7 +3567,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -3462,7 +3462,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3568,7 +3568,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -3537,7 +3537,7 @@
                                 createdTime: file.createdTime,
                                 modifiedTime: file.modifiedTime,
                                 thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                                 viewUrl,
                                 driveApiDownloadUrl: apiDownloadUrl,
                                 appProperties: file.appProperties || {},
@@ -3661,7 +3661,7 @@
                         const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
                         return {
                             ...file,
-                            downloadUrl: DriveUtils.buildUcDownloadUrl(file.id) || apiDownloadUrl,
+                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
                             viewUrl,
                             driveApiDownloadUrl: apiDownloadUrl
                         };


### PR DESCRIPTION
## Summary
- replace DriveUtils.buildUcDownloadUrl references with DriveLinkHelper.buildUcDownloadUrl in the Google Drive provider
- update index and all UI variants so Drive download links use the shared helper

## Testing
- browser_container.run_playwright_script (load index.html)


------
https://chatgpt.com/codex/tasks/task_e_68e16be4a1a4832da4316ed96e1971fb