### PR TITLE
Ensure folder flushes bump cloud versions monotonically

### DIFF
--- a/tests/manual/folder-sync-version-regression.md
+++ b/tests/manual/folder-sync-version-regression.md
@@ -1,0 +1,68 @@
+# Folder Sync version regression check
+
+This manual regression script verifies that a local flush updates the cached `cloudVersion` across tabs/devices that share the same IndexedDB cache.
+
+## Prerequisites
+
+1. Build/serve `ui-v9b.html` and sign into the same provider in two browser contexts (Device A and Device B). A second tab in the same browser profile works because it reuses the cache.
+2. Select the same folder in both tabs so they point at identical cached data.
+3. Open the developer console in both tabs. The UI now exposes `window.__orbitalAppState`, `window.__orbitalFolderSyncCoordinator`, and `window.__orbitalDbManager` for debugging helpers.
+
+## Device B – start the probe
+
+Run the following helper first on Device B. It records the current `cloudVersion`, waits for Device A to broadcast that a flush occurred, and asserts the cached state increased immediately.
+
+```js
+(async function foldersyncProbeB(channelName = 'foldersync-version-regression') {
+  const coordinator = window.__orbitalFolderSyncCoordinator;
+  if (!coordinator) throw new Error('FolderSyncCoordinator is not available. Open a folder first.');
+  const folderId = window.__orbitalAppState.currentFolder?.id;
+  if (!folderId) throw new Error('Select a folder before running the probe.');
+  const context = coordinator.buildContext(folderId);
+  const db = window.__orbitalDbManager;
+  const beforeState = await db.getFolderState(context);
+  const beforeCloud = Number(beforeState?.cloudVersion || 0);
+  console.log('[Device B] cloudVersion before flush:', beforeCloud);
+  await new Promise((resolve, reject) => {
+    const channel = new BroadcastChannel(channelName);
+    const timeout = setTimeout(() => {
+      channel.close();
+      reject(new Error('Timed out waiting for Device A to flush.'));
+    }, 8000);
+    channel.onmessage = async (event) => {
+      if (!event?.data || event.data.type !== 'foldersync:flush-recorded') return;
+      if (event.data.folderId !== folderId) return;
+      clearTimeout(timeout);
+      channel.close();
+      const afterState = await db.getFolderState(context);
+      const afterCloud = Number(afterState?.cloudVersion || 0);
+      console.log('[Device B] cloudVersion after flush:', afterCloud);
+      console.assert(afterCloud > beforeCloud, `Expected cloudVersion ${afterCloud} to exceed ${beforeCloud}`);
+      resolve();
+    };
+    channel.postMessage({ type: 'foldersync:probe-ready', folderId });
+  });
+})().catch((error) => console.error('Device B probe failed:', error));
+```
+
+## Device A – perform the flush
+
+Immediately after the probe is running on Device B, execute the following snippet on Device A to trigger a local flush and broadcast the chosen version.
+
+```js
+(async function foldersyncProbeA(channelName = 'foldersync-version-regression') {
+  const coordinator = window.__orbitalFolderSyncCoordinator;
+  if (!coordinator) throw new Error('FolderSyncCoordinator is not available. Open a folder first.');
+  const folderId = window.__orbitalAppState.currentFolder?.id;
+  if (!folderId) throw new Error('Select a folder before running the probe.');
+  const nextVersion = await coordinator.recordLocalFlush(folderId, { timestamp: Date.now() });
+  console.log('[Device A] flushed folder version:', nextVersion);
+  const channel = new BroadcastChannel(channelName);
+  channel.postMessage({ type: 'foldersync:flush-recorded', folderId, nextVersion });
+  channel.close();
+})();
+```
+
+## Expected result
+
+Device B should immediately log a higher `cloudVersion` and the console assertion should pass without throwing. If the assertion fails, the regression fix is broken.

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -2773,11 +2773,14 @@
                 const timestamp = options.timestamp || Date.now();
                 const context = this.buildContext(folderId);
                 const existing = await this.dbManager.getFolderState(context) || { ...context, folderId, localVersion: 0, cloudVersion: 0 };
-                let nextVersion = Number(existing.localVersion || 0) + 1;
+                const currentLocalVersion = Number(existing.localVersion || 0);
+                const currentCloudVersion = Number(existing.cloudVersion || 0);
+                const baselineVersion = Math.max(currentLocalVersion, currentCloudVersion);
+                let nextVersion = Math.max(Date.now(), baselineVersion + 1);
                 if (options.targetVersion != null) {
                     const numericTarget = Number(options.targetVersion);
-                    if (!Number.isNaN(numericTarget) && numericTarget > Number(existing.localVersion || 0)) {
-                        nextVersion = numericTarget;
+                    if (!Number.isNaN(numericTarget)) {
+                        nextVersion = Math.max(nextVersion, numericTarget);
                     }
                 }
                 await this.dbManager.saveFolderState({ ...existing, ...context, folderId, localVersion: nextVersion, cloudVersion: nextVersion, lastLocalMutation: timestamp, lastCloudAck: timestamp });
@@ -7147,6 +7150,10 @@ this.updateImageCounters();
                 state.folderSyncCoordinator = new FolderSyncCoordinator({ dbManager: state.dbManager, logger: state.syncLog });
                 state.folderSyncCoordinator.setDeltaHandler((payload) => App.applyDeltaFromCoordinator(payload));
                 state.syncManager = new SyncManager({ dbManager: state.dbManager, logger: state.syncLog });
+                window.__orbitalAppState = state;
+                window.__orbitalFolderSyncCoordinator = state.folderSyncCoordinator;
+                window.__orbitalDbManager = state.dbManager;
+                window.__orbitalSyncManager = state.syncManager;
                 state.syncManager.start();
                 state.metadataExtractor = new MetadataExtractor();
                 Utils.showScreen('provider-screen');


### PR DESCRIPTION
## Summary
- compute the next folder version using a timestamp floor so every flush exceeds cached peers
- expose the app state for debugging helpers and document a manual regression probe for cross-tab cloudVersion checks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3902d7e68832d89aed342e3211617