### PR TITLE
Align Drive shortcut handling across legacy HTML builds

### DIFF
--- a/index+holdj.html
+++ b/index+holdj.html
@@ -898,6 +898,74 @@
             folderMoveMode: { active: false, files: [] },
             activeRequests: new AbortController()
         };
+        const DriveLinkHelper = {
+            extractFileId(input) {
+                if (!input) return null;
+                if (typeof input === 'string' && !input.includes('://') && /^[a-zA-Z0-9_-]{10,}$/.test(input)) {
+                    return input;
+                }
+                try {
+                    const url = new URL(input);
+                    const idParam = url.searchParams.get('id') || url.searchParams.get('file_id');
+                    if (idParam) return idParam;
+                    const pathMatch = url.pathname.match(/\/file\/d\/([^/]+)/);
+                    if (pathMatch && pathMatch[1]) return pathMatch[1];
+                    const ucMatch = url.pathname.match(/\/uc(?:\/export)?\/download\/([^/?]+)/);
+                    if (ucMatch && ucMatch[1]) return ucMatch[1];
+                } catch (error) {
+                    return null;
+                }
+                return null;
+            },
+            buildUcDownloadUrl(fileId) {
+                if (!fileId) return null;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
+            },
+            buildApiDownloadUrl(fileId) {
+                if (!fileId) return null;
+                return `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`;
+            },
+            normalizeToAssetUrl(rawUrl, fallbackId = null) {
+                if (!rawUrl || typeof rawUrl !== 'string') return null;
+                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const fileId = fallbackId || this.extractFileId(rawUrl);
+                try {
+                    const parsed = new URL(rawUrl);
+                    const host = parsed.hostname;
+                    if (directHosts.test(host)) {
+                        return rawUrl;
+                    }
+                    if (host === 'drive.google.com') {
+                        if (parsed.pathname.startsWith('/uc')) {
+                            parsed.searchParams.set('export', 'view');
+                            if (!parsed.searchParams.get('id') && fileId) {
+                                parsed.searchParams.set('id', fileId);
+                            }
+                            return parsed.toString();
+                        }
+                        if (fileId) {
+                            return this.buildUcDownloadUrl(fileId);
+                        }
+                    }
+                    if (host === 'www.googleapis.com') {
+                        parsed.searchParams.set('alt', 'media');
+                        return parsed.toString();
+                    }
+                    if (fileId) {
+                        return this.buildUcDownloadUrl(fileId);
+                    }
+                } catch (error) {
+                    if (fileId) {
+                        return this.buildUcDownloadUrl(fileId) || this.buildApiDownloadUrl(fileId);
+                    }
+                    return null;
+                }
+                if (fileId) {
+                    return this.buildUcDownloadUrl(fileId) || this.buildApiDownloadUrl(fileId);
+                }
+                return null;
+            }
+        };
         const Utils = {
             elements: {},
 
@@ -1122,10 +1190,11 @@
             
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1135,8 +1204,15 @@
             },
 
             getFallbackImageUrl(file) {
-                 if (state.providerType === 'googledrive') {
-                    return file.downloadUrl || `https://www.googleapis.com/drive/v3/files/${file.id}?alt=media`;
+                if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
+                    if (file.thumbnailLink) {
+                        return file.thumbnailLink.replace('=s220', '=s800');
+                    }
+                    if (file.thumbnail && file.thumbnail.url) {
+                        return file.thumbnail.url.replace('=s220', '=s800');
+                    }
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -1366,6 +1442,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -1430,7 +1552,14 @@
             }
             async makeApiCall(endpoint, options = {}, isJson = true) {
                 if (!this.accessToken) { throw new Error('Not authenticated'); }
-                const url = endpoint.startsWith('https://') ? endpoint : `${this.apiBase}${endpoint}`;
+                let url;
+                if (endpoint.startsWith('https://')) {
+                    url = endpoint;
+                } else if (endpoint.startsWith('/upload/drive/')) {
+                    url = `https://www.googleapis.com${endpoint}`;
+                } else {
+                    url = `${this.apiBase}${endpoint}`;
+                }
                 const headers = { 'Authorization': `Bearer ${this.accessToken}`, ...options.headers };
                 if(isJson) { headers['Content-Type'] = 'application/json'; }
                 let response = await fetch(url, { ...options, headers });
@@ -1446,22 +1575,215 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({ id: folder.id, name: folder.name, type: 'folder', createdTime: folder.createdTime, modifiedTime: folder.modifiedTime }));
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
+                    id: folder.id,
+                    name: folder.name,
+                    type: 'folder',
+                    createdTime: folder.createdTime,
+                    modifiedTime: folder.modifiedTime,
+                    itemCount: 0, // Google Drive API doesn't provide this in the list call
+                    hasChildren: false // Assume false to not show a non-functional 'Browse' button
+                }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files.filter(file => file.mimeType && file.mimeType.startsWith('image/')).map(file => ({ id: file.id, name: file.name, type: 'file', mimeType: file.mimeType, size: file.size ? parseInt(file.size) : 0, createdTime: file.createdTime, modifiedTime: file.modifiedTime, thumbnailLink: file.thumbnailLink, downloadUrl: file.webContentLink, appProperties: file.appProperties || {}, parents: file.parents }));
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
+            }
+            async loadFolderManifest(folderId, options = {}) {
+                try {
+                    const query = `'${folderId}' in parents and name = '.orbital8-state.json' and trashed=false`;
+                    const url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,modifiedTime,appProperties,parents)&supportsAllDrives=true&includeItemsFromAllDrives=true&pageSize=1`;
+                    const response = await this.makeApiCall(url, { signal: options.signal });
+                    const manifestFile = response.files && response.files[0];
+                    if (!manifestFile) {
+                        return null;
+                    }
+                    const fileId = manifestFile.id;
+                    let manifestData = {};
+                    try {
+                        const mediaResponse = await this.makeApiCall(`/files/${fileId}?alt=media`, { method: 'GET', signal: options.signal }, false);
+                        const text = await mediaResponse.text();
+                        manifestData = text ? JSON.parse(text) : {};
+                    } catch (error) {
+                        if (/403|404/.test(error.message || '')) {
+                            state.syncLog?.log({ event: 'manifest:fetch:forbidden', level: 'error', details: `Drive denied manifest content for ${folderId}: ${error.message}` });
+                            return { entries: {}, requiresFullResync: true, cloudVersion: Date.now(), manifestFileId: fileId };
+                        }
+                        throw error;
+                    }
+                    const cloudVersion = Number(manifestData.cloudVersion || manifestFile.appProperties?.orbital8CloudVersion || Date.now());
+                    return {
+                        entries: manifestData.entries || {},
+                        requiresFullResync: Boolean(manifestData.requiresFullResync),
+                        cloudVersion,
+                        manifestFileId: fileId
+                    };
+                } catch (error) {
+                    if (/403|404/.test(error.message || '')) {
+                        state.syncLog?.log({ event: 'manifest:fetch:fallback', level: 'warn', details: `Manifest lookup failed for ${folderId}: ${error.message}` });
+                        return { entries: {}, requiresFullResync: true, cloudVersion: Date.now() };
+                    }
+                    throw error;
+                }
+            }
+            async saveFolderManifest(folderId, manifest, options = {}) {
+                const cloudVersion = manifest.cloudVersion ?? Date.now();
+                const payload = {
+                    folderId,
+                    provider: 'googledrive',
+                    cloudVersion,
+                    requiresFullResync: Boolean(manifest.requiresFullResync),
+                    entries: manifest.entries || {},
+                    updatedAt: new Date().toISOString()
+                };
+                const metadata = {
+                    name: '.orbital8-state.json',
+                    parents: [folderId],
+                    mimeType: 'application/json',
+                    appProperties: { orbital8CloudVersion: String(cloudVersion) }
+                };
+                const headers = { 'Content-Type': 'application/json' };
+                let fileId = manifest.manifestFileId || options.manifestFileId || null;
+                let discoveredManifests = null;
+                if (!fileId) {
+                    try {
+                        const query = `'${folderId}' in parents and name = '.orbital8-state.json' and trashed=false`;
+                        const lookupUrl = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true&pageSize=10`;
+                        const lookupResponse = await this.makeApiCall(lookupUrl, { signal: options.signal });
+                        const files = Array.isArray(lookupResponse?.files) ? lookupResponse.files : [];
+                        if (files.length > 0) {
+                            fileId = files[0].id;
+                            discoveredManifests = files;
+                        }
+                    } catch (error) {
+                        state.syncLog?.log({ event: 'manifest:lookup:fallback', level: 'warn', details: `Failed to locate existing manifest for ${folderId}: ${error.message}` });
+                    }
+                }
+                if (!fileId) {
+                    const createResponse = await this.makeApiCall('/files?supportsAllDrives=true&includeItemsFromAllDrives=true', { method: 'POST', body: JSON.stringify(metadata) });
+                    fileId = createResponse.id;
+                }
+                await this.makeApiCall(`/files/${fileId}?supportsAllDrives=true&includeItemsFromAllDrives=true`, { method: 'PATCH', body: JSON.stringify({ appProperties: metadata.appProperties }) });
+                if (Array.isArray(discoveredManifests) && discoveredManifests.length > 1) {
+                    const duplicateIds = discoveredManifests.slice(1).map(file => file.id);
+                    state.syncLog?.log({ event: 'manifest:duplicates', level: 'warn', details: `Detected ${duplicateIds.length} duplicate manifest files for ${folderId}.`, data: { duplicates: duplicateIds } });
+                }
+                const uploadUrl = `/upload/drive/v3/files/${fileId}?uploadType=media&supportsAllDrives=true&includeItemsFromAllDrives=true`;
+                await this.makeApiCall(uploadUrl, { method: 'PATCH', body: JSON.stringify(payload), headers, signal: options.signal }, false);
+                state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted Drive manifest for ${folderId}`, data: { provider: 'googledrive', entries: Object.keys(payload.entries || {}).length, cloudVersion } });
+                return { cloudVersion, manifestFileId: fileId };
+            }
+            async updateFolderVersionMarker(folderId, version, options = {}) {
+                let fileId = options.manifestFileId;
+                if (!fileId) {
+                    const manifest = await this.loadFolderManifest(folderId, { signal: options.signal });
+                    fileId = manifest?.manifestFileId;
+                }
+                if (!fileId) {
+                    await this.saveFolderManifest(folderId, { entries: {}, cloudVersion: version, requiresFullResync: false });
+                    return;
+                }
+                await this.makeApiCall(`/files/${fileId}?supportsAllDrives=true&includeItemsFromAllDrives=true`, {
+                    method: 'PATCH',
+                    body: JSON.stringify({ appProperties: { orbital8CloudVersion: String(version) } })
+                });
+            }
+            async fetchFilesByIds(folderId, fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
+            }
+            async drillIntoFolder(folder) {
+                // Not applicable for Google Drive's flat folder structure, but fulfills the interface.
+                return Promise.resolve([]);
+            }
+            async navigateToParent() {
+                // Not applicable for Google Drive's flat folder structure, returns the root list.
+                return this.getFolders();
             }
             async moveFileToFolder(fileId, targetFolderId) {
                 const file = await this.makeApiCall(`/files/${fileId}?fields=parents`);
@@ -1469,10 +1791,18 @@
                 await this.makeApiCall(`/files/${fileId}?addParents=${targetFolderId}&removeParents=${previousParents}&fields=id,parents`, { method: 'PATCH' });
                 return true;
             }
-            async updateFileProperties(fileId, properties) {
-                await this.makeApiCall(`/files/${fileId}`, { method: 'PATCH', body: JSON.stringify({ appProperties: properties }) });
+            async updateFileMetadata(fileId, metadata) {
+                await this.makeApiCall(`/files/${fileId}`, { method: 'PATCH', body: JSON.stringify({ appProperties: metadata }) });
                 return true;
             }
+            async updateUserMetadata(fileId, updates) {
+                const file = state.imageFiles.find(f => f.id === fileId);
+                if (!file) return;
+                Object.assign(file, updates);
+                await state.dbManager.saveMetadata(file.id, file, { folderId: state.currentFolder.id, providerType: state.providerType });
+                await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
+            }
+
             async deleteFile(fileId) {
                 await this.makeApiCall(`/files/${fileId}`, { method: 'PATCH', body: JSON.stringify({ trashed: true }) });
                 return true;

--- a/index.html
+++ b/index.html
@@ -1068,7 +1068,7 @@
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);
@@ -1342,10 +1342,11 @@
             },
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1356,13 +1357,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s800');
                     }
                     if (file.thumbnail && file.thumbnail.url) {
                         return file.thumbnail.url.replace('=s220', '=s800');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -3421,6 +3423,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -3508,8 +3556,9 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
                     id: folder.id,
                     name: folder.name,
                     type: 'folder',
@@ -3520,37 +3569,54 @@
                 }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files
-                        .filter(file => file.mimeType && file.mimeType.startsWith('image/'))
-                        .map(file => {
-                            const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                            const apiDownloadUrl = file.webContentLink || null;
-                            return {
-                                id: file.id,
-                                name: file.name,
-                                type: 'file',
-                                mimeType: file.mimeType,
-                                size: file.size ? parseInt(file.size) : 0,
-                                createdTime: file.createdTime,
-                                modifiedTime: file.modifiedTime,
-                                thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                                viewUrl,
-                                driveApiDownloadUrl: apiDownloadUrl,
-                                appProperties: file.appProperties || {},
-                                parents: file.parents
-                            };
-                        });
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
             }
             async loadFolderManifest(folderId, options = {}) {
@@ -3654,21 +3720,43 @@
             }
             async fetchFilesByIds(folderId, fileIds = [], options = {}) {
                 if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
-                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal: options.signal }));
-                const files = await Promise.allSettled(requests);
-                return files
-                    .filter(result => result.status === 'fulfilled')
-                    .map(result => {
-                        const file = result.value;
-                        const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                        const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
-                        return {
-                            ...file,
-                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                            viewUrl,
-                            driveApiDownloadUrl: apiDownloadUrl
-                        };
-                    });
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
             }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -1070,7 +1070,7 @@
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);
@@ -1344,10 +1344,11 @@
             },
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1358,13 +1359,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s800');
                     }
                     if (file.thumbnail && file.thumbnail.url) {
                         return file.thumbnail.url.replace('=s220', '=s800');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -3423,6 +3425,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -3510,8 +3558,9 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
                     id: folder.id,
                     name: folder.name,
                     type: 'folder',
@@ -3522,37 +3571,54 @@
                 }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files
-                        .filter(file => file.mimeType && file.mimeType.startsWith('image/'))
-                        .map(file => {
-                            const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                            const apiDownloadUrl = file.webContentLink || null;
-                            return {
-                                id: file.id,
-                                name: file.name,
-                                type: 'file',
-                                mimeType: file.mimeType,
-                                size: file.size ? parseInt(file.size) : 0,
-                                createdTime: file.createdTime,
-                                modifiedTime: file.modifiedTime,
-                                thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                                viewUrl,
-                                driveApiDownloadUrl: apiDownloadUrl,
-                                appProperties: file.appProperties || {},
-                                parents: file.parents
-                            };
-                        });
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
             }
             async loadFolderManifest(folderId, options = {}) {
@@ -3656,21 +3722,43 @@
             }
             async fetchFilesByIds(folderId, fileIds = [], options = {}) {
                 if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
-                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal: options.signal }));
-                const files = await Promise.allSettled(requests);
-                return files
-                    .filter(result => result.status === 'fulfilled')
-                    .map(result => {
-                        const file = result.value;
-                        const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                        const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
-                        return {
-                            ...file,
-                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                            viewUrl,
-                            driveApiDownloadUrl: apiDownloadUrl
-                        };
-                    });
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
             }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -1040,6 +1040,74 @@
             pendingBackgroundProbe: null,
             showDebugToasts: true
         };
+        const DriveLinkHelper = {
+            extractFileId(input) {
+                if (!input) return null;
+                if (typeof input === 'string' && !input.includes('://') && /^[a-zA-Z0-9_-]{10,}$/.test(input)) {
+                    return input;
+                }
+                try {
+                    const url = new URL(input);
+                    const idParam = url.searchParams.get('id') || url.searchParams.get('file_id');
+                    if (idParam) return idParam;
+                    const pathMatch = url.pathname.match(/\/file\/d\/([^/]+)/);
+                    if (pathMatch && pathMatch[1]) return pathMatch[1];
+                    const ucMatch = url.pathname.match(/\/uc(?:\/export)?\/download\/([^/?]+)/);
+                    if (ucMatch && ucMatch[1]) return ucMatch[1];
+                } catch (error) {
+                    return null;
+                }
+                return null;
+            },
+            buildUcDownloadUrl(fileId) {
+                if (!fileId) return null;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
+            },
+            buildApiDownloadUrl(fileId) {
+                if (!fileId) return null;
+                return `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`;
+            },
+            normalizeToAssetUrl(rawUrl, fallbackId = null) {
+                if (!rawUrl || typeof rawUrl !== 'string') return null;
+                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const fileId = fallbackId || this.extractFileId(rawUrl);
+                try {
+                    const parsed = new URL(rawUrl);
+                    const host = parsed.hostname;
+                    if (directHosts.test(host)) {
+                        return rawUrl;
+                    }
+                    if (host === 'drive.google.com') {
+                        if (parsed.pathname.startsWith('/uc')) {
+                            parsed.searchParams.set('export', 'view');
+                            if (!parsed.searchParams.get('id') && fileId) {
+                                parsed.searchParams.set('id', fileId);
+                            }
+                            return parsed.toString();
+                        }
+                        if (fileId) {
+                            return this.buildUcDownloadUrl(fileId);
+                        }
+                    }
+                    if (host === 'www.googleapis.com') {
+                        parsed.searchParams.set('alt', 'media');
+                        return parsed.toString();
+                    }
+                    if (fileId) {
+                        return this.buildUcDownloadUrl(fileId);
+                    }
+                } catch (error) {
+                    if (fileId) {
+                        return this.buildUcDownloadUrl(fileId) || this.buildApiDownloadUrl(fileId);
+                    }
+                    return null;
+                }
+                if (fileId) {
+                    return this.buildUcDownloadUrl(fileId) || this.buildApiDownloadUrl(fileId);
+                }
+                return null;
+            }
+        };
         const Utils = {
             elements: {},
 
@@ -1275,10 +1343,11 @@
             
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1289,13 +1358,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s800');
                     }
                     if (file.thumbnail && file.thumbnail.url) {
                         return file.thumbnail.url.replace('=s220', '=s800');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -3347,6 +3417,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -3434,8 +3550,9 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
                     id: folder.id,
                     name: folder.name,
                     type: 'folder',
@@ -3446,37 +3563,54 @@
                 }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files
-                        .filter(file => file.mimeType && file.mimeType.startsWith('image/'))
-                        .map(file => {
-                            const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                            const apiDownloadUrl = file.webContentLink || null;
-                            return {
-                                id: file.id,
-                                name: file.name,
-                                type: 'file',
-                                mimeType: file.mimeType,
-                                size: file.size ? parseInt(file.size) : 0,
-                                createdTime: file.createdTime,
-                                modifiedTime: file.modifiedTime,
-                                thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                                viewUrl,
-                                driveApiDownloadUrl: apiDownloadUrl,
-                                appProperties: file.appProperties || {},
-                                parents: file.parents
-                            };
-                        });
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
             }
             async loadFolderManifest(folderId, options = {}) {
@@ -3534,11 +3668,29 @@
                 };
                 const headers = { 'Content-Type': 'application/json' };
                 let fileId = manifest.manifestFileId || options.manifestFileId || null;
+                let discoveredManifests = null;
+                if (!fileId) {
+                    try {
+                        const query = `'${folderId}' in parents and name = '.orbital8-state.json' and trashed=false`;
+                        const lookupUrl = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true&pageSize=10`;
+                        const lookupResponse = await this.makeApiCall(lookupUrl, { signal: options.signal });
+                        const files = Array.isArray(lookupResponse?.files) ? lookupResponse.files : [];
+                        if (files.length > 0) {
+                            fileId = files[0].id;
+                            discoveredManifests = files;
+                        }
+                    } catch (error) {
+                        state.syncLog?.log({ event: 'manifest:lookup:fallback', level: 'warn', details: `Failed to locate existing manifest for ${folderId}: ${error.message}` });
+                    }
+                }
                 if (!fileId) {
                     const createResponse = await this.makeApiCall('/files?supportsAllDrives=true&includeItemsFromAllDrives=true', { method: 'POST', body: JSON.stringify(metadata) });
                     fileId = createResponse.id;
-                } else {
-                    await this.makeApiCall(`/files/${fileId}?supportsAllDrives=true&includeItemsFromAllDrives=true`, { method: 'PATCH', body: JSON.stringify({ appProperties: metadata.appProperties }) });
+                }
+                await this.makeApiCall(`/files/${fileId}?supportsAllDrives=true&includeItemsFromAllDrives=true`, { method: 'PATCH', body: JSON.stringify({ appProperties: metadata.appProperties }) });
+                if (Array.isArray(discoveredManifests) && discoveredManifests.length > 1) {
+                    const duplicateIds = discoveredManifests.slice(1).map(file => file.id);
+                    state.syncLog?.log({ event: 'manifest:duplicates', level: 'warn', details: `Detected ${duplicateIds.length} duplicate manifest files for ${folderId}.`, data: { duplicates: duplicateIds } });
                 }
                 const uploadUrl = `/upload/drive/v3/files/${fileId}?uploadType=media&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                 await this.makeApiCall(uploadUrl, { method: 'PATCH', body: JSON.stringify(payload), headers, signal: options.signal }, false);
@@ -3562,21 +3714,43 @@
             }
             async fetchFilesByIds(folderId, fileIds = [], options = {}) {
                 if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
-                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal: options.signal }));
-                const files = await Promise.allSettled(requests);
-                return files
-                    .filter(result => result.status === 'fulfilled')
-                    .map(result => {
-                        const file = result.value;
-                        const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                        const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
-                        return {
-                            ...file,
-                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                            viewUrl,
-                            driveApiDownloadUrl: apiDownloadUrl
-                        };
-                    });
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
             }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -1040,6 +1040,74 @@
             pendingBackgroundProbe: null,
             showDebugToasts: true
         };
+        const DriveLinkHelper = {
+            extractFileId(input) {
+                if (!input) return null;
+                if (typeof input === 'string' && !input.includes('://') && /^[a-zA-Z0-9_-]{10,}$/.test(input)) {
+                    return input;
+                }
+                try {
+                    const url = new URL(input);
+                    const idParam = url.searchParams.get('id') || url.searchParams.get('file_id');
+                    if (idParam) return idParam;
+                    const pathMatch = url.pathname.match(/\/file\/d\/([^/]+)/);
+                    if (pathMatch && pathMatch[1]) return pathMatch[1];
+                    const ucMatch = url.pathname.match(/\/uc(?:\/export)?\/download\/([^/?]+)/);
+                    if (ucMatch && ucMatch[1]) return ucMatch[1];
+                } catch (error) {
+                    return null;
+                }
+                return null;
+            },
+            buildUcDownloadUrl(fileId) {
+                if (!fileId) return null;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
+            },
+            buildApiDownloadUrl(fileId) {
+                if (!fileId) return null;
+                return `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`;
+            },
+            normalizeToAssetUrl(rawUrl, fallbackId = null) {
+                if (!rawUrl || typeof rawUrl !== 'string') return null;
+                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const fileId = fallbackId || this.extractFileId(rawUrl);
+                try {
+                    const parsed = new URL(rawUrl);
+                    const host = parsed.hostname;
+                    if (directHosts.test(host)) {
+                        return rawUrl;
+                    }
+                    if (host === 'drive.google.com') {
+                        if (parsed.pathname.startsWith('/uc')) {
+                            parsed.searchParams.set('export', 'view');
+                            if (!parsed.searchParams.get('id') && fileId) {
+                                parsed.searchParams.set('id', fileId);
+                            }
+                            return parsed.toString();
+                        }
+                        if (fileId) {
+                            return this.buildUcDownloadUrl(fileId);
+                        }
+                    }
+                    if (host === 'www.googleapis.com') {
+                        parsed.searchParams.set('alt', 'media');
+                        return parsed.toString();
+                    }
+                    if (fileId) {
+                        return this.buildUcDownloadUrl(fileId);
+                    }
+                } catch (error) {
+                    if (fileId) {
+                        return this.buildUcDownloadUrl(fileId) || this.buildApiDownloadUrl(fileId);
+                    }
+                    return null;
+                }
+                if (fileId) {
+                    return this.buildUcDownloadUrl(fileId) || this.buildApiDownloadUrl(fileId);
+                }
+                return null;
+            }
+        };
         const Utils = {
             elements: {},
 
@@ -1276,10 +1344,11 @@
             
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1290,13 +1359,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s800');
                     }
                     if (file.thumbnail && file.thumbnail.url) {
                         return file.thumbnail.url.replace('=s220', '=s800');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -3348,6 +3418,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -3435,8 +3551,9 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
                     id: folder.id,
                     name: folder.name,
                     type: 'folder',
@@ -3447,37 +3564,54 @@
                 }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files
-                        .filter(file => file.mimeType && file.mimeType.startsWith('image/'))
-                        .map(file => {
-                            const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                            const apiDownloadUrl = file.webContentLink || null;
-                            return {
-                                id: file.id,
-                                name: file.name,
-                                type: 'file',
-                                mimeType: file.mimeType,
-                                size: file.size ? parseInt(file.size) : 0,
-                                createdTime: file.createdTime,
-                                modifiedTime: file.modifiedTime,
-                                thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                                viewUrl,
-                                driveApiDownloadUrl: apiDownloadUrl,
-                                appProperties: file.appProperties || {},
-                                parents: file.parents
-                            };
-                        });
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
             }
             async loadFolderManifest(folderId, options = {}) {
@@ -3535,11 +3669,29 @@
                 };
                 const headers = { 'Content-Type': 'application/json' };
                 let fileId = manifest.manifestFileId || options.manifestFileId || null;
+                let discoveredManifests = null;
+                if (!fileId) {
+                    try {
+                        const query = `'${folderId}' in parents and name = '.orbital8-state.json' and trashed=false`;
+                        const lookupUrl = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true&pageSize=10`;
+                        const lookupResponse = await this.makeApiCall(lookupUrl, { signal: options.signal });
+                        const files = Array.isArray(lookupResponse?.files) ? lookupResponse.files : [];
+                        if (files.length > 0) {
+                            fileId = files[0].id;
+                            discoveredManifests = files;
+                        }
+                    } catch (error) {
+                        state.syncLog?.log({ event: 'manifest:lookup:fallback', level: 'warn', details: `Failed to locate existing manifest for ${folderId}: ${error.message}` });
+                    }
+                }
                 if (!fileId) {
                     const createResponse = await this.makeApiCall('/files?supportsAllDrives=true&includeItemsFromAllDrives=true', { method: 'POST', body: JSON.stringify(metadata) });
                     fileId = createResponse.id;
-                } else {
-                    await this.makeApiCall(`/files/${fileId}?supportsAllDrives=true&includeItemsFromAllDrives=true`, { method: 'PATCH', body: JSON.stringify({ appProperties: metadata.appProperties }) });
+                }
+                await this.makeApiCall(`/files/${fileId}?supportsAllDrives=true&includeItemsFromAllDrives=true`, { method: 'PATCH', body: JSON.stringify({ appProperties: metadata.appProperties }) });
+                if (Array.isArray(discoveredManifests) && discoveredManifests.length > 1) {
+                    const duplicateIds = discoveredManifests.slice(1).map(file => file.id);
+                    state.syncLog?.log({ event: 'manifest:duplicates', level: 'warn', details: `Detected ${duplicateIds.length} duplicate manifest files for ${folderId}.`, data: { duplicates: duplicateIds } });
                 }
                 const uploadUrl = `/upload/drive/v3/files/${fileId}?uploadType=media&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                 await this.makeApiCall(uploadUrl, { method: 'PATCH', body: JSON.stringify(payload), headers, signal: options.signal }, false);
@@ -3563,21 +3715,43 @@
             }
             async fetchFilesByIds(folderId, fileIds = [], options = {}) {
                 if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
-                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal: options.signal }));
-                const files = await Promise.allSettled(requests);
-                return files
-                    .filter(result => result.status === 'fulfilled')
-                    .map(result => {
-                        const file = result.value;
-                        const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                        const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
-                        return {
-                            ...file,
-                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                            viewUrl,
-                            driveApiDownloadUrl: apiDownloadUrl
-                        };
-                    });
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
             }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.

--- a/ui-v2-old.html
+++ b/ui-v2-old.html
@@ -1044,6 +1044,74 @@
             sessionVisitedFolders: new Set(),
             showDebugToasts: true
         };
+        const DriveLinkHelper = {
+            extractFileId(input) {
+                if (!input) return null;
+                if (typeof input === 'string' && !input.includes('://') && /^[a-zA-Z0-9_-]{10,}$/.test(input)) {
+                    return input;
+                }
+                try {
+                    const url = new URL(input);
+                    const idParam = url.searchParams.get('id') || url.searchParams.get('file_id');
+                    if (idParam) return idParam;
+                    const pathMatch = url.pathname.match(/\/file\/d\/([^/]+)/);
+                    if (pathMatch && pathMatch[1]) return pathMatch[1];
+                    const ucMatch = url.pathname.match(/\/uc(?:\/export)?\/download\/([^/?]+)/);
+                    if (ucMatch && ucMatch[1]) return ucMatch[1];
+                } catch (error) {
+                    return null;
+                }
+                return null;
+            },
+            buildUcDownloadUrl(fileId) {
+                if (!fileId) return null;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
+            },
+            buildApiDownloadUrl(fileId) {
+                if (!fileId) return null;
+                return `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`;
+            },
+            normalizeToAssetUrl(rawUrl, fallbackId = null) {
+                if (!rawUrl || typeof rawUrl !== 'string') return null;
+                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const fileId = fallbackId || this.extractFileId(rawUrl);
+                try {
+                    const parsed = new URL(rawUrl);
+                    const host = parsed.hostname;
+                    if (directHosts.test(host)) {
+                        return rawUrl;
+                    }
+                    if (host === 'drive.google.com') {
+                        if (parsed.pathname.startsWith('/uc')) {
+                            parsed.searchParams.set('export', 'view');
+                            if (!parsed.searchParams.get('id') && fileId) {
+                                parsed.searchParams.set('id', fileId);
+                            }
+                            return parsed.toString();
+                        }
+                        if (fileId) {
+                            return this.buildUcDownloadUrl(fileId);
+                        }
+                    }
+                    if (host === 'www.googleapis.com') {
+                        parsed.searchParams.set('alt', 'media');
+                        return parsed.toString();
+                    }
+                    if (fileId) {
+                        return this.buildUcDownloadUrl(fileId);
+                    }
+                } catch (error) {
+                    if (fileId) {
+                        return this.buildUcDownloadUrl(fileId) || this.buildApiDownloadUrl(fileId);
+                    }
+                    return null;
+                }
+                if (fileId) {
+                    return this.buildUcDownloadUrl(fileId) || this.buildApiDownloadUrl(fileId);
+                }
+                return null;
+            }
+        };
         const Utils = {
             elements: {},
 
@@ -1281,10 +1349,11 @@
             
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1295,13 +1364,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s800');
                     }
                     if (file.thumbnail && file.thumbnail.url) {
                         return file.thumbnail.url.replace('=s220', '=s800');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -2038,6 +2108,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -2102,7 +2218,14 @@
             }
             async makeApiCall(endpoint, options = {}, isJson = true) {
                 if (!this.accessToken) { throw new Error('Not authenticated'); }
-                const url = endpoint.startsWith('https://') ? endpoint : `${this.apiBase}${endpoint}`;
+                let url;
+                if (endpoint.startsWith('https://')) {
+                    url = endpoint;
+                } else if (endpoint.startsWith('/upload/drive/')) {
+                    url = `https://www.googleapis.com${endpoint}`;
+                } else {
+                    url = `${this.apiBase}${endpoint}`;
+                }
                 const headers = { 'Authorization': `Bearer ${this.accessToken}`, ...options.headers };
                 if(isJson) { headers['Content-Type'] = 'application/json'; }
                 let response = await fetch(url, { ...options, headers });
@@ -2118,8 +2241,9 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
                     id: folder.id,
                     name: folder.name,
                     type: 'folder',
@@ -2130,18 +2254,194 @@
                 }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files.filter(file => file.mimeType && file.mimeType.startsWith('image/')).map(file => ({ id: file.id, name: file.name, type: 'file', mimeType: file.mimeType, size: file.size ? parseInt(file.size) : 0, createdTime: file.createdTime, modifiedTime: file.modifiedTime, thumbnailLink: file.thumbnailLink, downloadUrl: file.webContentLink, appProperties: file.appProperties || {}, parents: file.parents }));
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
+            }
+            async loadFolderManifest(folderId, options = {}) {
+                try {
+                    const query = `'${folderId}' in parents and name = '.orbital8-state.json' and trashed=false`;
+                    const url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,modifiedTime,appProperties,parents)&supportsAllDrives=true&includeItemsFromAllDrives=true&pageSize=1`;
+                    const response = await this.makeApiCall(url, { signal: options.signal });
+                    const manifestFile = response.files && response.files[0];
+                    if (!manifestFile) {
+                        return null;
+                    }
+                    const fileId = manifestFile.id;
+                    let manifestData = {};
+                    try {
+                        const mediaResponse = await this.makeApiCall(`/files/${fileId}?alt=media`, { method: 'GET', signal: options.signal }, false);
+                        const text = await mediaResponse.text();
+                        manifestData = text ? JSON.parse(text) : {};
+                    } catch (error) {
+                        if (/403|404/.test(error.message || '')) {
+                            state.syncLog?.log({ event: 'manifest:fetch:forbidden', level: 'error', details: `Drive denied manifest content for ${folderId}: ${error.message}` });
+                            return { entries: {}, requiresFullResync: true, cloudVersion: Date.now(), manifestFileId: fileId };
+                        }
+                        throw error;
+                    }
+                    const cloudVersion = Number(manifestData.cloudVersion || manifestFile.appProperties?.orbital8CloudVersion || Date.now());
+                    return {
+                        entries: manifestData.entries || {},
+                        requiresFullResync: Boolean(manifestData.requiresFullResync),
+                        cloudVersion,
+                        manifestFileId: fileId
+                    };
+                } catch (error) {
+                    if (/403|404/.test(error.message || '')) {
+                        state.syncLog?.log({ event: 'manifest:fetch:fallback', level: 'warn', details: `Manifest lookup failed for ${folderId}: ${error.message}` });
+                        return { entries: {}, requiresFullResync: true, cloudVersion: Date.now() };
+                    }
+                    throw error;
+                }
+            }
+            async saveFolderManifest(folderId, manifest, options = {}) {
+                const cloudVersion = manifest.cloudVersion ?? Date.now();
+                const payload = {
+                    folderId,
+                    provider: 'googledrive',
+                    cloudVersion,
+                    requiresFullResync: Boolean(manifest.requiresFullResync),
+                    entries: manifest.entries || {},
+                    updatedAt: new Date().toISOString()
+                };
+                const metadata = {
+                    name: '.orbital8-state.json',
+                    parents: [folderId],
+                    mimeType: 'application/json',
+                    appProperties: { orbital8CloudVersion: String(cloudVersion) }
+                };
+                const headers = { 'Content-Type': 'application/json' };
+                let fileId = manifest.manifestFileId || options.manifestFileId || null;
+                let discoveredManifests = null;
+                if (!fileId) {
+                    try {
+                        const query = `'${folderId}' in parents and name = '.orbital8-state.json' and trashed=false`;
+                        const lookupUrl = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true&pageSize=10`;
+                        const lookupResponse = await this.makeApiCall(lookupUrl, { signal: options.signal });
+                        const files = Array.isArray(lookupResponse?.files) ? lookupResponse.files : [];
+                        if (files.length > 0) {
+                            fileId = files[0].id;
+                            discoveredManifests = files;
+                        }
+                    } catch (error) {
+                        state.syncLog?.log({ event: 'manifest:lookup:fallback', level: 'warn', details: `Failed to locate existing manifest for ${folderId}: ${error.message}` });
+                    }
+                }
+                if (!fileId) {
+                    const createResponse = await this.makeApiCall('/files?supportsAllDrives=true&includeItemsFromAllDrives=true', { method: 'POST', body: JSON.stringify(metadata) });
+                    fileId = createResponse.id;
+                }
+                await this.makeApiCall(`/files/${fileId}?supportsAllDrives=true&includeItemsFromAllDrives=true`, { method: 'PATCH', body: JSON.stringify({ appProperties: metadata.appProperties }) });
+                if (Array.isArray(discoveredManifests) && discoveredManifests.length > 1) {
+                    const duplicateIds = discoveredManifests.slice(1).map(file => file.id);
+                    state.syncLog?.log({ event: 'manifest:duplicates', level: 'warn', details: `Detected ${duplicateIds.length} duplicate manifest files for ${folderId}.`, data: { duplicates: duplicateIds } });
+                }
+                const uploadUrl = `/upload/drive/v3/files/${fileId}?uploadType=media&supportsAllDrives=true&includeItemsFromAllDrives=true`;
+                await this.makeApiCall(uploadUrl, { method: 'PATCH', body: JSON.stringify(payload), headers, signal: options.signal }, false);
+                state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted Drive manifest for ${folderId}`, data: { provider: 'googledrive', entries: Object.keys(payload.entries || {}).length, cloudVersion } });
+                return { cloudVersion, manifestFileId: fileId };
+            }
+            async updateFolderVersionMarker(folderId, version, options = {}) {
+                let fileId = options.manifestFileId;
+                if (!fileId) {
+                    const manifest = await this.loadFolderManifest(folderId, { signal: options.signal });
+                    fileId = manifest?.manifestFileId;
+                }
+                if (!fileId) {
+                    await this.saveFolderManifest(folderId, { entries: {}, cloudVersion: version, requiresFullResync: false });
+                    return;
+                }
+                await this.makeApiCall(`/files/${fileId}?supportsAllDrives=true&includeItemsFromAllDrives=true`, {
+                    method: 'PATCH',
+                    body: JSON.stringify({ appProperties: { orbital8CloudVersion: String(version) } })
+                });
+            }
+            async fetchFilesByIds(folderId, fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
             }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.
@@ -2165,7 +2465,7 @@
                 const file = state.imageFiles.find(f => f.id === fileId);
                 if (!file) return;
                 Object.assign(file, updates);
-                await state.dbManager.saveMetadata(file.id, file);
+                await state.dbManager.saveMetadata(file.id, file, { folderId: state.currentFolder.id, providerType: state.providerType });
                 await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
             }
 

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -1070,7 +1070,7 @@
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);
@@ -1344,10 +1344,11 @@
             },
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1358,13 +1359,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s800');
                     }
                     if (file.thumbnail && file.thumbnail.url) {
                         return file.thumbnail.url.replace('=s220', '=s800');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -3423,6 +3425,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -3510,8 +3558,9 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
                     id: folder.id,
                     name: folder.name,
                     type: 'folder',
@@ -3522,37 +3571,54 @@
                 }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files
-                        .filter(file => file.mimeType && file.mimeType.startsWith('image/'))
-                        .map(file => {
-                            const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                            const apiDownloadUrl = file.webContentLink || null;
-                            return {
-                                id: file.id,
-                                name: file.name,
-                                type: 'file',
-                                mimeType: file.mimeType,
-                                size: file.size ? parseInt(file.size) : 0,
-                                createdTime: file.createdTime,
-                                modifiedTime: file.modifiedTime,
-                                thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                                viewUrl,
-                                driveApiDownloadUrl: apiDownloadUrl,
-                                appProperties: file.appProperties || {},
-                                parents: file.parents
-                            };
-                        });
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
             }
             async loadFolderManifest(folderId, options = {}) {
@@ -3656,21 +3722,43 @@
             }
             async fetchFilesByIds(folderId, fileIds = [], options = {}) {
                 if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
-                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal: options.signal }));
-                const files = await Promise.allSettled(requests);
-                return files
-                    .filter(result => result.status === 'fulfilled')
-                    .map(result => {
-                        const file = result.value;
-                        const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                        const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
-                        return {
-                            ...file,
-                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                            viewUrl,
-                            driveApiDownloadUrl: apiDownloadUrl
-                        };
-                    });
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
             }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -1070,7 +1070,7 @@
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);
@@ -1344,10 +1344,11 @@
             },
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1358,13 +1359,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s800');
                     }
                     if (file.thumbnail && file.thumbnail.url) {
                         return file.thumbnail.url.replace('=s220', '=s800');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -3423,6 +3425,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -3510,8 +3558,9 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
                     id: folder.id,
                     name: folder.name,
                     type: 'folder',
@@ -3522,37 +3571,54 @@
                 }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files
-                        .filter(file => file.mimeType && file.mimeType.startsWith('image/'))
-                        .map(file => {
-                            const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                            const apiDownloadUrl = file.webContentLink || null;
-                            return {
-                                id: file.id,
-                                name: file.name,
-                                type: 'file',
-                                mimeType: file.mimeType,
-                                size: file.size ? parseInt(file.size) : 0,
-                                createdTime: file.createdTime,
-                                modifiedTime: file.modifiedTime,
-                                thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                                viewUrl,
-                                driveApiDownloadUrl: apiDownloadUrl,
-                                appProperties: file.appProperties || {},
-                                parents: file.parents
-                            };
-                        });
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
             }
             async loadFolderManifest(folderId, options = {}) {
@@ -3656,21 +3722,43 @@
             }
             async fetchFilesByIds(folderId, fileIds = [], options = {}) {
                 if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
-                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal: options.signal }));
-                const files = await Promise.allSettled(requests);
-                return files
-                    .filter(result => result.status === 'fulfilled')
-                    .map(result => {
-                        const file = result.value;
-                        const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                        const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
-                        return {
-                            ...file,
-                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                            viewUrl,
-                            driveApiDownloadUrl: apiDownloadUrl
-                        };
-                    });
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
             }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -1070,7 +1070,7 @@
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);
@@ -1344,10 +1344,11 @@
             },
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1358,13 +1359,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s800');
                     }
                     if (file.thumbnail && file.thumbnail.url) {
                         return file.thumbnail.url.replace('=s220', '=s800');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -3423,6 +3425,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -3510,8 +3558,9 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
                     id: folder.id,
                     name: folder.name,
                     type: 'folder',
@@ -3522,37 +3571,54 @@
                 }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files
-                        .filter(file => file.mimeType && file.mimeType.startsWith('image/'))
-                        .map(file => {
-                            const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                            const apiDownloadUrl = file.webContentLink || null;
-                            return {
-                                id: file.id,
-                                name: file.name,
-                                type: 'file',
-                                mimeType: file.mimeType,
-                                size: file.size ? parseInt(file.size) : 0,
-                                createdTime: file.createdTime,
-                                modifiedTime: file.modifiedTime,
-                                thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                                viewUrl,
-                                driveApiDownloadUrl: apiDownloadUrl,
-                                appProperties: file.appProperties || {},
-                                parents: file.parents
-                            };
-                        });
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
             }
             async loadFolderManifest(folderId, options = {}) {
@@ -3656,21 +3722,43 @@
             }
             async fetchFilesByIds(folderId, fileIds = [], options = {}) {
                 if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
-                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal: options.signal }));
-                const files = await Promise.allSettled(requests);
-                return files
-                    .filter(result => result.status === 'fulfilled')
-                    .map(result => {
-                        const file = result.value;
-                        const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                        const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
-                        return {
-                            ...file,
-                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                            viewUrl,
-                            driveApiDownloadUrl: apiDownloadUrl
-                        };
-                    });
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
             }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -1070,7 +1070,7 @@
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);
@@ -1344,10 +1344,11 @@
             },
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1358,13 +1359,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s800');
                     }
                     if (file.thumbnail && file.thumbnail.url) {
                         return file.thumbnail.url.replace('=s220', '=s800');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -3423,6 +3425,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -3510,8 +3558,9 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
                     id: folder.id,
                     name: folder.name,
                     type: 'folder',
@@ -3522,37 +3571,54 @@
                 }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files
-                        .filter(file => file.mimeType && file.mimeType.startsWith('image/'))
-                        .map(file => {
-                            const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                            const apiDownloadUrl = file.webContentLink || null;
-                            return {
-                                id: file.id,
-                                name: file.name,
-                                type: 'file',
-                                mimeType: file.mimeType,
-                                size: file.size ? parseInt(file.size) : 0,
-                                createdTime: file.createdTime,
-                                modifiedTime: file.modifiedTime,
-                                thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                                viewUrl,
-                                driveApiDownloadUrl: apiDownloadUrl,
-                                appProperties: file.appProperties || {},
-                                parents: file.parents
-                            };
-                        });
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
             }
             async loadFolderManifest(folderId, options = {}) {
@@ -3656,21 +3722,43 @@
             }
             async fetchFilesByIds(folderId, fileIds = [], options = {}) {
                 if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
-                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal: options.signal }));
-                const files = await Promise.allSettled(requests);
-                return files
-                    .filter(result => result.status === 'fulfilled')
-                    .map(result => {
-                        const file = result.value;
-                        const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                        const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
-                        return {
-                            ...file,
-                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                            viewUrl,
-                            driveApiDownloadUrl: apiDownloadUrl
-                        };
-                    });
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
             }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -1070,7 +1070,7 @@
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);
@@ -1344,10 +1344,11 @@
             },
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1358,13 +1359,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s800');
                     }
                     if (file.thumbnail && file.thumbnail.url) {
                         return file.thumbnail.url.replace('=s220', '=s800');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -3423,6 +3425,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -3510,8 +3558,9 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
                     id: folder.id,
                     name: folder.name,
                     type: 'folder',
@@ -3522,37 +3571,54 @@
                 }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files
-                        .filter(file => file.mimeType && file.mimeType.startsWith('image/'))
-                        .map(file => {
-                            const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                            const apiDownloadUrl = file.webContentLink || null;
-                            return {
-                                id: file.id,
-                                name: file.name,
-                                type: 'file',
-                                mimeType: file.mimeType,
-                                size: file.size ? parseInt(file.size) : 0,
-                                createdTime: file.createdTime,
-                                modifiedTime: file.modifiedTime,
-                                thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                                viewUrl,
-                                driveApiDownloadUrl: apiDownloadUrl,
-                                appProperties: file.appProperties || {},
-                                parents: file.parents
-                            };
-                        });
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
             }
             async loadFolderManifest(folderId, options = {}) {
@@ -3656,21 +3722,43 @@
             }
             async fetchFilesByIds(folderId, fileIds = [], options = {}) {
                 if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
-                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal: options.signal }));
-                const files = await Promise.allSettled(requests);
-                return files
-                    .filter(result => result.status === 'fulfilled')
-                    .map(result => {
-                        const file = result.value;
-                        const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                        const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
-                        return {
-                            ...file,
-                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                            viewUrl,
-                            driveApiDownloadUrl: apiDownloadUrl
-                        };
-                    });
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
             }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -1070,7 +1070,7 @@
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);
@@ -1344,10 +1344,11 @@
             },
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1358,13 +1359,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s800');
                     }
                     if (file.thumbnail && file.thumbnail.url) {
                         return file.thumbnail.url.replace('=s220', '=s800');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -3423,6 +3425,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -3510,8 +3558,9 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
                     id: folder.id,
                     name: folder.name,
                     type: 'folder',
@@ -3522,37 +3571,54 @@
                 }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files
-                        .filter(file => file.mimeType && file.mimeType.startsWith('image/'))
-                        .map(file => {
-                            const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                            const apiDownloadUrl = file.webContentLink || null;
-                            return {
-                                id: file.id,
-                                name: file.name,
-                                type: 'file',
-                                mimeType: file.mimeType,
-                                size: file.size ? parseInt(file.size) : 0,
-                                createdTime: file.createdTime,
-                                modifiedTime: file.modifiedTime,
-                                thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                                viewUrl,
-                                driveApiDownloadUrl: apiDownloadUrl,
-                                appProperties: file.appProperties || {},
-                                parents: file.parents
-                            };
-                        });
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
             }
             async loadFolderManifest(folderId, options = {}) {
@@ -3656,21 +3722,43 @@
             }
             async fetchFilesByIds(folderId, fileIds = [], options = {}) {
                 if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
-                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal: options.signal }));
-                const files = await Promise.allSettled(requests);
-                return files
-                    .filter(result => result.status === 'fulfilled')
-                    .map(result => {
-                        const file = result.value;
-                        const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                        const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
-                        return {
-                            ...file,
-                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                            viewUrl,
-                            driveApiDownloadUrl: apiDownloadUrl
-                        };
-                    });
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
             }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -1070,7 +1070,7 @@
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);
@@ -1344,10 +1344,11 @@
             },
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1358,13 +1359,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s800');
                     }
                     if (file.thumbnail && file.thumbnail.url) {
                         return file.thumbnail.url.replace('=s220', '=s800');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -3423,6 +3425,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -3510,8 +3558,9 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
                     id: folder.id,
                     name: folder.name,
                     type: 'folder',
@@ -3522,37 +3571,54 @@
                 }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files
-                        .filter(file => file.mimeType && file.mimeType.startsWith('image/'))
-                        .map(file => {
-                            const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                            const apiDownloadUrl = file.webContentLink || null;
-                            return {
-                                id: file.id,
-                                name: file.name,
-                                type: 'file',
-                                mimeType: file.mimeType,
-                                size: file.size ? parseInt(file.size) : 0,
-                                createdTime: file.createdTime,
-                                modifiedTime: file.modifiedTime,
-                                thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                                viewUrl,
-                                driveApiDownloadUrl: apiDownloadUrl,
-                                appProperties: file.appProperties || {},
-                                parents: file.parents
-                            };
-                        });
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
             }
             async loadFolderManifest(folderId, options = {}) {
@@ -3656,21 +3722,43 @@
             }
             async fetchFilesByIds(folderId, fileIds = [], options = {}) {
                 if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
-                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal: options.signal }));
-                const files = await Promise.allSettled(requests);
-                return files
-                    .filter(result => result.status === 'fulfilled')
-                    .map(result => {
-                        const file = result.value;
-                        const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                        const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
-                        return {
-                            ...file,
-                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                            viewUrl,
-                            driveApiDownloadUrl: apiDownloadUrl
-                        };
-                    });
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
             }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -1070,7 +1070,7 @@
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);
@@ -1344,10 +1344,11 @@
             },
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1358,13 +1359,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s800');
                     }
                     if (file.thumbnail && file.thumbnail.url) {
                         return file.thumbnail.url.replace('=s220', '=s800');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -3423,6 +3425,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -3510,8 +3558,9 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
                     id: folder.id,
                     name: folder.name,
                     type: 'folder',
@@ -3522,37 +3571,54 @@
                 }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files
-                        .filter(file => file.mimeType && file.mimeType.startsWith('image/'))
-                        .map(file => {
-                            const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                            const apiDownloadUrl = file.webContentLink || null;
-                            return {
-                                id: file.id,
-                                name: file.name,
-                                type: 'file',
-                                mimeType: file.mimeType,
-                                size: file.size ? parseInt(file.size) : 0,
-                                createdTime: file.createdTime,
-                                modifiedTime: file.modifiedTime,
-                                thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                                viewUrl,
-                                driveApiDownloadUrl: apiDownloadUrl,
-                                appProperties: file.appProperties || {},
-                                parents: file.parents
-                            };
-                        });
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
             }
             async loadFolderManifest(folderId, options = {}) {
@@ -3656,21 +3722,43 @@
             }
             async fetchFilesByIds(folderId, fileIds = [], options = {}) {
                 if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
-                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal: options.signal }));
-                const files = await Promise.allSettled(requests);
-                return files
-                    .filter(result => result.status === 'fulfilled')
-                    .map(result => {
-                        const file = result.value;
-                        const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                        const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
-                        return {
-                            ...file,
-                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                            viewUrl,
-                            driveApiDownloadUrl: apiDownloadUrl
-                        };
-                    });
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
             }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -1070,7 +1070,7 @@
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);
@@ -1344,10 +1344,11 @@
             },
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1358,13 +1359,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s800');
                     }
                     if (file.thumbnail && file.thumbnail.url) {
                         return file.thumbnail.url.replace('=s220', '=s800');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -3423,6 +3425,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -3510,8 +3558,9 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
                     id: folder.id,
                     name: folder.name,
                     type: 'folder',
@@ -3522,37 +3571,54 @@
                 }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files
-                        .filter(file => file.mimeType && file.mimeType.startsWith('image/'))
-                        .map(file => {
-                            const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                            const apiDownloadUrl = file.webContentLink || null;
-                            return {
-                                id: file.id,
-                                name: file.name,
-                                type: 'file',
-                                mimeType: file.mimeType,
-                                size: file.size ? parseInt(file.size) : 0,
-                                createdTime: file.createdTime,
-                                modifiedTime: file.modifiedTime,
-                                thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                                viewUrl,
-                                driveApiDownloadUrl: apiDownloadUrl,
-                                appProperties: file.appProperties || {},
-                                parents: file.parents
-                            };
-                        });
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
             }
             async loadFolderManifest(folderId, options = {}) {
@@ -3656,21 +3722,43 @@
             }
             async fetchFilesByIds(folderId, fileIds = [], options = {}) {
                 if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
-                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal: options.signal }));
-                const files = await Promise.allSettled(requests);
-                return files
-                    .filter(result => result.status === 'fulfilled')
-                    .map(result => {
-                        const file = result.value;
-                        const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                        const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
-                        return {
-                            ...file,
-                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                            viewUrl,
-                            driveApiDownloadUrl: apiDownloadUrl
-                        };
-                    });
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
             }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -1070,7 +1070,7 @@
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);
@@ -1344,10 +1344,11 @@
             },
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1358,13 +1359,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s800');
                     }
                     if (file.thumbnail && file.thumbnail.url) {
                         return file.thumbnail.url.replace('=s220', '=s800');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -3423,6 +3425,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -3510,8 +3558,9 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
                     id: folder.id,
                     name: folder.name,
                     type: 'folder',
@@ -3522,37 +3571,54 @@
                 }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files
-                        .filter(file => file.mimeType && file.mimeType.startsWith('image/'))
-                        .map(file => {
-                            const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                            const apiDownloadUrl = file.webContentLink || null;
-                            return {
-                                id: file.id,
-                                name: file.name,
-                                type: 'file',
-                                mimeType: file.mimeType,
-                                size: file.size ? parseInt(file.size) : 0,
-                                createdTime: file.createdTime,
-                                modifiedTime: file.modifiedTime,
-                                thumbnailLink: file.thumbnailLink,
-                                downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                                viewUrl,
-                                driveApiDownloadUrl: apiDownloadUrl,
-                                appProperties: file.appProperties || {},
-                                parents: file.parents
-                            };
-                        });
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
             }
             async loadFolderManifest(folderId, options = {}) {
@@ -3656,21 +3722,43 @@
             }
             async fetchFilesByIds(folderId, fileIds = [], options = {}) {
                 if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
-                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal: options.signal }));
-                const files = await Promise.allSettled(requests);
-                return files
-                    .filter(result => result.status === 'fulfilled')
-                    .map(result => {
-                        const file = result.value;
-                        const viewUrl = file.webViewLink || `https://drive.google.com/file/d/${file.id}/view`;
-                        const apiDownloadUrl = file.webContentLink || file.driveApiDownloadUrl || null;
-                        return {
-                            ...file,
-                            downloadUrl: DriveLinkHelper.buildUcDownloadUrl(file.id) || apiDownloadUrl,
-                            viewUrl,
-                            driveApiDownloadUrl: apiDownloadUrl
-                        };
-                    });
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
             }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.

--- a/ui.html
+++ b/ui.html
@@ -1039,6 +1039,74 @@
             sessionVisitedFolders: new Set(),
             showDebugToasts: true
         };
+        const DriveLinkHelper = {
+            extractFileId(input) {
+                if (!input) return null;
+                if (typeof input === 'string' && !input.includes('://') && /^[a-zA-Z0-9_-]{10,}$/.test(input)) {
+                    return input;
+                }
+                try {
+                    const url = new URL(input);
+                    const idParam = url.searchParams.get('id') || url.searchParams.get('file_id');
+                    if (idParam) return idParam;
+                    const pathMatch = url.pathname.match(/\/file\/d\/([^/]+)/);
+                    if (pathMatch && pathMatch[1]) return pathMatch[1];
+                    const ucMatch = url.pathname.match(/\/uc(?:\/export)?\/download\/([^/?]+)/);
+                    if (ucMatch && ucMatch[1]) return ucMatch[1];
+                } catch (error) {
+                    return null;
+                }
+                return null;
+            },
+            buildUcDownloadUrl(fileId) {
+                if (!fileId) return null;
+                return `https://drive.google.com/uc?id=${fileId}&export=view`;
+            },
+            buildApiDownloadUrl(fileId) {
+                if (!fileId) return null;
+                return `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`;
+            },
+            normalizeToAssetUrl(rawUrl, fallbackId = null) {
+                if (!rawUrl || typeof rawUrl !== 'string') return null;
+                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const fileId = fallbackId || this.extractFileId(rawUrl);
+                try {
+                    const parsed = new URL(rawUrl);
+                    const host = parsed.hostname;
+                    if (directHosts.test(host)) {
+                        return rawUrl;
+                    }
+                    if (host === 'drive.google.com') {
+                        if (parsed.pathname.startsWith('/uc')) {
+                            parsed.searchParams.set('export', 'view');
+                            if (!parsed.searchParams.get('id') && fileId) {
+                                parsed.searchParams.set('id', fileId);
+                            }
+                            return parsed.toString();
+                        }
+                        if (fileId) {
+                            return this.buildUcDownloadUrl(fileId);
+                        }
+                    }
+                    if (host === 'www.googleapis.com') {
+                        parsed.searchParams.set('alt', 'media');
+                        return parsed.toString();
+                    }
+                    if (fileId) {
+                        return this.buildUcDownloadUrl(fileId);
+                    }
+                } catch (error) {
+                    if (fileId) {
+                        return this.buildUcDownloadUrl(fileId) || this.buildApiDownloadUrl(fileId);
+                    }
+                    return null;
+                }
+                if (fileId) {
+                    return this.buildUcDownloadUrl(fileId) || this.buildApiDownloadUrl(fileId);
+                }
+                return null;
+            }
+        };
         const Utils = {
             elements: {},
 
@@ -1270,10 +1338,11 @@
             
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s1000');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w1000`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w1000`;
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1284,13 +1353,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
+                    const effectiveId = file?.targetFileId || file?.id;
                     if (file.thumbnailLink) {
                         return file.thumbnailLink.replace('=s220', '=s800');
                     }
                     if (file.thumbnail && file.thumbnail.url) {
                         return file.thumbnail.url.replace('=s220', '=s800');
                     }
-                    return `https://drive.google.com/thumbnail?id=${file.id}&sz=w800`;
+                    return `https://drive.google.com/thumbnail?id=${effectiveId}&sz=w800`;
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -1574,6 +1644,52 @@
                 this.isAuthenticated = false; this.onProgressCallback = null;
                 this.loadStoredCredentials();
             }
+            normalizeDriveFileMetadata(file, options = {}) {
+                const target = options.target || file;
+                const targetId = target?.id || null;
+                const fallbackId = targetId || file?.id || null;
+                const effectiveId = options.useShortcutId ? file.id : fallbackId;
+                const viewUrl = target?.webViewLink || (fallbackId ? `https://drive.google.com/file/d/${fallbackId}/view` : '');
+                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId) : null);
+                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId) : null) || apiDownloadUrl;
+                const sizeValue = target?.size != null ? Number(target.size) : null;
+
+                const normalized = {
+                    id: effectiveId,
+                    name: file?.name || target?.name,
+                    type: 'file',
+                    mimeType: target?.mimeType,
+                    size: Number.isFinite(sizeValue) ? sizeValue : 0,
+                    createdTime: target?.createdTime || file?.createdTime,
+                    modifiedTime: target?.modifiedTime || file?.modifiedTime,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink,
+                    downloadUrl,
+                    viewUrl,
+                    driveApiDownloadUrl: apiDownloadUrl,
+                    appProperties: target?.appProperties || file?.appProperties || {},
+                    parents: file?.parents || target?.parents || [],
+                    targetFileId: targetId || fallbackId || null
+                };
+
+                if (options.useShortcutId) {
+                    normalized.shortcutId = file.id;
+                    normalized.isShortcut = true;
+                    normalized.shortcutDetails = file.shortcutDetails || null;
+                }
+
+                return normalized;
+            }
+            async fetchRawFilesByIds(fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const signal = options.signal;
+                const fields = 'id,name,mimeType,size,createdTime,modifiedTime,appProperties,parents,thumbnailLink,webContentLink,webViewLink,shortcutDetails(targetId,targetMimeType)';
+                const requests = fileIds.map(id => this.makeApiCall(`/files/${id}?fields=${fields}&supportsAllDrives=true&includeItemsFromAllDrives=true`, { signal }));
+                const responses = await Promise.allSettled(requests);
+                return responses
+                    .filter(result => result.status === 'fulfilled')
+                    .map(result => result.value)
+                    .filter(Boolean);
+            }
             loadStoredCredentials() {
                 this.accessToken = localStorage.getItem('google_access_token');
                 this.refreshToken = localStorage.getItem('google_refresh_token');
@@ -1638,7 +1754,14 @@
             }
             async makeApiCall(endpoint, options = {}, isJson = true) {
                 if (!this.accessToken) { throw new Error('Not authenticated'); }
-                const url = endpoint.startsWith('https://') ? endpoint : `${this.apiBase}${endpoint}`;
+                let url;
+                if (endpoint.startsWith('https://')) {
+                    url = endpoint;
+                } else if (endpoint.startsWith('/upload/drive/')) {
+                    url = `https://www.googleapis.com${endpoint}`;
+                } else {
+                    url = `${this.apiBase}${endpoint}`;
+                }
                 const headers = { 'Authorization': `Bearer ${this.accessToken}`, ...options.headers };
                 if(isJson) { headers['Content-Type'] = 'application/json'; }
                 let response = await fetch(url, { ...options, headers });
@@ -1654,8 +1777,9 @@
                 return response;
             }
             async getFolders() {
-                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc');
-                return response.files.map(folder => ({
+                const response = await this.makeApiCall('/files?q=mimeType%3D%27application/vnd.google-apps.folder%27&fields=files(id,name,createdTime,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true');
+                const folders = Array.isArray(response.files) ? response.files : [];
+                return folders.map(folder => ({
                     id: folder.id,
                     name: folder.name,
                     type: 'folder',
@@ -1666,18 +1790,194 @@
                 }));
             }
             async getFilesAndMetadata(folderId = 'root') {
-                const allFiles = []; let nextPageToken = null;
+                const allFiles = [];
+                let nextPageToken = null;
+                const signal = state.activeRequests?.signal;
+
                 do {
-                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/')`;
-                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,appProperties,parents),nextPageToken&pageSize=100`;
+                    const query = `'${folderId}' in parents and trashed=false and (mimeType contains 'image/' or mimeType = 'application/vnd.google-apps.shortcut')`;
+                    let url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,createdTime,modifiedTime,thumbnailLink,webContentLink,webViewLink,appProperties,parents,shortcutDetails(targetId,targetMimeType)),nextPageToken&pageSize=100&supportsAllDrives=true&includeItemsFromAllDrives=true`;
                     if (nextPageToken) { url += `&pageToken=${nextPageToken}`; }
-                    const response = await this.makeApiCall(url, { signal: state.activeRequests.signal });
-                    const files = response.files.filter(file => file.mimeType && file.mimeType.startsWith('image/')).map(file => ({ id: file.id, name: file.name, type: 'file', mimeType: file.mimeType, size: file.size ? parseInt(file.size) : 0, createdTime: file.createdTime, modifiedTime: file.modifiedTime, thumbnailLink: file.thumbnailLink, downloadUrl: file.webContentLink, appProperties: file.appProperties || {}, parents: file.parents }));
-                    allFiles.push(...files);
+
+                    const response = await this.makeApiCall(url, { signal });
+                    const files = Array.isArray(response.files) ? response.files : [];
+                    const directImages = [];
+                    const shortcutCandidates = [];
+
+                    for (const file of files) {
+                        if (file?.mimeType?.startsWith('image/')) {
+                            directImages.push(file);
+                        } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                            shortcutCandidates.push(file);
+                        }
+                    }
+
+                    const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                    let resolvedShortcuts = [];
+                    if (shortcutCandidates.length > 0) {
+                        const targetIds = [...new Set(shortcutCandidates
+                            .map(file => file.shortcutDetails?.targetId)
+                            .filter(Boolean))];
+
+                        if (targetIds.length > 0) {
+                            const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal });
+                            const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                            resolvedShortcuts = shortcutCandidates
+                                .map(shortcut => {
+                                    const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                                    if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                                    return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                                })
+                                .filter(Boolean);
+                        }
+                    }
+
+                    allFiles.push(...normalized, ...resolvedShortcuts);
                     nextPageToken = response.nextPageToken;
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 } while (nextPageToken);
+
                 return { folders: [], files: allFiles };
+            }
+            async loadFolderManifest(folderId, options = {}) {
+                try {
+                    const query = `'${folderId}' in parents and name = '.orbital8-state.json' and trashed=false`;
+                    const url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,modifiedTime,appProperties,parents)&supportsAllDrives=true&includeItemsFromAllDrives=true&pageSize=1`;
+                    const response = await this.makeApiCall(url, { signal: options.signal });
+                    const manifestFile = response.files && response.files[0];
+                    if (!manifestFile) {
+                        return null;
+                    }
+                    const fileId = manifestFile.id;
+                    let manifestData = {};
+                    try {
+                        const mediaResponse = await this.makeApiCall(`/files/${fileId}?alt=media`, { method: 'GET', signal: options.signal }, false);
+                        const text = await mediaResponse.text();
+                        manifestData = text ? JSON.parse(text) : {};
+                    } catch (error) {
+                        if (/403|404/.test(error.message || '')) {
+                            state.syncLog?.log({ event: 'manifest:fetch:forbidden', level: 'error', details: `Drive denied manifest content for ${folderId}: ${error.message}` });
+                            return { entries: {}, requiresFullResync: true, cloudVersion: Date.now(), manifestFileId: fileId };
+                        }
+                        throw error;
+                    }
+                    const cloudVersion = Number(manifestData.cloudVersion || manifestFile.appProperties?.orbital8CloudVersion || Date.now());
+                    return {
+                        entries: manifestData.entries || {},
+                        requiresFullResync: Boolean(manifestData.requiresFullResync),
+                        cloudVersion,
+                        manifestFileId: fileId
+                    };
+                } catch (error) {
+                    if (/403|404/.test(error.message || '')) {
+                        state.syncLog?.log({ event: 'manifest:fetch:fallback', level: 'warn', details: `Manifest lookup failed for ${folderId}: ${error.message}` });
+                        return { entries: {}, requiresFullResync: true, cloudVersion: Date.now() };
+                    }
+                    throw error;
+                }
+            }
+            async saveFolderManifest(folderId, manifest, options = {}) {
+                const cloudVersion = manifest.cloudVersion ?? Date.now();
+                const payload = {
+                    folderId,
+                    provider: 'googledrive',
+                    cloudVersion,
+                    requiresFullResync: Boolean(manifest.requiresFullResync),
+                    entries: manifest.entries || {},
+                    updatedAt: new Date().toISOString()
+                };
+                const metadata = {
+                    name: '.orbital8-state.json',
+                    parents: [folderId],
+                    mimeType: 'application/json',
+                    appProperties: { orbital8CloudVersion: String(cloudVersion) }
+                };
+                const headers = { 'Content-Type': 'application/json' };
+                let fileId = manifest.manifestFileId || options.manifestFileId || null;
+                let discoveredManifests = null;
+                if (!fileId) {
+                    try {
+                        const query = `'${folderId}' in parents and name = '.orbital8-state.json' and trashed=false`;
+                        const lookupUrl = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true&pageSize=10`;
+                        const lookupResponse = await this.makeApiCall(lookupUrl, { signal: options.signal });
+                        const files = Array.isArray(lookupResponse?.files) ? lookupResponse.files : [];
+                        if (files.length > 0) {
+                            fileId = files[0].id;
+                            discoveredManifests = files;
+                        }
+                    } catch (error) {
+                        state.syncLog?.log({ event: 'manifest:lookup:fallback', level: 'warn', details: `Failed to locate existing manifest for ${folderId}: ${error.message}` });
+                    }
+                }
+                if (!fileId) {
+                    const createResponse = await this.makeApiCall('/files?supportsAllDrives=true&includeItemsFromAllDrives=true', { method: 'POST', body: JSON.stringify(metadata) });
+                    fileId = createResponse.id;
+                }
+                await this.makeApiCall(`/files/${fileId}?supportsAllDrives=true&includeItemsFromAllDrives=true`, { method: 'PATCH', body: JSON.stringify({ appProperties: metadata.appProperties }) });
+                if (Array.isArray(discoveredManifests) && discoveredManifests.length > 1) {
+                    const duplicateIds = discoveredManifests.slice(1).map(file => file.id);
+                    state.syncLog?.log({ event: 'manifest:duplicates', level: 'warn', details: `Detected ${duplicateIds.length} duplicate manifest files for ${folderId}.`, data: { duplicates: duplicateIds } });
+                }
+                const uploadUrl = `/upload/drive/v3/files/${fileId}?uploadType=media&supportsAllDrives=true&includeItemsFromAllDrives=true`;
+                await this.makeApiCall(uploadUrl, { method: 'PATCH', body: JSON.stringify(payload), headers, signal: options.signal }, false);
+                state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted Drive manifest for ${folderId}`, data: { provider: 'googledrive', entries: Object.keys(payload.entries || {}).length, cloudVersion } });
+                return { cloudVersion, manifestFileId: fileId };
+            }
+            async updateFolderVersionMarker(folderId, version, options = {}) {
+                let fileId = options.manifestFileId;
+                if (!fileId) {
+                    const manifest = await this.loadFolderManifest(folderId, { signal: options.signal });
+                    fileId = manifest?.manifestFileId;
+                }
+                if (!fileId) {
+                    await this.saveFolderManifest(folderId, { entries: {}, cloudVersion: version, requiresFullResync: false });
+                    return;
+                }
+                await this.makeApiCall(`/files/${fileId}?supportsAllDrives=true&includeItemsFromAllDrives=true`, {
+                    method: 'PATCH',
+                    body: JSON.stringify({ appProperties: { orbital8CloudVersion: String(version) } })
+                });
+            }
+            async fetchFilesByIds(folderId, fileIds = [], options = {}) {
+                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
+                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
+                const directImages = [];
+                const shortcutCandidates = [];
+
+                for (const file of rawFiles) {
+                    if (file?.mimeType?.startsWith('image/')) {
+                        directImages.push(file);
+                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
+                        shortcutCandidates.push(file);
+                    }
+                }
+
+                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
+
+                if (shortcutCandidates.length === 0) {
+                    return normalized;
+                }
+
+                const targetIds = [...new Set(shortcutCandidates
+                    .map(file => file.shortcutDetails?.targetId)
+                    .filter(Boolean))];
+
+                if (targetIds.length === 0) {
+                    return normalized;
+                }
+
+                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
+                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
+                const resolvedShortcuts = shortcutCandidates
+                    .map(shortcut => {
+                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
+                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
+                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
+                    })
+                    .filter(Boolean);
+
+                return [...normalized, ...resolvedShortcuts];
             }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.
@@ -1701,7 +2001,7 @@
                 const file = state.imageFiles.find(f => f.id === fileId);
                 if (!file) return;
                 Object.assign(file, updates);
-                await state.dbManager.saveMetadata(file.id, file);
+                await state.dbManager.saveMetadata(file.id, file, { folderId: state.currentFolder.id, providerType: state.providerType });
                 await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
             }
 


### PR DESCRIPTION
## Summary
- sync the DriveLinkHelper and GoogleDriveProvider implementations across the legacy HTML variants with the shortcut-aware logic from ui-v7
- update image URL helpers to honor targetFileId so thumbnails and fallbacks use shareable links consistently

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e207457ee0832d86f684d3bff609c7