### PR TITLE
Restore toast overlay for ui v9b

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -436,7 +436,7 @@
         .copy-button:hover { background: #d97706; transform: translateY(-1px); box-shadow: 0 2px 4px rgba(245, 158, 11, 0.3); }
         .copy-button:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(245, 158, 11, 0.3); }
         .copy-button.copied { background: #10b981; transform: scale(1.1); }
-.app-footer {
+        .app-footer {
             position: fixed;
             bottom: 0;
             left: 0;
@@ -456,39 +456,27 @@
         .app-footer .footer-baseline {
             color: rgba(255, 255, 255, 0.6);
         }
-        .app-footer .footer-status {
-            position: absolute;
-            inset: 4px 12px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            padding: 6px 14px;
-            border-radius: 9999px;
-            background: rgba(0, 0, 0, 0.85);
-            color: rgba(255, 255, 255, 0.95);
-            font-size: 12px;
+        .toast {
+            position: fixed;
+            bottom: 20px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(0, 0, 0, 0.8);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 8px;
+            font-size: 14px;
             font-weight: 500;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            z-index: 2000;
             opacity: 0;
+            transition: opacity 0.3s ease;
+            backdrop-filter: blur(10px);
             pointer-events: none;
-            transition: opacity 0.2s ease;
-            white-space: nowrap;
-            max-width: calc(100% - 24px);
-            overflow: hidden;
-            text-overflow: ellipsis;
         }
-        .app-footer .footer-status.active {
-            opacity: 1;
-        }
-        .app-footer .footer-status.success {
-            background: rgba(16, 185, 129, 0.9);
-        }
-        .app-footer .footer-status.info {
-            background: rgba(59, 130, 246, 0.9);
-        }
-        .app-footer .footer-status.error {
-            background: rgba(239, 68, 68, 0.9);
-        }
+        .toast.show { opacity: 1; pointer-events: auto; }
+        .toast.success { background: rgba(16, 185, 129, 0.9); }
+        .toast.info { background: rgba(59, 130, 246, 0.9); }
+        .toast.error { background: rgba(239, 68, 68, 0.9); }
         .app-footer .footer-link {
             background: transparent;
             border: none;
@@ -723,7 +711,6 @@
         </div>
         <div class="app-footer">
             <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
-            <span class="footer-status" aria-live="polite"></span>
         </div>
     </div>
     
@@ -741,7 +728,6 @@
         </div>
         <div class="app-footer">
             <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
-            <span class="footer-status" aria-live="polite"></span>
         </div>
     </div>
     
@@ -759,7 +745,6 @@
         </div>
         <div class="app-footer">
             <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
-            <span class="footer-status" aria-live="polite"></span>
         </div>
     </div>
     
@@ -776,7 +761,6 @@
         </div>
         <div class="app-footer">
             <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
-            <span class="footer-status" aria-live="polite"></span>
         </div>
     </div>
     
@@ -843,10 +827,11 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
             </svg>
         </button>
-        
+
+        <div id="toast" class="toast"></div>
+
         <div class="app-footer">
             <span class="footer-baseline">Orbital8-O-2025-10-12 09:30 AM · v9</span>
-            <span class="footer-status" aria-live="polite"></span>
         </div>
     </div>
     
@@ -1173,6 +1158,7 @@
                     emptyState: document.getElementById('empty-state'),
                     selectAnotherStackBtn: document.getElementById('select-another-stack-btn'),
                     selectAnotherFolderBtn: document.getElementById('select-another-folder-btn'),
+                    toast: document.getElementById('toast'),
                     
                     centerTrashBtn: document.getElementById('center-trash-btn'),
                     focusStackName: document.getElementById('focus-stack-name'),
@@ -1274,33 +1260,28 @@
                     return;
                 }
                 if (!important && Math.random() < 0.7) return;
-                const statusElements = [];
-                document.querySelectorAll('.app-footer').forEach(footer => {
-                    let statusSpan = footer.querySelector('.footer-status');
-                    if (!statusSpan) {
-                        statusSpan = document.createElement('span');
-                        statusSpan.className = 'footer-status';
-                        statusSpan.setAttribute('aria-live', 'polite');
-                        footer.appendChild(statusSpan);
-                    }
-                    statusSpan.textContent = message;
-                    statusSpan.classList.remove('active', 'success', 'error', 'info');
-                    statusSpan.classList.add('active', type);
-                    statusElements.push(statusSpan);
-                });
-                if (statusElements.length === 0) {
+
+                const toast = this.elements.toast || document.getElementById('toast');
+                if (!toast) {
                     return;
                 }
+
+                toast.textContent = message;
+                toast.classList.remove('show', 'success', 'info', 'error');
+                toast.classList.add('show');
+                if (type) {
+                    toast.classList.add(type);
+                }
+
                 if (this._toastHideTimer) {
                     clearTimeout(this._toastHideTimer);
                 }
                 this._toastHideTimer = setTimeout(() => {
-                    statusElements.forEach(statusSpan => {
-                        statusSpan.textContent = '';
-                        statusSpan.classList.remove('active', 'success', 'error', 'info');
-                    });
+                    toast.classList.remove('show', 'success', 'info', 'error');
+                    toast.textContent = '';
                     this._toastHideTimer = null;
                 }, 3000);
+
                 if (important && state.haptic) {
                     const hapticType = type === 'error' ? 'error' : 'buttonPress';
                     state.haptic.triggerFeedback(hapticType);
@@ -1312,10 +1293,12 @@
                     clearTimeout(this._toastHideTimer);
                     this._toastHideTimer = null;
                 }
-                document.querySelectorAll('.app-footer .footer-status').forEach(statusSpan => {
-                    statusSpan.textContent = '';
-                    statusSpan.classList.remove('active', 'success', 'error', 'info');
-                });
+
+                const toast = this.elements.toast || document.getElementById('toast');
+                if (toast) {
+                    toast.classList.remove('show', 'success', 'info', 'error');
+                    toast.textContent = '';
+                }
             },
             
             async setImageSrc(img, file) {


### PR DESCRIPTION
## Summary
- replace per-footer toast spans with the shared toast overlay structure in ui-v9b
- update utility toast helpers to drive the restored overlay node
- remove unused footer status handling while keeping baseline text in each footer

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e334c648c8832da8849b287b9cdf74