### PR TITLE
Ensure Google Drive mutations include shared drive params

### DIFF
--- a/ui-v7.html
+++ b/ui-v7.html
@@ -3929,13 +3929,13 @@
                 return this.getFolders();
             }
             async moveFileToFolder(fileId, targetFolderId) {
-                const file = await this.makeApiCall(`/files/${fileId}?fields=parents`);
+                const file = await this.makeApiCall(`/files/${fileId}?fields=parents&supportsAllDrives=true&includeItemsFromAllDrives=true`);
                 const previousParents = file.parents.join(',');
-                await this.makeApiCall(`/files/${fileId}?addParents=${targetFolderId}&removeParents=${previousParents}&fields=id,parents`, { method: 'PATCH' });
+                await this.makeApiCall(`/files/${fileId}?addParents=${targetFolderId}&removeParents=${previousParents}&fields=id,parents&supportsAllDrives=true&includeItemsFromAllDrives=true`, { method: 'PATCH' });
                 return true;
             }
             async updateFileMetadata(fileId, metadata) {
-                await this.makeApiCall(`/files/${fileId}`, { method: 'PATCH', body: JSON.stringify({ appProperties: metadata }) });
+                await this.makeApiCall(`/files/${fileId}?supportsAllDrives=true&includeItemsFromAllDrives=true`, { method: 'PATCH', body: JSON.stringify({ appProperties: metadata }) });
                 return true;
             }
             async updateUserMetadata(fileId, updates) {
@@ -3947,7 +3947,7 @@
             }
 
             async deleteFile(fileId) {
-                await this.makeApiCall(`/files/${fileId}`, { method: 'PATCH', body: JSON.stringify({ trashed: true }) });
+                await this.makeApiCall(`/files/${fileId}?supportsAllDrives=true&includeItemsFromAllDrives=true`, { method: 'PATCH', body: JSON.stringify({ trashed: true }) });
                 return true;
             }
             async disconnect() {


### PR DESCRIPTION
## Summary
- append supportsAllDrives/includeItemsFromAllDrives to Google Drive move, metadata update, and delete requests so shared-drive items work

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2e13bc21c832dbd2c55babf575648