### PR TITLE
Handle empty background delta with folder selection

### DIFF
--- a/ui-v7.html
+++ b/ui-v7.html
@@ -4353,12 +4353,12 @@
                             await this.returnToFolderSelection();
                         }
                     } else {
-                        Core.initializeStacks();
-                        Core.updateStackCounts();
                         if (hasImages) {
+                            Core.initializeStacks();
+                            Core.updateStackCounts();
                             await Core.displayCurrentImage();
                         } else {
-                            Core.showEmptyState();
+                            await this.returnToFolderSelection();
                         }
                     }
 


### PR DESCRIPTION
## Summary
- avoid reinitializing stacks during background sync when the last image was removed
- return to the folder picker when no images remain so the viewer stays consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e26632e718832d9ad1a5a6ce85a3c6