### PR TITLE
Handle missing folder timestamps in ui-v7

### DIFF
--- a/ui-v7.html
+++ b/ui-v7.html
@@ -6774,11 +6774,25 @@ this.updateImageCounters();
                     return;
                 }
 
+                const formatFolderDate = (folderData) => {
+                    const timestamp = folderData?.modifiedTime || folderData?.createdTime;
+                    if (!timestamp) {
+                        return 'Date unavailable';
+                    }
+
+                    const parsedTime = Date.parse(timestamp);
+                    if (Number.isNaN(parsedTime)) {
+                        return 'Date unavailable';
+                    }
+
+                    return new Date(parsedTime).toLocaleDateString();
+                };
+
                 folders.forEach(folder => {
                     const div = document.createElement('div');
                     div.className = 'folder-item';
 
-                    let dateInfo = new Date(folder.modifiedTime).toLocaleDateString();
+                    let dateInfo = formatFolderDate(folder);
                     if (folder.itemCount > 0) {
                          dateInfo += ` • ${folder.itemCount} items`;
                     }


### PR DESCRIPTION
## Summary
- guard folder timestamp parsing in the folder list UI to avoid RangeErrors
- supply a "Date unavailable" placeholder while preserving existing suffix details

## Testing
- node - <<'NODE' ...

------
https://chatgpt.com/codex/tasks/task_e_68e27a3658b0832d9400435a0c4f2ac0