### PR TITLE
Prevent manifest saves from being aborted by navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -4451,17 +4451,23 @@
                             try {
                                 const manifestCloudVersion = manifestSeed?.cloudVersion ?? preparation?.remoteManifest?.cloudVersion ?? preparation?.folderState?.cloudVersion ?? Date.now();
                                 const manifestLocalVersion = preparation?.folderState?.localVersion ?? manifestCloudVersion;
+                                const manifestOptions = { manifestFileId };
+                                // Manifest persistence must survive folder exits; avoid tying this to the navigation abort controller.
                                 remoteManifestResponse = await state.provider.saveFolderManifest(folderId, {
                                     entries: manifestEntries,
                                     requiresFullResync: false,
                                     cloudVersion: manifestCloudVersion,
                                     localVersion: manifestLocalVersion,
                                     manifestFileId
-                                }, { signal: state.activeRequests?.signal, manifestFileId });
+                                }, manifestOptions);
                                 state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted manifest for ${folderId}`, data: { entries: Object.keys(manifestEntries).length } });
                             } catch (error) {
-                                manifestRequiresRescan = true;
-                                state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                if (error?.name === 'AbortError') {
+                                    state.syncLog?.log({ event: 'manifest:save:aborted', level: 'warn', details: `Manifest save cancelled: ${error.message}` });
+                                } else {
+                                    manifestRequiresRescan = true;
+                                    state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                }
                             }
                         }
 
@@ -4606,7 +4612,8 @@
                     if (state.syncManager) {
                         await state.syncManager.flush({ reason: 'folder-switch' });
                     }
-                    state.activeRequests.abort();
+                    state.activeRequests?.abort();
+                    // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
                     state.activeRequests = new AbortController();
                     this.resetViewState({ skipEmptyState: true });
                     await Folders.load();

--- a/reports/manifest-persistence-task.md
+++ b/reports/manifest-persistence-task.md
@@ -1,0 +1,28 @@
+# Suggested Task: Stabilize manifest persistence across index and UI variants
+
+## Summary
+Navigation away from an active folder aborts in-flight manifest saves because `App.syncFolderFromCloud` reuses `state.activeRequests` for persistence while `App.returnToFolderSelection` calls `abort()` on the same controller. This leaves the remote `.orbital8-state.json` stale, so other devices observe the "0 folder" condition and never receive new queue entries.
+
+## Scope
+- index.html
+- ui-v1.html
+- ui-v2.html
+- ui-v3.html
+- ui-v4.html
+- ui-v4a.html
+- ui-v5.html
+- ui-v6.html
+- ui-v7.html
+- ui-v8.html
+- ui-v9.html
+- ui-v9a.html
+- ui-v9b.html
+- ui-v10.html
+- ui-v11.html
+
+## Task Checklist
+1. In each file's `App.syncFolderFromCloud`, stop passing `state.activeRequests?.signal` to `state.provider.saveFolderManifest`; use a dedicated `AbortController` for manifest persistence or omit the signal entirely so navigation aborts do not cancel the write.
+2. Refactor `App.returnToFolderSelection` so aborting navigation requests does not touch the manifest controller. If a dedicated controller is used, wait for the save to resolve or explicitly leave it untouched when resetting UI state.
+3. Update the `catch` blocks around manifest saves to distinguish genuine provider failures from intentional navigation aborts. Only set `manifestRequiresRescan = true` when the provider call fails, not when the manifest controller was explicitly cancelled by the user.
+4. Add inline comments noting that manifest persistence must survive folder exits to prevent the "0 folder" state across devices.
+5. Manually verify that leaving a folder during sync still results in the manifest being updated on Google Drive/OneDrive and that subsequent launches do not trigger a forced rescan.

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -4453,17 +4453,23 @@
                             try {
                                 const manifestCloudVersion = manifestSeed?.cloudVersion ?? preparation?.remoteManifest?.cloudVersion ?? preparation?.folderState?.cloudVersion ?? Date.now();
                                 const manifestLocalVersion = preparation?.folderState?.localVersion ?? manifestCloudVersion;
+                                const manifestOptions = { manifestFileId };
+                                // Manifest persistence must survive folder exits; avoid tying this to the navigation abort controller.
                                 remoteManifestResponse = await state.provider.saveFolderManifest(folderId, {
                                     entries: manifestEntries,
                                     requiresFullResync: false,
                                     cloudVersion: manifestCloudVersion,
                                     localVersion: manifestLocalVersion,
                                     manifestFileId
-                                }, { signal: state.activeRequests?.signal, manifestFileId });
+                                }, manifestOptions);
                                 state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted manifest for ${folderId}`, data: { entries: Object.keys(manifestEntries).length } });
                             } catch (error) {
-                                manifestRequiresRescan = true;
-                                state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                if (error?.name === 'AbortError') {
+                                    state.syncLog?.log({ event: 'manifest:save:aborted', level: 'warn', details: `Manifest save cancelled: ${error.message}` });
+                                } else {
+                                    manifestRequiresRescan = true;
+                                    state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                }
                             }
                         }
 
@@ -4608,7 +4614,8 @@
                     if (state.syncManager) {
                         await state.syncManager.flush({ reason: 'folder-switch' });
                     }
-                    state.activeRequests.abort();
+                    state.activeRequests?.abort();
+                    // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
                     state.activeRequests = new AbortController();
                     this.resetViewState({ skipEmptyState: true });
                     await Folders.load();

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -4427,17 +4427,23 @@
                         let manifestRequiresRescan = false;
                         if (state.provider && typeof state.provider.saveFolderManifest === 'function') {
                             try {
+                                const manifestOptions = { manifestFileId: preparation?.remoteManifest?.manifestFileId || preparation?.localManifest?.manifestFileId || null };
+                                // Manifest persistence must survive folder exits; avoid tying this to the navigation abort controller.
                                 remoteManifestResponse = await state.provider.saveFolderManifest(folderId, {
                                     entries: manifestEntries,
                                     requiresFullResync: false,
                                     cloudVersion: preparation?.remoteManifest?.cloudVersion ?? preparation?.folderState?.cloudVersion ?? 0,
                                     localVersion: preparation?.folderState?.localVersion ?? 0,
                                     manifestFileId: preparation?.remoteManifest?.manifestFileId || preparation?.localManifest?.manifestFileId || null
-                                }, { signal: state.activeRequests?.signal });
+                                }, manifestOptions);
                                 state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted manifest for ${folderId}`, data: { entries: Object.keys(manifestEntries).length } });
                             } catch (error) {
-                                manifestRequiresRescan = true;
-                                state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                if (error?.name === 'AbortError') {
+                                    state.syncLog?.log({ event: 'manifest:save:aborted', level: 'warn', details: `Manifest save cancelled: ${error.message}` });
+                                } else {
+                                    manifestRequiresRescan = true;
+                                    state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                }
                             }
                         }
 
@@ -4564,7 +4570,9 @@
                     if (state.syncManager) {
                         await state.syncManager.flush({ reason: 'folder-switch' });
                     }
-                    state.activeRequests.abort(); 
+                    state.activeRequests?.abort();
+                    // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
+                    state.activeRequests = new AbortController();
                     this.resetViewState();
                     Utils.showScreen('folder-screen');
                     await Folders.load();

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -4428,17 +4428,23 @@
                         let manifestRequiresRescan = false;
                         if (state.provider && typeof state.provider.saveFolderManifest === 'function') {
                             try {
+                                const manifestOptions = { manifestFileId: preparation?.remoteManifest?.manifestFileId || preparation?.localManifest?.manifestFileId || null };
+                                // Manifest persistence must survive folder exits; avoid tying this to the navigation abort controller.
                                 remoteManifestResponse = await state.provider.saveFolderManifest(folderId, {
                                     entries: manifestEntries,
                                     requiresFullResync: false,
                                     cloudVersion: preparation?.remoteManifest?.cloudVersion ?? preparation?.folderState?.cloudVersion ?? 0,
                                     localVersion: preparation?.folderState?.localVersion ?? 0,
                                     manifestFileId: preparation?.remoteManifest?.manifestFileId || preparation?.localManifest?.manifestFileId || null
-                                }, { signal: state.activeRequests?.signal });
+                                }, manifestOptions);
                                 state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted manifest for ${folderId}`, data: { entries: Object.keys(manifestEntries).length } });
                             } catch (error) {
-                                manifestRequiresRescan = true;
-                                state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                if (error?.name === 'AbortError') {
+                                    state.syncLog?.log({ event: 'manifest:save:aborted', level: 'warn', details: `Manifest save cancelled: ${error.message}` });
+                                } else {
+                                    manifestRequiresRescan = true;
+                                    state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                }
                             }
                         }
 
@@ -4565,7 +4571,9 @@
                     if (state.syncManager) {
                         await state.syncManager.flush({ reason: 'folder-switch' });
                     }
-                    state.activeRequests.abort(); 
+                    state.activeRequests?.abort();
+                    // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
+                    state.activeRequests = new AbortController();
                     this.resetViewState();
                     Utils.showScreen('folder-screen');
                     await Folders.load();

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -4453,17 +4453,23 @@
                             try {
                                 const manifestCloudVersion = manifestSeed?.cloudVersion ?? preparation?.remoteManifest?.cloudVersion ?? preparation?.folderState?.cloudVersion ?? Date.now();
                                 const manifestLocalVersion = preparation?.folderState?.localVersion ?? manifestCloudVersion;
+                                const manifestOptions = { manifestFileId };
+                                // Manifest persistence must survive folder exits; avoid tying this to the navigation abort controller.
                                 remoteManifestResponse = await state.provider.saveFolderManifest(folderId, {
                                     entries: manifestEntries,
                                     requiresFullResync: false,
                                     cloudVersion: manifestCloudVersion,
                                     localVersion: manifestLocalVersion,
                                     manifestFileId
-                                }, { signal: state.activeRequests?.signal, manifestFileId });
+                                }, manifestOptions);
                                 state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted manifest for ${folderId}`, data: { entries: Object.keys(manifestEntries).length } });
                             } catch (error) {
-                                manifestRequiresRescan = true;
-                                state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                if (error?.name === 'AbortError') {
+                                    state.syncLog?.log({ event: 'manifest:save:aborted', level: 'warn', details: `Manifest save cancelled: ${error.message}` });
+                                } else {
+                                    manifestRequiresRescan = true;
+                                    state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                }
                             }
                         }
 
@@ -4608,7 +4614,8 @@
                     if (state.syncManager) {
                         await state.syncManager.flush({ reason: 'folder-switch' });
                     }
-                    state.activeRequests.abort();
+                    state.activeRequests?.abort();
+                    // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
                     state.activeRequests = new AbortController();
                     this.resetViewState({ skipEmptyState: true });
                     await Folders.load();

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -4453,17 +4453,23 @@
                             try {
                                 const manifestCloudVersion = manifestSeed?.cloudVersion ?? preparation?.remoteManifest?.cloudVersion ?? preparation?.folderState?.cloudVersion ?? Date.now();
                                 const manifestLocalVersion = preparation?.folderState?.localVersion ?? manifestCloudVersion;
+                                const manifestOptions = { manifestFileId };
+                                // Manifest persistence must survive folder exits; avoid tying this to the navigation abort controller.
                                 remoteManifestResponse = await state.provider.saveFolderManifest(folderId, {
                                     entries: manifestEntries,
                                     requiresFullResync: false,
                                     cloudVersion: manifestCloudVersion,
                                     localVersion: manifestLocalVersion,
                                     manifestFileId
-                                }, { signal: state.activeRequests?.signal, manifestFileId });
+                                }, manifestOptions);
                                 state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted manifest for ${folderId}`, data: { entries: Object.keys(manifestEntries).length } });
                             } catch (error) {
-                                manifestRequiresRescan = true;
-                                state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                if (error?.name === 'AbortError') {
+                                    state.syncLog?.log({ event: 'manifest:save:aborted', level: 'warn', details: `Manifest save cancelled: ${error.message}` });
+                                } else {
+                                    manifestRequiresRescan = true;
+                                    state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                }
                             }
                         }
 
@@ -4608,7 +4614,8 @@
                     if (state.syncManager) {
                         await state.syncManager.flush({ reason: 'folder-switch' });
                     }
-                    state.activeRequests.abort();
+                    state.activeRequests?.abort();
+                    // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
                     state.activeRequests = new AbortController();
                     this.resetViewState({ skipEmptyState: true });
                     await Folders.load();

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -4453,17 +4453,23 @@
                             try {
                                 const manifestCloudVersion = manifestSeed?.cloudVersion ?? preparation?.remoteManifest?.cloudVersion ?? preparation?.folderState?.cloudVersion ?? Date.now();
                                 const manifestLocalVersion = preparation?.folderState?.localVersion ?? manifestCloudVersion;
+                                const manifestOptions = { manifestFileId };
+                                // Manifest persistence must survive folder exits; avoid tying this to the navigation abort controller.
                                 remoteManifestResponse = await state.provider.saveFolderManifest(folderId, {
                                     entries: manifestEntries,
                                     requiresFullResync: false,
                                     cloudVersion: manifestCloudVersion,
                                     localVersion: manifestLocalVersion,
                                     manifestFileId
-                                }, { signal: state.activeRequests?.signal, manifestFileId });
+                                }, manifestOptions);
                                 state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted manifest for ${folderId}`, data: { entries: Object.keys(manifestEntries).length } });
                             } catch (error) {
-                                manifestRequiresRescan = true;
-                                state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                if (error?.name === 'AbortError') {
+                                    state.syncLog?.log({ event: 'manifest:save:aborted', level: 'warn', details: `Manifest save cancelled: ${error.message}` });
+                                } else {
+                                    manifestRequiresRescan = true;
+                                    state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                }
                             }
                         }
 
@@ -4608,7 +4614,8 @@
                     if (state.syncManager) {
                         await state.syncManager.flush({ reason: 'folder-switch' });
                     }
-                    state.activeRequests.abort();
+                    state.activeRequests?.abort();
+                    // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
                     state.activeRequests = new AbortController();
                     this.resetViewState({ skipEmptyState: true });
                     await Folders.load();

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -4453,17 +4453,23 @@
                             try {
                                 const manifestCloudVersion = manifestSeed?.cloudVersion ?? preparation?.remoteManifest?.cloudVersion ?? preparation?.folderState?.cloudVersion ?? Date.now();
                                 const manifestLocalVersion = preparation?.folderState?.localVersion ?? manifestCloudVersion;
+                                const manifestOptions = { manifestFileId };
+                                // Manifest persistence must survive folder exits; avoid tying this to the navigation abort controller.
                                 remoteManifestResponse = await state.provider.saveFolderManifest(folderId, {
                                     entries: manifestEntries,
                                     requiresFullResync: false,
                                     cloudVersion: manifestCloudVersion,
                                     localVersion: manifestLocalVersion,
                                     manifestFileId
-                                }, { signal: state.activeRequests?.signal, manifestFileId });
+                                }, manifestOptions);
                                 state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted manifest for ${folderId}`, data: { entries: Object.keys(manifestEntries).length } });
                             } catch (error) {
-                                manifestRequiresRescan = true;
-                                state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                if (error?.name === 'AbortError') {
+                                    state.syncLog?.log({ event: 'manifest:save:aborted', level: 'warn', details: `Manifest save cancelled: ${error.message}` });
+                                } else {
+                                    manifestRequiresRescan = true;
+                                    state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                }
                             }
                         }
 
@@ -4608,7 +4614,8 @@
                     if (state.syncManager) {
                         await state.syncManager.flush({ reason: 'folder-switch' });
                     }
-                    state.activeRequests.abort();
+                    state.activeRequests?.abort();
+                    // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
                     state.activeRequests = new AbortController();
                     this.resetViewState({ skipEmptyState: true });
                     await Folders.load();

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -4453,17 +4453,23 @@
                             try {
                                 const manifestCloudVersion = manifestSeed?.cloudVersion ?? preparation?.remoteManifest?.cloudVersion ?? preparation?.folderState?.cloudVersion ?? Date.now();
                                 const manifestLocalVersion = preparation?.folderState?.localVersion ?? manifestCloudVersion;
+                                const manifestOptions = { manifestFileId };
+                                // Manifest persistence must survive folder exits; avoid tying this to the navigation abort controller.
                                 remoteManifestResponse = await state.provider.saveFolderManifest(folderId, {
                                     entries: manifestEntries,
                                     requiresFullResync: false,
                                     cloudVersion: manifestCloudVersion,
                                     localVersion: manifestLocalVersion,
                                     manifestFileId
-                                }, { signal: state.activeRequests?.signal, manifestFileId });
+                                }, manifestOptions);
                                 state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted manifest for ${folderId}`, data: { entries: Object.keys(manifestEntries).length } });
                             } catch (error) {
-                                manifestRequiresRescan = true;
-                                state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                if (error?.name === 'AbortError') {
+                                    state.syncLog?.log({ event: 'manifest:save:aborted', level: 'warn', details: `Manifest save cancelled: ${error.message}` });
+                                } else {
+                                    manifestRequiresRescan = true;
+                                    state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                }
                             }
                         }
 
@@ -4608,7 +4614,8 @@
                     if (state.syncManager) {
                         await state.syncManager.flush({ reason: 'folder-switch' });
                     }
-                    state.activeRequests.abort();
+                    state.activeRequests?.abort();
+                    // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
                     state.activeRequests = new AbortController();
                     this.resetViewState({ skipEmptyState: true });
                     await Folders.load();

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -4453,17 +4453,23 @@
                             try {
                                 const manifestCloudVersion = manifestSeed?.cloudVersion ?? preparation?.remoteManifest?.cloudVersion ?? preparation?.folderState?.cloudVersion ?? Date.now();
                                 const manifestLocalVersion = preparation?.folderState?.localVersion ?? manifestCloudVersion;
+                                const manifestOptions = { manifestFileId };
+                                // Manifest persistence must survive folder exits; avoid tying this to the navigation abort controller.
                                 remoteManifestResponse = await state.provider.saveFolderManifest(folderId, {
                                     entries: manifestEntries,
                                     requiresFullResync: false,
                                     cloudVersion: manifestCloudVersion,
                                     localVersion: manifestLocalVersion,
                                     manifestFileId
-                                }, { signal: state.activeRequests?.signal, manifestFileId });
+                                }, manifestOptions);
                                 state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted manifest for ${folderId}`, data: { entries: Object.keys(manifestEntries).length } });
                             } catch (error) {
-                                manifestRequiresRescan = true;
-                                state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                if (error?.name === 'AbortError') {
+                                    state.syncLog?.log({ event: 'manifest:save:aborted', level: 'warn', details: `Manifest save cancelled: ${error.message}` });
+                                } else {
+                                    manifestRequiresRescan = true;
+                                    state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                }
                             }
                         }
 
@@ -4608,7 +4614,8 @@
                     if (state.syncManager) {
                         await state.syncManager.flush({ reason: 'folder-switch' });
                     }
-                    state.activeRequests.abort();
+                    state.activeRequests?.abort();
+                    // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
                     state.activeRequests = new AbortController();
                     this.resetViewState({ skipEmptyState: true });
                     await Folders.load();

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -4453,17 +4453,23 @@
                             try {
                                 const manifestCloudVersion = manifestSeed?.cloudVersion ?? preparation?.remoteManifest?.cloudVersion ?? preparation?.folderState?.cloudVersion ?? Date.now();
                                 const manifestLocalVersion = preparation?.folderState?.localVersion ?? manifestCloudVersion;
+                                const manifestOptions = { manifestFileId };
+                                // Manifest persistence must survive folder exits; avoid tying this to the navigation abort controller.
                                 remoteManifestResponse = await state.provider.saveFolderManifest(folderId, {
                                     entries: manifestEntries,
                                     requiresFullResync: false,
                                     cloudVersion: manifestCloudVersion,
                                     localVersion: manifestLocalVersion,
                                     manifestFileId
-                                }, { signal: state.activeRequests?.signal, manifestFileId });
+                                }, manifestOptions);
                                 state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted manifest for ${folderId}`, data: { entries: Object.keys(manifestEntries).length } });
                             } catch (error) {
-                                manifestRequiresRescan = true;
-                                state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                if (error?.name === 'AbortError') {
+                                    state.syncLog?.log({ event: 'manifest:save:aborted', level: 'warn', details: `Manifest save cancelled: ${error.message}` });
+                                } else {
+                                    manifestRequiresRescan = true;
+                                    state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                }
                             }
                         }
 
@@ -4608,7 +4614,8 @@
                     if (state.syncManager) {
                         await state.syncManager.flush({ reason: 'folder-switch' });
                     }
-                    state.activeRequests.abort();
+                    state.activeRequests?.abort();
+                    // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
                     state.activeRequests = new AbortController();
                     this.resetViewState({ skipEmptyState: true });
                     await Folders.load();

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -4453,17 +4453,23 @@
                             try {
                                 const manifestCloudVersion = manifestSeed?.cloudVersion ?? preparation?.remoteManifest?.cloudVersion ?? preparation?.folderState?.cloudVersion ?? Date.now();
                                 const manifestLocalVersion = preparation?.folderState?.localVersion ?? manifestCloudVersion;
+                                const manifestOptions = { manifestFileId };
+                                // Manifest persistence must survive folder exits; avoid tying this to the navigation abort controller.
                                 remoteManifestResponse = await state.provider.saveFolderManifest(folderId, {
                                     entries: manifestEntries,
                                     requiresFullResync: false,
                                     cloudVersion: manifestCloudVersion,
                                     localVersion: manifestLocalVersion,
                                     manifestFileId
-                                }, { signal: state.activeRequests?.signal, manifestFileId });
+                                }, manifestOptions);
                                 state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted manifest for ${folderId}`, data: { entries: Object.keys(manifestEntries).length } });
                             } catch (error) {
-                                manifestRequiresRescan = true;
-                                state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                if (error?.name === 'AbortError') {
+                                    state.syncLog?.log({ event: 'manifest:save:aborted', level: 'warn', details: `Manifest save cancelled: ${error.message}` });
+                                } else {
+                                    manifestRequiresRescan = true;
+                                    state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                }
                             }
                         }
 
@@ -4608,7 +4614,8 @@
                     if (state.syncManager) {
                         await state.syncManager.flush({ reason: 'folder-switch' });
                     }
-                    state.activeRequests.abort();
+                    state.activeRequests?.abort();
+                    // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
                     state.activeRequests = new AbortController();
                     this.resetViewState({ skipEmptyState: true });
                     await Folders.load();

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -4453,17 +4453,23 @@
                             try {
                                 const manifestCloudVersion = manifestSeed?.cloudVersion ?? preparation?.remoteManifest?.cloudVersion ?? preparation?.folderState?.cloudVersion ?? Date.now();
                                 const manifestLocalVersion = preparation?.folderState?.localVersion ?? manifestCloudVersion;
+                                const manifestOptions = { manifestFileId };
+                                // Manifest persistence must survive folder exits; avoid tying this to the navigation abort controller.
                                 remoteManifestResponse = await state.provider.saveFolderManifest(folderId, {
                                     entries: manifestEntries,
                                     requiresFullResync: false,
                                     cloudVersion: manifestCloudVersion,
                                     localVersion: manifestLocalVersion,
                                     manifestFileId
-                                }, { signal: state.activeRequests?.signal, manifestFileId });
+                                }, manifestOptions);
                                 state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted manifest for ${folderId}`, data: { entries: Object.keys(manifestEntries).length } });
                             } catch (error) {
-                                manifestRequiresRescan = true;
-                                state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                if (error?.name === 'AbortError') {
+                                    state.syncLog?.log({ event: 'manifest:save:aborted', level: 'warn', details: `Manifest save cancelled: ${error.message}` });
+                                } else {
+                                    manifestRequiresRescan = true;
+                                    state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                }
                             }
                         }
 
@@ -4608,7 +4614,8 @@
                     if (state.syncManager) {
                         await state.syncManager.flush({ reason: 'folder-switch' });
                     }
-                    state.activeRequests.abort();
+                    state.activeRequests?.abort();
+                    // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
                     state.activeRequests = new AbortController();
                     this.resetViewState({ skipEmptyState: true });
                     await Folders.load();

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -4453,17 +4453,23 @@
                             try {
                                 const manifestCloudVersion = manifestSeed?.cloudVersion ?? preparation?.remoteManifest?.cloudVersion ?? preparation?.folderState?.cloudVersion ?? Date.now();
                                 const manifestLocalVersion = preparation?.folderState?.localVersion ?? manifestCloudVersion;
+                                const manifestOptions = { manifestFileId };
+                                // Manifest persistence must survive folder exits; avoid tying this to the navigation abort controller.
                                 remoteManifestResponse = await state.provider.saveFolderManifest(folderId, {
                                     entries: manifestEntries,
                                     requiresFullResync: false,
                                     cloudVersion: manifestCloudVersion,
                                     localVersion: manifestLocalVersion,
                                     manifestFileId
-                                }, { signal: state.activeRequests?.signal, manifestFileId });
+                                }, manifestOptions);
                                 state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted manifest for ${folderId}`, data: { entries: Object.keys(manifestEntries).length } });
                             } catch (error) {
-                                manifestRequiresRescan = true;
-                                state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                if (error?.name === 'AbortError') {
+                                    state.syncLog?.log({ event: 'manifest:save:aborted', level: 'warn', details: `Manifest save cancelled: ${error.message}` });
+                                } else {
+                                    manifestRequiresRescan = true;
+                                    state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                }
                             }
                         }
 
@@ -4608,7 +4614,8 @@
                     if (state.syncManager) {
                         await state.syncManager.flush({ reason: 'folder-switch' });
                     }
-                    state.activeRequests.abort();
+                    state.activeRequests?.abort();
+                    // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
                     state.activeRequests = new AbortController();
                     this.resetViewState({ skipEmptyState: true });
                     await Folders.load();

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -4453,17 +4453,23 @@
                             try {
                                 const manifestCloudVersion = manifestSeed?.cloudVersion ?? preparation?.remoteManifest?.cloudVersion ?? preparation?.folderState?.cloudVersion ?? Date.now();
                                 const manifestLocalVersion = preparation?.folderState?.localVersion ?? manifestCloudVersion;
+                                const manifestOptions = { manifestFileId };
+                                // Manifest persistence must survive folder exits; avoid tying this to the navigation abort controller.
                                 remoteManifestResponse = await state.provider.saveFolderManifest(folderId, {
                                     entries: manifestEntries,
                                     requiresFullResync: false,
                                     cloudVersion: manifestCloudVersion,
                                     localVersion: manifestLocalVersion,
                                     manifestFileId
-                                }, { signal: state.activeRequests?.signal, manifestFileId });
+                                }, manifestOptions);
                                 state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted manifest for ${folderId}`, data: { entries: Object.keys(manifestEntries).length } });
                             } catch (error) {
-                                manifestRequiresRescan = true;
-                                state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                if (error?.name === 'AbortError') {
+                                    state.syncLog?.log({ event: 'manifest:save:aborted', level: 'warn', details: `Manifest save cancelled: ${error.message}` });
+                                } else {
+                                    manifestRequiresRescan = true;
+                                    state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
+                                }
                             }
                         }
 
@@ -4608,7 +4614,8 @@
                     if (state.syncManager) {
                         await state.syncManager.flush({ reason: 'folder-switch' });
                     }
-                    state.activeRequests.abort();
+                    state.activeRequests?.abort();
+                    // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
                     state.activeRequests = new AbortController();
                     this.resetViewState({ skipEmptyState: true });
                     await Folders.load();


### PR DESCRIPTION
## Summary
- decouple manifest persistence from the shared navigation abort controller across index.html and the ui-v1 through ui-v11 builds
- treat AbortError as a user cancellation instead of forcing a full rescan and document why the manifest controller is isolated
- reset the navigation abort controller when returning to folder selection without cancelling the manifest write

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e23dd08b3c832d9e4ce949d0fb90d3