### PR TITLE
Prevent toasts from overlapping trash counter

### DIFF
--- a/performance.html
+++ b/performance.html
@@ -119,7 +119,7 @@
         .status.info { background: rgba(59, 130, 246, 0.2); color: #3b82f6; border: 1px solid rgba(59, 130, 246, 0.3); }
         
         .toast {
-            position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
+            position: fixed; bottom: calc(env(safe-area-inset-bottom, 0px) + 84px); left: 50%; transform: translateX(-50%);
             background: rgba(0, 0, 0, 0.8); color: white; padding: 12px 20px; border-radius: 8px;
             font-size: 14px; font-weight: 500; z-index: 2000; opacity: 0; transition: opacity 0.3s ease; backdrop-filter: blur(10px);
         }
@@ -225,6 +225,7 @@
         .pill-counter:hover { opacity: 1; transform: scale(1.05); }
         .pill-counter.top { top: 10px; left: 50%; transform: translateX(-50%); }
         .pill-counter.bottom-center { bottom: 20px; left: 50%; transform: translateX(-50%); }
+        .app-container.toast-visible .pill-counter.bottom-center { transform: translate(-50%, calc(-48px - env(safe-area-inset-bottom, 0px))); }
         .pill-counter.left { left: 10px; top: 50%; transform: translateY(-50%); }
         .pill-counter.right { right: 10px; top: 50%; transform: translateY(-50%); }
         
@@ -1262,9 +1263,12 @@
             
             showToast(message, type = 'success', important = false) {
                 if (!important && Math.random() < 0.7) return;
-                const toast = this.elements.toast;
+                const { toast, appContainer } = this.elements;
                 toast.textContent = message;
                 toast.className = `toast ${type} show`;
+                if (appContainer) {
+                    appContainer.classList.add('toast-visible');
+                }
                 const footers = Array.from(document.querySelectorAll('.app-footer'));
                 const footerStatuses = footers.map(footer => {
                     let statusSpan = footer.querySelector('.footer-status');
@@ -1297,6 +1301,9 @@
                 }
                 this._toastHideTimer = setTimeout(() => {
                     toast.classList.remove('show');
+                    if (appContainer) {
+                        appContainer.classList.remove('toast-visible');
+                    }
                     footerStatuses.forEach(({ statusSpan, baselineText }) => {
                         statusSpan.textContent = baselineText;
                         statusSpan.classList.remove('success', 'error', 'info');


### PR DESCRIPTION
## Summary
- lift the toast overlay to account for the trash counter and safe-area insets
- offset the trash pill while a toast is visible to keep the UI clear
- toggle a toast-visible class from Utils.showToast so layout reacts to overlay visibility

## Testing
- Manual: opened performance.html locally and triggered a toast

------
https://chatgpt.com/codex/tasks/task_e_68e334ccda20832d80f7f431f1bb1be8