### PR TITLE
Fix Google Drive shortcut image loading

### DIFF
--- a/ui-v7.html
+++ b/ui-v7.html
@@ -1344,10 +1344,11 @@
             },
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1358,13 +1359,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s800');
                     }
                     if (file.thumbnail && file.thumbnail.url) {
                         return file.thumbnail.url.replace('=s220', '=s800');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -3423,6 +3425,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -3510,8 +3558,9 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
                     id: folder.id,
                     name: folder.name,
                     type: 'folder',
@@ -3522,37 +3571,54 @@
                 }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files
-                        .filter(file => file.mimeType && file.mimeType.startsWith('image/'))
-                        .map(file => {
-                            const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                            const apiDownloadUrl = file.webContentLink || null;
-                            return {
-                                id: file.id,
-                                name: file.name,
-                                type: 'file',
-                                mimeType: file.mimeType,
-                                size: file.size ? parseInt(file.size) : 0,
-                                createdTime: file.createdTime,
-                                modifiedTime: file.modifiedTime,
-                                thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                                viewUrl,
-                                driveApiDownloadUrl: apiDownloadUrl,
-                                appProperties: file.appProperties || {},
-                                parents: file.parents
-                            };
-                        });
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
             }
             async loadFolderManifest(folderId, options = {}) {
@@ -3656,21 +3722,43 @@
             }
             async fetchFilesByIds(folderId, fileIds = [], options = {}) {
                 if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
-                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal: options.signal }));
-                const files = await Promise.allSettled(requests);
-                return files
-                    .filter(result => result.status === 'fulfilled')
-                    .map(result => {
-                        const file = result.value;
-                        const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                        const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
-                        return {
-                            ...file,
-                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                            viewUrl,
-                            driveApiDownloadUrl: apiDownloadUrl
-                        };
-                    });
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
             }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.


### PR DESCRIPTION
## Summary
- normalize Google Drive file metadata so shortcut entries resolve to their target image IDs
- refresh Google Drive folder listings and sync routines to include shared drives and shortcut-backed images
- ensure Google Drive thumbnails and fallbacks use the resolved target file identifier

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1b9516e9c832d9a38327b68971296