### PR TITLE
Guard delta sync UI transitions when folders empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -4341,14 +4341,19 @@
                     const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
                     state.sessionVisitedFolders.add(key);
 
+                    const hasImages = state.imageFiles.length > 0;
                     if (!background) {
-                        this.switchToCommonUI();
-                        Core.initializeStacks();
-                        Core.initializeImageDisplay();
+                        if (hasImages) {
+                            this.switchToCommonUI();
+                            Core.initializeStacks();
+                            Core.initializeImageDisplay();
+                        } else {
+                            await this.returnToFolderSelection();
+                        }
                     } else {
                         Core.initializeStacks();
                         Core.updateStackCounts();
-                        if (state.imageFiles.length > 0) {
+                        if (hasImages) {
                             await Core.displayCurrentImage();
                         } else {
                             Core.showEmptyState();
@@ -4371,7 +4376,7 @@
                         details: `Delta applied for ${folderId}: ${changedIds.length} updates, ${removedIds.length} removals.`,
                         data: { cloudVersion: updatedCloudVersion }
                     });
-                    return state.imageFiles.length > 0;
+                    return hasImages;
                 } catch (error) {
                     state.syncLog?.log({ event: 'foldersync:delta-error', level: 'error', details: `Delta sync failed: ${error.message}` });
                     Utils.showToast(`Delta sync failed: ${error.message}`, 'error', true);

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -4343,14 +4343,19 @@
                     const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
                     state.sessionVisitedFolders.add(key);
 
+                    const hasImages = state.imageFiles.length > 0;
                     if (!background) {
-                        this.switchToCommonUI();
-                        Core.initializeStacks();
-                        Core.initializeImageDisplay();
+                        if (hasImages) {
+                            this.switchToCommonUI();
+                            Core.initializeStacks();
+                            Core.initializeImageDisplay();
+                        } else {
+                            await this.returnToFolderSelection();
+                        }
                     } else {
                         Core.initializeStacks();
                         Core.updateStackCounts();
-                        if (state.imageFiles.length > 0) {
+                        if (hasImages) {
                             await Core.displayCurrentImage();
                         } else {
                             Core.showEmptyState();
@@ -4373,7 +4378,7 @@
                         details: `Delta applied for ${folderId}: ${changedIds.length} updates, ${removedIds.length} removals.`,
                         data: { cloudVersion: updatedCloudVersion }
                     });
-                    return state.imageFiles.length > 0;
+                    return hasImages;
                 } catch (error) {
                     state.syncLog?.log({ event: 'foldersync:delta-error', level: 'error', details: `Delta sync failed: ${error.message}` });
                     Utils.showToast(`Delta sync failed: ${error.message}`, 'error', true);

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -4335,14 +4335,19 @@
                     const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
                     state.sessionVisitedFolders.add(key);
 
+                    const hasImages = state.imageFiles.length > 0;
                     if (!background) {
-                        this.switchToCommonUI();
-                        Core.initializeStacks();
-                        Core.initializeImageDisplay();
+                        if (hasImages) {
+                            this.switchToCommonUI();
+                            Core.initializeStacks();
+                            Core.initializeImageDisplay();
+                        } else {
+                            await this.returnToFolderSelection();
+                        }
                     } else {
                         Core.initializeStacks();
                         Core.updateStackCounts();
-                        if (state.imageFiles.length > 0) {
+                        if (hasImages) {
                             await Core.displayCurrentImage();
                         } else {
                             Core.showEmptyState();
@@ -4365,7 +4370,7 @@
                         details: `Delta applied for ${folderId}: ${changedIds.length} updates, ${removedIds.length} removals.`,
                         data: { cloudVersion: updatedCloudVersion }
                     });
-                    return state.imageFiles.length > 0;
+                    return hasImages;
                 } catch (error) {
                     state.syncLog?.log({ event: 'foldersync:delta-error', level: 'error', details: `Delta sync failed: ${error.message}` });
                     Utils.showToast(`Delta sync failed: ${error.message}`, 'error', true);

--- a/ui-v11.html
+++ b/ui-v11.html
@@ -4336,14 +4336,19 @@
                     const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
                     state.sessionVisitedFolders.add(key);
 
+                    const hasImages = state.imageFiles.length > 0;
                     if (!background) {
-                        this.switchToCommonUI();
-                        Core.initializeStacks();
-                        Core.initializeImageDisplay();
+                        if (hasImages) {
+                            this.switchToCommonUI();
+                            Core.initializeStacks();
+                            Core.initializeImageDisplay();
+                        } else {
+                            await this.returnToFolderSelection();
+                        }
                     } else {
                         Core.initializeStacks();
                         Core.updateStackCounts();
-                        if (state.imageFiles.length > 0) {
+                        if (hasImages) {
                             await Core.displayCurrentImage();
                         } else {
                             Core.showEmptyState();
@@ -4366,7 +4371,7 @@
                         details: `Delta applied for ${folderId}: ${changedIds.length} updates, ${removedIds.length} removals.`,
                         data: { cloudVersion: updatedCloudVersion }
                     });
-                    return state.imageFiles.length > 0;
+                    return hasImages;
                 } catch (error) {
                     state.syncLog?.log({ event: 'foldersync:delta-error', level: 'error', details: `Delta sync failed: ${error.message}` });
                     Utils.showToast(`Delta sync failed: ${error.message}`, 'error', true);

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -4343,14 +4343,19 @@
                     const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
                     state.sessionVisitedFolders.add(key);
 
+                    const hasImages = state.imageFiles.length > 0;
                     if (!background) {
-                        this.switchToCommonUI();
-                        Core.initializeStacks();
-                        Core.initializeImageDisplay();
+                        if (hasImages) {
+                            this.switchToCommonUI();
+                            Core.initializeStacks();
+                            Core.initializeImageDisplay();
+                        } else {
+                            await this.returnToFolderSelection();
+                        }
                     } else {
                         Core.initializeStacks();
                         Core.updateStackCounts();
-                        if (state.imageFiles.length > 0) {
+                        if (hasImages) {
                             await Core.displayCurrentImage();
                         } else {
                             Core.showEmptyState();
@@ -4373,7 +4378,7 @@
                         details: `Delta applied for ${folderId}: ${changedIds.length} updates, ${removedIds.length} removals.`,
                         data: { cloudVersion: updatedCloudVersion }
                     });
-                    return state.imageFiles.length > 0;
+                    return hasImages;
                 } catch (error) {
                     state.syncLog?.log({ event: 'foldersync:delta-error', level: 'error', details: `Delta sync failed: ${error.message}` });
                     Utils.showToast(`Delta sync failed: ${error.message}`, 'error', true);

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -4343,14 +4343,19 @@
                     const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
                     state.sessionVisitedFolders.add(key);
 
+                    const hasImages = state.imageFiles.length > 0;
                     if (!background) {
-                        this.switchToCommonUI();
-                        Core.initializeStacks();
-                        Core.initializeImageDisplay();
+                        if (hasImages) {
+                            this.switchToCommonUI();
+                            Core.initializeStacks();
+                            Core.initializeImageDisplay();
+                        } else {
+                            await this.returnToFolderSelection();
+                        }
                     } else {
                         Core.initializeStacks();
                         Core.updateStackCounts();
-                        if (state.imageFiles.length > 0) {
+                        if (hasImages) {
                             await Core.displayCurrentImage();
                         } else {
                             Core.showEmptyState();
@@ -4373,7 +4378,7 @@
                         details: `Delta applied for ${folderId}: ${changedIds.length} updates, ${removedIds.length} removals.`,
                         data: { cloudVersion: updatedCloudVersion }
                     });
-                    return state.imageFiles.length > 0;
+                    return hasImages;
                 } catch (error) {
                     state.syncLog?.log({ event: 'foldersync:delta-error', level: 'error', details: `Delta sync failed: ${error.message}` });
                     Utils.showToast(`Delta sync failed: ${error.message}`, 'error', true);

--- a/ui-v4.html
+++ b/ui-v4.html
@@ -4343,14 +4343,19 @@
                     const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
                     state.sessionVisitedFolders.add(key);
 
+                    const hasImages = state.imageFiles.length > 0;
                     if (!background) {
-                        this.switchToCommonUI();
-                        Core.initializeStacks();
-                        Core.initializeImageDisplay();
+                        if (hasImages) {
+                            this.switchToCommonUI();
+                            Core.initializeStacks();
+                            Core.initializeImageDisplay();
+                        } else {
+                            await this.returnToFolderSelection();
+                        }
                     } else {
                         Core.initializeStacks();
                         Core.updateStackCounts();
-                        if (state.imageFiles.length > 0) {
+                        if (hasImages) {
                             await Core.displayCurrentImage();
                         } else {
                             Core.showEmptyState();
@@ -4373,7 +4378,7 @@
                         details: `Delta applied for ${folderId}: ${changedIds.length} updates, ${removedIds.length} removals.`,
                         data: { cloudVersion: updatedCloudVersion }
                     });
-                    return state.imageFiles.length > 0;
+                    return hasImages;
                 } catch (error) {
                     state.syncLog?.log({ event: 'foldersync:delta-error', level: 'error', details: `Delta sync failed: ${error.message}` });
                     Utils.showToast(`Delta sync failed: ${error.message}`, 'error', true);

--- a/ui-v4a.html
+++ b/ui-v4a.html
@@ -4343,14 +4343,19 @@
                     const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
                     state.sessionVisitedFolders.add(key);
 
+                    const hasImages = state.imageFiles.length > 0;
                     if (!background) {
-                        this.switchToCommonUI();
-                        Core.initializeStacks();
-                        Core.initializeImageDisplay();
+                        if (hasImages) {
+                            this.switchToCommonUI();
+                            Core.initializeStacks();
+                            Core.initializeImageDisplay();
+                        } else {
+                            await this.returnToFolderSelection();
+                        }
                     } else {
                         Core.initializeStacks();
                         Core.updateStackCounts();
-                        if (state.imageFiles.length > 0) {
+                        if (hasImages) {
                             await Core.displayCurrentImage();
                         } else {
                             Core.showEmptyState();
@@ -4373,7 +4378,7 @@
                         details: `Delta applied for ${folderId}: ${changedIds.length} updates, ${removedIds.length} removals.`,
                         data: { cloudVersion: updatedCloudVersion }
                     });
-                    return state.imageFiles.length > 0;
+                    return hasImages;
                 } catch (error) {
                     state.syncLog?.log({ event: 'foldersync:delta-error', level: 'error', details: `Delta sync failed: ${error.message}` });
                     Utils.showToast(`Delta sync failed: ${error.message}`, 'error', true);

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -4343,14 +4343,19 @@
                     const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
                     state.sessionVisitedFolders.add(key);
 
+                    const hasImages = state.imageFiles.length > 0;
                     if (!background) {
-                        this.switchToCommonUI();
-                        Core.initializeStacks();
-                        Core.initializeImageDisplay();
+                        if (hasImages) {
+                            this.switchToCommonUI();
+                            Core.initializeStacks();
+                            Core.initializeImageDisplay();
+                        } else {
+                            await this.returnToFolderSelection();
+                        }
                     } else {
                         Core.initializeStacks();
                         Core.updateStackCounts();
-                        if (state.imageFiles.length > 0) {
+                        if (hasImages) {
                             await Core.displayCurrentImage();
                         } else {
                             Core.showEmptyState();
@@ -4373,7 +4378,7 @@
                         details: `Delta applied for ${folderId}: ${changedIds.length} updates, ${removedIds.length} removals.`,
                         data: { cloudVersion: updatedCloudVersion }
                     });
-                    return state.imageFiles.length > 0;
+                    return hasImages;
                 } catch (error) {
                     state.syncLog?.log({ event: 'foldersync:delta-error', level: 'error', details: `Delta sync failed: ${error.message}` });
                     Utils.showToast(`Delta sync failed: ${error.message}`, 'error', true);

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -4343,14 +4343,19 @@
                     const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
                     state.sessionVisitedFolders.add(key);
 
+                    const hasImages = state.imageFiles.length > 0;
                     if (!background) {
-                        this.switchToCommonUI();
-                        Core.initializeStacks();
-                        Core.initializeImageDisplay();
+                        if (hasImages) {
+                            this.switchToCommonUI();
+                            Core.initializeStacks();
+                            Core.initializeImageDisplay();
+                        } else {
+                            await this.returnToFolderSelection();
+                        }
                     } else {
                         Core.initializeStacks();
                         Core.updateStackCounts();
-                        if (state.imageFiles.length > 0) {
+                        if (hasImages) {
                             await Core.displayCurrentImage();
                         } else {
                             Core.showEmptyState();
@@ -4373,7 +4378,7 @@
                         details: `Delta applied for ${folderId}: ${changedIds.length} updates, ${removedIds.length} removals.`,
                         data: { cloudVersion: updatedCloudVersion }
                     });
-                    return state.imageFiles.length > 0;
+                    return hasImages;
                 } catch (error) {
                     state.syncLog?.log({ event: 'foldersync:delta-error', level: 'error', details: `Delta sync failed: ${error.message}` });
                     Utils.showToast(`Delta sync failed: ${error.message}`, 'error', true);

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -4343,14 +4343,19 @@
                     const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
                     state.sessionVisitedFolders.add(key);
 
+                    const hasImages = state.imageFiles.length > 0;
                     if (!background) {
-                        this.switchToCommonUI();
-                        Core.initializeStacks();
-                        Core.initializeImageDisplay();
+                        if (hasImages) {
+                            this.switchToCommonUI();
+                            Core.initializeStacks();
+                            Core.initializeImageDisplay();
+                        } else {
+                            await this.returnToFolderSelection();
+                        }
                     } else {
                         Core.initializeStacks();
                         Core.updateStackCounts();
-                        if (state.imageFiles.length > 0) {
+                        if (hasImages) {
                             await Core.displayCurrentImage();
                         } else {
                             Core.showEmptyState();
@@ -4373,7 +4378,7 @@
                         details: `Delta applied for ${folderId}: ${changedIds.length} updates, ${removedIds.length} removals.`,
                         data: { cloudVersion: updatedCloudVersion }
                     });
-                    return state.imageFiles.length > 0;
+                    return hasImages;
                 } catch (error) {
                     state.syncLog?.log({ event: 'foldersync:delta-error', level: 'error', details: `Delta sync failed: ${error.message}` });
                     Utils.showToast(`Delta sync failed: ${error.message}`, 'error', true);

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -4343,14 +4343,19 @@
                     const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
                     state.sessionVisitedFolders.add(key);
 
+                    const hasImages = state.imageFiles.length > 0;
                     if (!background) {
-                        this.switchToCommonUI();
-                        Core.initializeStacks();
-                        Core.initializeImageDisplay();
+                        if (hasImages) {
+                            this.switchToCommonUI();
+                            Core.initializeStacks();
+                            Core.initializeImageDisplay();
+                        } else {
+                            await this.returnToFolderSelection();
+                        }
                     } else {
                         Core.initializeStacks();
                         Core.updateStackCounts();
-                        if (state.imageFiles.length > 0) {
+                        if (hasImages) {
                             await Core.displayCurrentImage();
                         } else {
                             Core.showEmptyState();
@@ -4373,7 +4378,7 @@
                         details: `Delta applied for ${folderId}: ${changedIds.length} updates, ${removedIds.length} removals.`,
                         data: { cloudVersion: updatedCloudVersion }
                     });
-                    return state.imageFiles.length > 0;
+                    return hasImages;
                 } catch (error) {
                     state.syncLog?.log({ event: 'foldersync:delta-error', level: 'error', details: `Delta sync failed: ${error.message}` });
                     Utils.showToast(`Delta sync failed: ${error.message}`, 'error', true);

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -4343,14 +4343,19 @@
                     const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
                     state.sessionVisitedFolders.add(key);
 
+                    const hasImages = state.imageFiles.length > 0;
                     if (!background) {
-                        this.switchToCommonUI();
-                        Core.initializeStacks();
-                        Core.initializeImageDisplay();
+                        if (hasImages) {
+                            this.switchToCommonUI();
+                            Core.initializeStacks();
+                            Core.initializeImageDisplay();
+                        } else {
+                            await this.returnToFolderSelection();
+                        }
                     } else {
                         Core.initializeStacks();
                         Core.updateStackCounts();
-                        if (state.imageFiles.length > 0) {
+                        if (hasImages) {
                             await Core.displayCurrentImage();
                         } else {
                             Core.showEmptyState();
@@ -4373,7 +4378,7 @@
                         details: `Delta applied for ${folderId}: ${changedIds.length} updates, ${removedIds.length} removals.`,
                         data: { cloudVersion: updatedCloudVersion }
                     });
-                    return state.imageFiles.length > 0;
+                    return hasImages;
                 } catch (error) {
                     state.syncLog?.log({ event: 'foldersync:delta-error', level: 'error', details: `Delta sync failed: ${error.message}` });
                     Utils.showToast(`Delta sync failed: ${error.message}`, 'error', true);

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -4343,14 +4343,19 @@
                     const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
                     state.sessionVisitedFolders.add(key);
 
+                    const hasImages = state.imageFiles.length > 0;
                     if (!background) {
-                        this.switchToCommonUI();
-                        Core.initializeStacks();
-                        Core.initializeImageDisplay();
+                        if (hasImages) {
+                            this.switchToCommonUI();
+                            Core.initializeStacks();
+                            Core.initializeImageDisplay();
+                        } else {
+                            await this.returnToFolderSelection();
+                        }
                     } else {
                         Core.initializeStacks();
                         Core.updateStackCounts();
-                        if (state.imageFiles.length > 0) {
+                        if (hasImages) {
                             await Core.displayCurrentImage();
                         } else {
                             Core.showEmptyState();
@@ -4373,7 +4378,7 @@
                         details: `Delta applied for ${folderId}: ${changedIds.length} updates, ${removedIds.length} removals.`,
                         data: { cloudVersion: updatedCloudVersion }
                     });
-                    return state.imageFiles.length > 0;
+                    return hasImages;
                 } catch (error) {
                     state.syncLog?.log({ event: 'foldersync:delta-error', level: 'error', details: `Delta sync failed: ${error.message}` });
                     Utils.showToast(`Delta sync failed: ${error.message}`, 'error', true);

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -4343,14 +4343,19 @@
                     const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
                     state.sessionVisitedFolders.add(key);
 
+                    const hasImages = state.imageFiles.length > 0;
                     if (!background) {
-                        this.switchToCommonUI();
-                        Core.initializeStacks();
-                        Core.initializeImageDisplay();
+                        if (hasImages) {
+                            this.switchToCommonUI();
+                            Core.initializeStacks();
+                            Core.initializeImageDisplay();
+                        } else {
+                            await this.returnToFolderSelection();
+                        }
                     } else {
                         Core.initializeStacks();
                         Core.updateStackCounts();
-                        if (state.imageFiles.length > 0) {
+                        if (hasImages) {
                             await Core.displayCurrentImage();
                         } else {
                             Core.showEmptyState();
@@ -4373,7 +4378,7 @@
                         details: `Delta applied for ${folderId}: ${changedIds.length} updates, ${removedIds.length} removals.`,
                         data: { cloudVersion: updatedCloudVersion }
                     });
-                    return state.imageFiles.length > 0;
+                    return hasImages;
                 } catch (error) {
                     state.syncLog?.log({ event: 'foldersync:delta-error', level: 'error', details: `Delta sync failed: ${error.message}` });
                     Utils.showToast(`Delta sync failed: ${error.message}`, 'error', true);


### PR DESCRIPTION
## Summary
- gate the delta-sync UI transition on folders still containing images across all entry points
- keep the folder picker visible by returning to selection before reporting an empty delta
- reuse a cached `hasImages` flag when initializing the viewer and reporting delta results

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2537a6da0832d8ced0eeee56c85e1