### PR TITLE
Gracefully handle folders with missing timestamps

### DIFF
--- a/ui-v7.html
+++ b/ui-v7.html
@@ -6822,7 +6822,7 @@ this.updateImageCounters();
                 }
 
                 const formatFolderDate = (folderData) => {
-                    const timestamp = folderData?.modifiedTime || folderData?.createdTime;
+                    const timestamp = folderData?.modifiedTime ?? folderData?.createdTime;
                     if (!timestamp) {
                         return 'Date unavailable';
                     }
@@ -6839,13 +6839,14 @@ this.updateImageCounters();
                     const div = document.createElement('div');
                     div.className = 'folder-item';
 
-                    let dateInfo = formatFolderDate(folder);
+                    const dateInfoParts = [formatFolderDate(folder)];
                     if (folder.itemCount > 0) {
-                         dateInfo += ` • ${folder.itemCount} items`;
+                        dateInfoParts.push(`${folder.itemCount} items`);
                     }
                     if (folder.hasChildren) {
-                        dateInfo += ` • Has subfolders`;
+                        dateInfoParts.push('Has subfolders');
                     }
+                    const dateInfo = dateInfoParts.join(' • ');
 
                     const iconColor = folder.hasChildren ? 'var(--accent)' : 'rgba(255, 255, 255, 0.6)';
 


### PR DESCRIPTION
## Summary
- guard folder timestamp formatting with a helper that validates modified/created times before display
- keep folder item counts and children indicators while falling back to a safe placeholder when no valid date exists

## Testing
- node <<'NODE'
const formatFolderDate = (folderData) => {
  const timestamp = folderData?.modifiedTime ?? folderData?.createdTime;
  if (!timestamp) {
    return 'Date unavailable';
  }

  const parsedTime = Date.parse(timestamp);
  if (Number.isNaN(parsedTime)) {
    return 'Date unavailable';
  }

  return new Date(parsedTime).toLocaleDateString();
};

console.log('Valid modified:', formatFolderDate({ modifiedTime: '2023-01-01T00:00:00Z' }));
console.log('Valid created:', formatFolderDate({ createdTime: '2022-05-05T12:00:00Z' }));
console.log('Invalid modified:', formatFolderDate({ modifiedTime: 'not-a-date' }));
console.log('Missing timestamps:', formatFolderDate({}));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68e2876ced50832d9aa4ca2067acec09