### PR TITLE
Fix default stack sequencing for uninitialized folders

### DIFF
--- a/index.html
+++ b/index.html
@@ -4577,7 +4577,7 @@
                         if (metadata) {
                             Object.assign(file, metadata);
                         } else {
-                            const defaultMetadata = this.generateDefaultMetadata(file);
+                            const defaultMetadata = this.generateDefaultMetadata(file, { index: i, total: files.length });
                             Object.assign(file, defaultMetadata);
                             await state.dbManager.saveMetadata(file.id, defaultMetadata, { folderId: state.currentFolder.id, providerType: state.providerType });
                         }
@@ -4588,12 +4588,12 @@
                 }
                 this.extractMetadataInBackground(files.filter(f => f.mimeType === 'image/png'));
             },
-            generateDefaultMetadata(file) {
-                 const baseMetadata = { 
-                    stack: 'in', 
-                    tags: [], 
-                    qualityRating: 0, 
-                    contentRating: 0, 
+            generateDefaultMetadata(file, context = {}) {
+                 const baseMetadata = {
+                    stack: 'in',
+                    tags: [],
+                    qualityRating: 0,
+                    contentRating: 0,
                     notes: '', 
                     stackSequence: 0, 
                     favorite: false,
@@ -4608,6 +4608,19 @@
                     baseMetadata.notes = file.appProperties.notes || '';
                     baseMetadata.stackSequence = parseInt(file.appProperties.stackSequence) || 0;
                     baseMetadata.favorite = file.appProperties.favorite === 'true';
+                 }
+                 const numericSequence = Number(baseMetadata.stackSequence);
+                 if (!Number.isFinite(numericSequence) || numericSequence === 0) {
+                    const timestampSource = file.modifiedTime || file.createdTime || null;
+                    let fallbackSequence = Date.now();
+                    if (timestampSource) {
+                        const parsed = Date.parse(timestampSource);
+                        if (!Number.isNaN(parsed)) {
+                            fallbackSequence = parsed;
+                        }
+                    }
+                    const indexOffset = typeof context.index === 'number' ? context.index : 0;
+                    baseMetadata.stackSequence = fallbackSequence - indexOffset;
                  }
                  return baseMetadata;
             },

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -4560,7 +4560,7 @@
                         if (metadata) {
                             Object.assign(file, metadata);
                         } else {
-                            const defaultMetadata = this.generateDefaultMetadata(file);
+                            const defaultMetadata = this.generateDefaultMetadata(file, { index: i, total: files.length });
                             Object.assign(file, defaultMetadata);
                             await state.dbManager.saveMetadata(file.id, defaultMetadata, { folderId: state.currentFolder.id, providerType: state.providerType });
                         }
@@ -4571,12 +4571,12 @@
                 }
                 this.extractMetadataInBackground(files.filter(f => f.mimeType === 'image/png'));
             },
-            generateDefaultMetadata(file) {
-                 const baseMetadata = { 
-                    stack: 'in', 
-                    tags: [], 
-                    qualityRating: 0, 
-                    contentRating: 0, 
+            generateDefaultMetadata(file, context = {}) {
+                 const baseMetadata = {
+                    stack: 'in',
+                    tags: [],
+                    qualityRating: 0,
+                    contentRating: 0,
                     notes: '', 
                     stackSequence: 0, 
                     favorite: false,
@@ -4591,6 +4591,19 @@
                     baseMetadata.notes = file.appProperties.notes || '';
                     baseMetadata.stackSequence = parseInt(file.appProperties.stackSequence) || 0;
                     baseMetadata.favorite = file.appProperties.favorite === 'true';
+                 }
+                 const numericSequence = Number(baseMetadata.stackSequence);
+                 if (!Number.isFinite(numericSequence) || numericSequence === 0) {
+                    const timestampSource = file.modifiedTime || file.createdTime || null;
+                    let fallbackSequence = Date.now();
+                    if (timestampSource) {
+                        const parsed = Date.parse(timestampSource);
+                        if (!Number.isNaN(parsed)) {
+                            fallbackSequence = parsed;
+                        }
+                    }
+                    const indexOffset = typeof context.index === 'number' ? context.index : 0;
+                    baseMetadata.stackSequence = fallbackSequence - indexOffset;
                  }
                  return baseMetadata;
             },


### PR DESCRIPTION
## Summary
- assign unique stackSequence values from file timestamps when cached metadata is missing
- update metadata generation to accept positional context so first-time loads preserve ordering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2e705db00832d915170fc5834b59d