### PR TITLE
Handle empty cloud folders without leaving viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -4423,9 +4423,37 @@
                     if (mergedFiles.length === 0) {
                         await state.dbManager.saveFolderCache(folderId, []);
                         state.imageFiles = [];
+                        const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
+                        state.sessionVisitedFolders.add(key);
+                        this.switchToCommonUI();
+                        Core.initializeStacks();
+                        Core.showEmptyState();
+                        Core.updateStackCounts();
+
+                        if (coordinator) {
+                            const manifestEntries = coordinator.buildManifestFromFiles(folderId, []);
+                            const fallbackVersion = preparation?.folderState?.cloudVersion ?? Date.now();
+                            const manifestPayload = {
+                                entries: manifestEntries,
+                                requiresFullResync: false,
+                                cloudVersion: fallbackVersion,
+                                localVersion: preparation?.folderState?.localVersion ?? fallbackVersion,
+                                manifestFileId: preparation?.localManifest?.manifestFileId || null
+                            };
+                            await coordinator.persistManifest(folderId, manifestPayload, {
+                                cloudVersion: manifestPayload.cloudVersion,
+                                localVersion: manifestPayload.localVersion,
+                                lastDiffSummary: { new: 0, updated: 0, removed: cachedFiles.length }
+                            });
+                            await coordinator.persistFolderState(folderId, {
+                                cloudVersion: manifestPayload.cloudVersion,
+                                localVersion: manifestPayload.localVersion,
+                                lastCloudAck: Date.now()
+                            });
+                        }
+
                         Utils.showToast('No images found in this folder', 'info', true);
-                        this.returnToFolderSelection();
-                        return false;
+                        return true;
                     }
 
                     for (const updatedId of updatedIds) {

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -4406,9 +4406,37 @@
                     if (mergedFiles.length === 0) {
                         await state.dbManager.saveFolderCache(folderId, []);
                         state.imageFiles = [];
+                        const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
+                        state.sessionVisitedFolders.add(key);
+                        this.switchToCommonUI();
+                        Core.initializeStacks();
+                        Core.showEmptyState();
+                        Core.updateStackCounts();
+
+                        if (coordinator) {
+                            const manifestEntries = coordinator.buildManifestFromFiles(folderId, []);
+                            const fallbackVersion = preparation?.folderState?.cloudVersion ?? Date.now();
+                            const manifestPayload = {
+                                entries: manifestEntries,
+                                requiresFullResync: false,
+                                cloudVersion: fallbackVersion,
+                                localVersion: preparation?.folderState?.localVersion ?? fallbackVersion,
+                                manifestFileId: preparation?.localManifest?.manifestFileId || null
+                            };
+                            await coordinator.persistManifest(folderId, manifestPayload, {
+                                cloudVersion: manifestPayload.cloudVersion,
+                                localVersion: manifestPayload.localVersion,
+                                lastDiffSummary: { new: 0, updated: 0, removed: cachedFiles.length }
+                            });
+                            await coordinator.persistFolderState(folderId, {
+                                cloudVersion: manifestPayload.cloudVersion,
+                                localVersion: manifestPayload.localVersion,
+                                lastCloudAck: Date.now()
+                            });
+                        }
+
                         Utils.showToast('No images found in this folder', 'info', true);
-                        this.returnToFolderSelection();
-                        return false;
+                        return true;
                     }
 
                     for (const updatedId of updatedIds) {


### PR DESCRIPTION
## Summary
- keep the viewer active when a synced folder contains no images so users see the empty-state UI
- persist empty-folder manifest metadata so cached state stays aligned with the cloud

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2e705db00832d915170fc5834b59d