### PR TITLE
Allow direct googleusercontent asset URLs

### DIFF
--- a/tests/google-drive-url.spec.ts
+++ b/tests/google-drive-url.spec.ts
@@ -15,7 +15,7 @@ test.describe('Google Drive direct image URLs', () => {
 
       await page.waitForTimeout(500);
 
-      const directUrl = await page.evaluate(() => {
+      const { driveUrl, directAssetUrl } = await page.evaluate(() => {
         const sampleFile = { id: 'sampleFileId123' };
         const stateRef = typeof state !== 'undefined' ? state : (window as any).state;
         const exportSystemRef = typeof ExportSystem !== 'undefined' ? ExportSystem : (window as any).ExportSystem;
@@ -29,11 +29,17 @@ test.describe('Google Drive direct image URLs', () => {
           stateRef.export = new exportSystemRef();
         }
 
-        return stateRef.export.getDirectImageURL(sampleFile);
+        const url = stateRef.export.getDirectImageURL(sampleFile);
+        const passthroughUrl = DriveLinkHelper.normalizeToAssetUrl(
+          'https://lh3.googleusercontent.com/some-direct-image'
+        );
+
+        return { driveUrl: url, directAssetUrl: passthroughUrl };
       });
 
-      expect(directUrl).toContain('https://drive.google.com/uc?id=sampleFileId123');
-      expect(directUrl).toContain('export=view');
+      expect(driveUrl).toContain('https://drive.google.com/uc?id=sampleFileId123');
+      expect(driveUrl).toContain('export=view');
+      expect(directAssetUrl).toBe('https://lh3.googleusercontent.com/some-direct-image');
     });
   }
 });

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -1069,7 +1069,7 @@
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -1069,7 +1069,7 @@
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);

--- a/ui-v2-old.html
+++ b/ui-v2-old.html
@@ -1073,7 +1073,7 @@
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -1070,7 +1070,7 @@
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);

--- a/ui.html
+++ b/ui.html
@@ -1068,7 +1068,7 @@
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
+                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);


### PR DESCRIPTION
## Summary
- update DriveLinkHelper.normalizeToAssetUrl across the legacy UI variants to accept bare and subdomain googleusercontent hosts
- expand the Playwright smoke test to verify direct googleusercontent links pass through unchanged

## Testing
- `npx playwright test tests/google-drive-url.spec.ts` *(fails: browserType.launch: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68e22e05c384832daa21da6f2e115181