### PR TITLE
Fix focus mode exit from resetting to first image

### DIFF
--- a/index.html
+++ b/index.html
@@ -6353,15 +6353,13 @@ this.updateImageCounters();
                 if (!state.isFocusMode) {
                     const currentStackArray = state.stacks[state.currentStack];
                     if (currentStackArray && currentStackArray.length > 0) {
-                        const currentFile = currentStackArray[state.currentStackPosition];
-                        if (currentFile) {
-                            const currentIndex = currentStackArray.findIndex(file => file.id === currentFile.id);
-                            if (currentIndex > 0) {
-                                const [item] = currentStackArray.splice(currentIndex, 1);
-                                currentStackArray.unshift(item);
-                            }
+                        if (state.currentStackPosition >= currentStackArray.length) {
+                            state.currentStackPosition = currentStackArray.length - 1;
+                        } else if (state.currentStackPosition < 0) {
                             state.currentStackPosition = 0;
                         }
+                    } else {
+                        state.currentStackPosition = 0;
                     }
                     Core.displayCurrentImage();
                 }


### PR DESCRIPTION
## Summary
- stop reordering the active stack when leaving focus mode so the current image stays in place
- clamp the stored stack index to a valid range before redrawing the image viewer

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68e33b471ac8832d92cd12d9c1ae0866