### PR TITLE
Restore focus mode item counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -557,7 +557,6 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode #back-button,

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -559,7 +559,6 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode #back-button,

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -559,7 +559,6 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode #back-button,

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -559,7 +559,6 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode #back-button,

--- a/ui-v2-old.html
+++ b/ui-v2-old.html
@@ -565,7 +565,6 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode #back-button,

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -559,7 +559,6 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode #back-button,

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -559,7 +559,6 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode #back-button,

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -559,7 +559,6 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode #back-button,

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -559,7 +559,6 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode #back-button,

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -559,7 +559,6 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode #back-button,

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -559,7 +559,6 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode #back-button,

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -559,7 +559,6 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode #back-button,

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -559,7 +559,6 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode #back-button,

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -559,7 +559,6 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode #back-button,

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -559,7 +559,6 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode #back-button,

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -559,7 +559,6 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode #back-button,

--- a/ui.html
+++ b/ui.html
@@ -557,7 +557,6 @@
             color: #ef4444; /* Solid red */
         }
 
-        #focus-image-count { display: none !important; }
 
         /* Focus Mode state toggling */
         .app-container.focus-mode #back-button,


### PR DESCRIPTION
## Summary
- remove the CSS override that hid the focus-mode item counter so it is visible again in index and UI variants

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1accf5c28832d9bde8c7d447905cf