### PR TITLE
Handle empty folder load in performance v2

### DIFF
--- a/performance-v2.html
+++ b/performance-v2.html
@@ -2409,8 +2409,10 @@
                     if (state.syncManager) {
                         state.syncManager.start(state.provider);
                     }
-                    await this.loadImages();
-                    this.switchToCommonUI();
+                    const loaded = await this.loadImages();
+                    if (loaded) {
+                        this.switchToCommonUI();
+                    }
                 } catch (error) {
                     Utils.showToast(`Initialization failed: ${error.message}`, 'error', true);
                     this.returnToFolderSelection();
@@ -2418,7 +2420,7 @@
             },
             async loadImages(options = {}) {
                 const folderId = state.currentFolder.id;
-                if (!folderId) return;
+                if (!folderId) return false;
                 const sessionKey = `${state.providerType || 'unknown'}::${folderId}`;
                 const firstVisit = !state.sessionVisitedFolders.has(sessionKey);
                 if (firstVisit || options.forceRefresh) {
@@ -2432,7 +2434,7 @@
                         state.imageFiles = [];
                         Utils.showToast('No images found in this folder', 'info', true);
                         this.returnToFolderSelection();
-                        return;
+                        return false;
                     }
                     state.imageFiles = record.files.map(file => ({ ...file }));
                     tierOneCache.set(record);
@@ -2444,9 +2446,11 @@
                     if (pendingPngs.length > 0) {
                         this.extractMetadataInBackground(pendingPngs);
                     }
+                    return true;
                 } catch (error) {
                     Utils.showToast(`Error loading images: ${error.message}`, 'error', true);
                     this.returnToFolderSelection();
+                    return false;
                 }
             },
             async processAllMetadata(files, isFirstLoad = false) {


### PR DESCRIPTION
## Summary
- have App.loadImages return a success boolean so callers can respond to failures
- ensure initializeWithProvider only switches to the main UI when images load successfully
- keep the folder selection screen visible when folders are empty or loading fails

## Testing
- Not run (manual verification only)


------
https://chatgpt.com/codex/tasks/task_e_68e24abe5268832dad7f4b3d525ffed8