### PR TITLE
Fix focus mode exit regression in v9b

### DIFF
--- a/index.html
+++ b/index.html
@@ -6353,15 +6353,13 @@ this.updateImageCounters();
                 if (!state.isFocusMode) {
                     const currentStackArray = state.stacks[state.currentStack];
                     if (currentStackArray && currentStackArray.length > 0) {
-                        const currentFile = currentStackArray[state.currentStackPosition];
-                        if (currentFile) {
-                            const currentIndex = currentStackArray.findIndex(file => file.id === currentFile.id);
-                            if (currentIndex > 0) {
-                                const [item] = currentStackArray.splice(currentIndex, 1);
-                                currentStackArray.unshift(item);
-                            }
+                        if (state.currentStackPosition >= currentStackArray.length) {
+                            state.currentStackPosition = currentStackArray.length - 1;
+                        } else if (state.currentStackPosition < 0) {
                             state.currentStackPosition = 0;
                         }
+                    } else {
+                        state.currentStackPosition = 0;
                     }
                     Core.displayCurrentImage();
                 }

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -6336,15 +6336,13 @@ this.updateImageCounters();
                 if (!state.isFocusMode) {
                     const currentStackArray = state.stacks[state.currentStack];
                     if (currentStackArray && currentStackArray.length > 0) {
-                        const currentFile = currentStackArray[state.currentStackPosition];
-                        if (currentFile) {
-                            const currentIndex = currentStackArray.findIndex(file => file.id === currentFile.id);
-                            if (currentIndex > 0) {
-                                const [item] = currentStackArray.splice(currentIndex, 1);
-                                currentStackArray.unshift(item);
-                            }
+                        if (state.currentStackPosition >= currentStackArray.length) {
+                            state.currentStackPosition = currentStackArray.length - 1;
+                        } else if (state.currentStackPosition < 0) {
                             state.currentStackPosition = 0;
                         }
+                    } else {
+                        state.currentStackPosition = 0;
                     }
                     Core.displayCurrentImage();
                 }


### PR DESCRIPTION
## Summary
- mirror the focus mode exit clamping logic in ui-v9b so the viewer stays on the current image after leaving focus mode

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e33b471ac8832d92cd12d9c1ae0866