### PR TITLE
Simplify folder preparation and remove delta sync handling

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -1024,7 +1024,6 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
-            pendingBackgroundProbe: null,
             showDebugToasts: true
         };
         const DriveLinkHelper = {
@@ -2417,9 +2416,6 @@
                 this.provider = null;
                 this.providerType = null;
                 this.lastSyncAppliedCount = 0;
-                this.deltaHandler = null;
-                this.backgroundProbes = new Map();
-                this.backgroundProbeDelay = 500;
             }
             setDbManager(dbManager) { this.dbManager = dbManager; }
             setLogger(logger) { this.logger = logger; }
@@ -2432,7 +2428,6 @@
                     details: this.provider ? `Coordinator bound to ${providerType}` : 'Cleared provider context.'
                 });
             }
-            setDeltaHandler(callback) { this.deltaHandler = typeof callback === 'function' ? callback : null; }
             buildContext(folderId) {
                 return { providerType: this.providerType || state.providerType || null, folderId };
             }
@@ -2441,73 +2436,110 @@
                 if (!this.dbManager) {
                     return { mode: 'full', reason: 'no-db' };
                 }
+
                 const context = this.buildContext(folderId);
-                const [folderState, localManifest] = await Promise.all([
+                let [folderState, localManifest] = await Promise.all([
                     this.dbManager.getFolderState(context),
                     this.dbManager.getFolderManifest(context)
                 ]);
 
-                if (forceFullResync) {
-                    this.logger?.log({ event: 'foldersync:prepare', level: 'warn', details: `Full resync forced for ${folderId}.` });
-                    if (localManifest) {
-                        await this.dbManager.saveFolderManifest({ ...localManifest, ...context, requiresFullResync: true });
-                    }
-                    return { mode: 'full', folderState, localManifest, reason: 'force' };
+                if (forceFullResync && localManifest) {
+                    await this.dbManager.saveFolderManifest({ ...localManifest, ...context, requiresFullResync: true });
                 }
 
-                if (!folderState || !localManifest) {
-                    this.logger?.log({ event: 'foldersync:coldstart', level: 'warn', details: `No cached state for ${folderId}; performing full scan.` });
+                let remoteVersion = null;
+                let manifestFileId = localManifest?.manifestFileId || null;
+
+                if (this.provider && typeof this.provider.getFolderVersion === 'function') {
+                    try {
+                        const versionInfo = await this.provider.getFolderVersion(folderId, options);
+                        if (versionInfo) {
+                            const numericVersion = Number(versionInfo.cloudVersion ?? versionInfo.version ?? versionInfo.localVersion ?? versionInfo);
+                            remoteVersion = Number.isFinite(numericVersion) ? numericVersion : null;
+                            if (versionInfo.manifestFileId) {
+                                manifestFileId = versionInfo.manifestFileId;
+                            }
+                            if (remoteVersion != null) {
+                                this.logger?.log({
+                                    event: 'foldersync:version-check',
+                                    level: 'info',
+                                    details: `Remote version ${remoteVersion} reported for ${folderId}.`
+                                });
+                            }
+                        }
+                    } catch (error) {
+                        this.logger?.log({ event: 'foldersync:version-check:error', level: 'warn', details: `Version probe failed for ${folderId}: ${error.message}` });
+                    }
+                }
+
+                const hasState = Boolean(folderState);
+                const hasManifest = Boolean(localManifest);
+                const manifestFlagged = Boolean(localManifest?.requiresFullResync);
+                const localVersion = Number(folderState?.cloudVersion ?? localManifest?.cloudVersion ?? 0) || 0;
+                const requiresManifest = forceFullResync || manifestFlagged || !hasState || !hasManifest || (remoteVersion != null && remoteVersion !== localVersion);
+
+                if (requiresManifest) {
+                    const reason = forceFullResync ? 'force' : (!hasState || !hasManifest ? 'cold-start' : manifestFlagged ? 'manifest-flag' : 'version-mismatch');
                     let remoteManifest = null;
                     try {
-                        remoteManifest = await this.fetchRemoteManifest(folderId, { reason: 'cold-start' });
+                        remoteManifest = await this.fetchRemoteManifest(folderId, { manifestFileId });
                     } catch (error) {
-                        this.logger?.log({ event: 'foldersync:coldstart:manifest-error', level: 'warn', details: `Failed to prefetch manifest for ${folderId}: ${error.message}` });
+                        this.logger?.log({ event: 'foldersync:manifest-fetch:error', level: 'warn', details: `Manifest fetch failed during prepare for ${folderId}: ${error.message}` });
                     }
-                    const manifestFileId = remoteManifest?.manifestFileId || null;
-                    return { mode: 'full', folderState, localManifest, remoteManifest, manifestFileId, reason: 'cold-start' };
+
+                    if (remoteManifest) {
+                        manifestFileId = remoteManifest.manifestFileId || manifestFileId || null;
+                        localManifest = await this.persistManifest(folderId, { ...remoteManifest, manifestFileId }, {
+                            cloudVersion: remoteManifest.cloudVersion,
+                            localVersion: remoteManifest.localVersion ?? remoteManifest.cloudVersion
+                        }) || remoteManifest;
+                        const updatedState = await this.persistFolderState(folderId, {
+                            cloudVersion: remoteManifest.cloudVersion ?? remoteVersion ?? Date.now(),
+                            localVersion: remoteManifest.localVersion ?? remoteManifest.cloudVersion ?? remoteVersion ?? localVersion,
+                            lastCloudAck: Date.now()
+                        });
+                        if (updatedState) {
+                            folderState = updatedState;
+                        }
+                        return {
+                            mode: 'full',
+                            folderState,
+                            localManifest,
+                            remoteVersion: remoteManifest.cloudVersion ?? remoteVersion,
+                            manifestFileId,
+                            reason
+                        };
+                    }
+
+                    if (!hasManifest) {
+                        this.logger?.log({ event: 'foldersync:manifest-missing', level: 'error', details: `No manifest available for ${folderId}; full sync required.` });
+                        return { mode: 'full', folderState, localManifest: null, remoteVersion, manifestFileId, reason: 'manifest-missing' };
+                    }
+
+                    return { mode: 'full', folderState, localManifest, remoteVersion, manifestFileId, reason };
                 }
 
-                if (localManifest.requiresFullResync) {
-                    this.logger?.log({ event: 'foldersync:manifest-flag', level: 'warn', details: `Manifest flagged full resync for ${folderId}.` });
-                    return { mode: 'full', folderState, localManifest, reason: 'manifest-flag' };
-                }
-
-                const localVersion = Number(folderState.localVersion || 0);
-                const cloudVersion = Number(folderState.cloudVersion || 0);
-                if (localVersion >= cloudVersion) {
-                    this.logger?.log({
-                        event: 'foldersync:hydrate-cache',
-                        level: 'info',
-                        details: `localVersion (${localVersion}) ≥ cloudVersion (${cloudVersion}); hydrating from cache.`,
-                        data: { folderId }
+                if (remoteVersion != null && remoteVersion === localVersion) {
+                    const updatedState = await this.persistFolderState(folderId, {
+                        cloudVersion: remoteVersion,
+                        lastCloudAck: Date.now()
                     });
-                    this.queueBackgroundProbe(folderId, { localManifest, folderState });
-                    return { mode: 'cache', folderState, localManifest };
-                }
-
-                const remoteManifest = await this.fetchRemoteManifest(folderId, { expectVersion: cloudVersion });
-                if (!remoteManifest) {
-                    return { mode: 'full', folderState, localManifest, reason: 'missing-remote' };
-                }
-                if (remoteManifest.requiresFullResync) {
-                    await this.dbManager.saveFolderManifest({ ...localManifest, ...context, requiresFullResync: true, cloudVersion: remoteManifest.cloudVersion ?? cloudVersion });
-                    return { mode: 'full', folderState, localManifest, remoteManifest, reason: 'remote-flag' };
-                }
-
-                const diff = this.computeManifestDiff(localManifest, remoteManifest);
-                if (!diff.hasChanges && Number(remoteManifest.cloudVersion || 0) <= localVersion) {
-                    await this.dbManager.saveFolderState({ ...folderState, ...context, cloudVersion: remoteManifest.cloudVersion ?? cloudVersion, localVersion });
-                    this.queueBackgroundProbe(folderId, { localManifest, folderState: { ...folderState, cloudVersion: remoteManifest.cloudVersion ?? cloudVersion } });
-                    return { mode: 'cache', folderState: { ...folderState, cloudVersion: remoteManifest.cloudVersion ?? cloudVersion }, localManifest };
+                    if (updatedState) {
+                        folderState = updatedState;
+                    }
                 }
 
                 this.logger?.log({
-                    event: 'foldersync:delta-ready',
+                    event: 'foldersync:cache-hydrate',
                     level: 'info',
-                    details: `Delta required: ${diff.changedIds.length} changed, ${diff.removedIds.length} removed.`,
-                    data: { folderId, cloudVersion: remoteManifest.cloudVersion ?? cloudVersion }
+                    details: `Hydrating ${folderId} from cache at version ${localVersion}.`
                 });
-                return { mode: 'delta', folderState, localManifest, remoteManifest, diff };
+
+                if (localManifest && manifestFileId && !localManifest.manifestFileId) {
+                    localManifest = { ...localManifest, manifestFileId };
+                }
+
+                return { mode: 'cache', folderState, localManifest, remoteVersion, manifestFileId };
             }
             async fetchRemoteManifest(folderId, options = {}) {
                 if (!this.provider || typeof this.provider.loadFolderManifest !== 'function') {
@@ -2534,45 +2566,6 @@
                     });
                     return null;
                 }
-            }
-            computeManifestDiff(localManifest, remoteManifest) {
-                const localEntries = (localManifest && localManifest.entries) || {};
-                const remoteEntries = (remoteManifest && remoteManifest.entries) || {};
-                const changedSet = new Set();
-                const removedIds = [];
-                const remoteKeys = Object.keys(remoteEntries);
-                for (const fileId of remoteKeys) {
-                    const remoteData = remoteEntries[fileId];
-                    const localData = localEntries[fileId];
-                    if (!localData) {
-                        changedSet.add(fileId);
-                        continue;
-                    }
-                    if (localData.changeNumber !== remoteData.changeNumber || localData.stack !== remoteData.stack || localData.notesHash !== remoteData.notesHash || (localData.flags || '') !== (remoteData.flags || '')) {
-                        changedSet.add(fileId);
-                    }
-                }
-                const remoteSet = new Set(remoteKeys);
-                Object.keys(localEntries).forEach(fileId => {
-                    if (!remoteSet.has(fileId)) {
-                        removedIds.push(fileId);
-                    }
-                });
-
-                const localVersion = Number(localManifest?.localVersion ?? localManifest?.cloudVersion ?? 0) || 0;
-                const remoteVersion = Number(remoteManifest?.localVersion ?? remoteManifest?.cloudVersion ?? 0) || 0;
-                let versionMismatch = false;
-                if (remoteVersion > localVersion) {
-                    versionMismatch = true;
-                    if (changedSet.size === 0 && removedIds.length === 0) {
-                        for (const fileId of remoteKeys) {
-                            changedSet.add(fileId);
-                        }
-                    }
-                }
-
-                const changedIds = Array.from(changedSet);
-                return { changedIds, removedIds, hasChanges: changedIds.length > 0 || removedIds.length > 0, versionMismatch };
             }
             buildManifestFromFiles(folderId, files = []) {
                 const entries = {};
@@ -2619,41 +2612,6 @@
                     hash |= 0;
                 }
                 return String(hash >>> 0);
-            }
-            queueBackgroundProbe(folderId, context = {}) {
-                if (this.backgroundProbes.has(folderId)) {
-                    clearTimeout(this.backgroundProbes.get(folderId));
-                }
-                const timer = setTimeout(() => {
-                    this.backgroundProbes.delete(folderId);
-                    this.backgroundProbe(folderId, context).catch(error => {
-                        this.logger?.log({ event: 'foldersync:probe:error', level: 'error', details: `Probe failed: ${error.message}` });
-                    });
-                }, this.backgroundProbeDelay);
-                this.backgroundProbes.set(folderId, timer);
-            }
-            async backgroundProbe(folderId, context = {}) {
-                const localManifest = context.localManifest || await this.dbManager?.getFolderManifest(this.buildContext(folderId));
-                if (!localManifest) return null;
-                const remoteManifest = await this.fetchRemoteManifest(folderId, { allowCreate: false, signal: context.signal });
-                if (!remoteManifest) return null;
-                if (remoteManifest.requiresFullResync) {
-                    const dbContext = { ...this.buildContext(folderId), manifestFileId: remoteManifest.manifestFileId };
-                    await this.dbManager?.saveFolderManifest({ ...dbContext, entries: remoteManifest.entries || {}, cloudVersion: remoteManifest.cloudVersion ?? Date.now(), localVersion: remoteManifest.cloudVersion ?? null, requiresFullResync: true });
-                    this.deltaHandler?.({ folderId, diff: { changedIds: [], removedIds: [], hasChanges: false }, remoteManifest, localManifest, forceFullResync: true });
-                    return { diff: { changedIds: [], removedIds: [], hasChanges: false }, remoteManifest };
-                }
-                const diff = this.computeManifestDiff(localManifest, remoteManifest);
-                this.logger?.log({
-                    event: 'foldersync:probe',
-                    level: diff.hasChanges ? 'warn' : 'info',
-                    details: diff.hasChanges ? `Background probe found ${diff.changedIds.length} updates (${diff.removedIds.length} removals).` : 'Background probe confirmed cache is fresh.',
-                    data: { folderId, cloudVersion: remoteManifest.cloudVersion ?? null }
-                });
-                if (diff.hasChanges && this.deltaHandler) {
-                    this.deltaHandler({ folderId, diff, remoteManifest, localManifest });
-                }
-                return { diff, remoteManifest };
             }
             async persistManifest(folderId, manifestRecord, extras = {}) {
                 if (!this.dbManager) return null;
@@ -3656,6 +3614,27 @@
                     throw error;
                 }
             }
+            async getFolderVersion(folderId, options = {}) {
+                try {
+                    const query = `'${folderId}' in parents and name = '.orbital8-state.json' and trashed=false`;
+                    const url = `/files?q=${encodeURIComponent(query)}&fields=files(id,appProperties,modifiedTime)&supportsAllDrives=true&includeItemsFromAllDrives=true&pageSize=1`;
+                    const response = await this.makeApiCall(url, { signal: options.signal });
+                    const manifestFile = response.files && response.files[0];
+                    if (!manifestFile) {
+                        return null;
+                    }
+                    const versionValue = Number(manifestFile.appProperties?.orbital8CloudVersion ?? (manifestFile.modifiedTime ? Date.parse(manifestFile.modifiedTime) : 0));
+                    return {
+                        cloudVersion: Number.isFinite(versionValue) ? versionValue : null,
+                        manifestFileId: manifestFile.id
+                    };
+                } catch (error) {
+                    if (/403|404/.test(error.message || '')) {
+                        return null;
+                    }
+                    throw error;
+                }
+            }
             async saveFolderManifest(folderId, manifest, options = {}) {
                 const cloudVersion = manifest.cloudVersion ?? Date.now();
                 const payload = {
@@ -3905,6 +3884,24 @@
                         return { entries: {}, requiresFullResync: true, cloudVersion: Date.now() };
                     }
                     throw error;
+                }
+            }
+            async getFolderVersion(folderId, options = {}) {
+                try {
+                    const stateResponse = await this.makeApiCall(`/me/drive/special/approot:/state/${folderId}.json:/content`, { method: 'GET', signal: options.signal });
+                    const stateData = await stateResponse.json();
+                    const versionValue = Number(stateData?.cloudVersion ?? stateData?.localVersion ?? 0);
+                    return {
+                        cloudVersion: Number.isFinite(versionValue) ? versionValue : null
+                    };
+                } catch (error) {
+                    if (/404/.test(String(error.message))) {
+                        return null;
+                    }
+                    if (/401/.test(String(error.message))) {
+                        throw error;
+                    }
+                    return null;
                 }
             }
             async saveFolderManifest(folderId, manifest, options = {}) {
@@ -4213,12 +4210,16 @@
                         }
                     }
 
-                    if (preparation?.mode === 'delta') {
-                        const deltaLoaded = await this.applyDeltaSync({ cachedFiles, sessionKey, preparation, navigationToken });
-                        return deltaLoaded !== false;
-                    }
+                    const shouldFullSync = Boolean(
+                        preparation?.mode === 'full' ||
+                        cachedFiles.length === 0 ||
+                        isFirstSessionVisit ||
+                        options.forceFullResync
+                    );
 
-                    if (preparation?.mode === 'full' || cachedFiles.length === 0 || isFirstSessionVisit || options.forceFullResync) {
+                    const canUseCache = !shouldFullSync && (preparation?.mode === 'cache' || !coordinator);
+
+                    if (!canUseCache) {
                         const synced = await this.syncFolderFromCloud(cachedFiles, sessionKey, { preparation, navigationToken });
                         return synced !== false;
                     }
@@ -4238,23 +4239,15 @@
                         return false;
                     }
 
-                    if (preparation?.mode === 'cache') {
-                        state.syncLog?.log({ event: 'foldersync:cache-hit', level: 'info', details: `Hydrated ${folderId} from cache while background probe runs.` });
-                    } else if (coordinator) {
-                        const localManifest = await state.dbManager.getFolderManifest({ providerType: state.providerType, folderId });
-                        if (this.isNavigationActive(navigationToken)) {
-                            coordinator.queueBackgroundProbe(folderId, { localManifest });
-                        }
+                    const cacheLog = {
+                        event: 'foldersync:cache-hit',
+                        level: 'info',
+                        details: `Hydrated ${folderId} from cache`
+                    };
+                    if (preparation?.remoteVersion != null) {
+                        cacheLog.data = { cloudVersion: preparation.remoteVersion };
                     }
-
-                    if (state.pendingBackgroundProbe?.folderId === folderId && this.isNavigationActive(navigationToken)) {
-                        const pending = state.pendingBackgroundProbe;
-                        state.pendingBackgroundProbe = null;
-                        await this.applyDeltaFromCoordinator({ ...pending, navigationToken });
-                        if (!this.isNavigationActive(navigationToken)) {
-                            return false;
-                        }
-                    }
+                    state.syncLog?.log(cacheLog);
 
                     return state.imageFiles.length > 0;
                 } catch (error) {
@@ -4302,166 +4295,6 @@
                     hasChanges: newIds.length > 0 || updatedIds.length > 0 || removedIds.length > 0
                 };
             },
-            async applyDeltaSync({ cachedFiles = [], sessionKey, preparation, background = false, navigationToken = null }) {
-                const folderId = state.currentFolder.id;
-                const diff = preparation?.diff || { changedIds: [], removedIds: [] };
-                const remoteManifest = preparation?.remoteManifest || null;
-                const folderState = preparation?.folderState || null;
-                const coordinator = state.folderSyncCoordinator;
-
-                if (!this.isNavigationActive(navigationToken)) {
-                    return false;
-                }
-
-                if (!background) {
-                    Utils.showScreen('loading-screen');
-                    Utils.updateLoadingProgress(0, (diff.changedIds?.length || 0) + (diff.removedIds?.length || 0), 'Applying cloud updates...');
-                }
-
-                try {
-                    const changedIds = diff.changedIds || [];
-                    let cloudFiles = [];
-                    if (changedIds.length > 0) {
-                        if (!state.provider || typeof state.provider.fetchFilesByIds !== 'function') {
-                            state.syncLog?.log({ event: 'foldersync:delta-fallback', level: 'error', details: 'Provider missing fetchFilesByIds; escalating to full resync.' });
-                            await coordinator?.markRequiresFullResync(folderId, 'delta-provider-missing');
-                            return this.syncFolderFromCloud(cachedFiles, sessionKey, { preparation: { ...preparation, mode: 'full' } });
-                        }
-                        cloudFiles = await state.provider.fetchFilesByIds(folderId, changedIds, { signal: state.activeRequests?.signal });
-                        if (!this.isNavigationActive(navigationToken)) {
-                            return false;
-                        }
-                    }
-
-                    const mergedMap = new Map((cachedFiles || []).map(file => [file.id, file]));
-                    const incompleteDelta = changedIds.length > 0 && cloudFiles.length !== changedIds.length;
-                    for (const file of cloudFiles) {
-                        const existing = mergedMap.get(file.id) || {};
-                        mergedMap.set(file.id, { ...existing, ...file });
-                    }
-                    const removedIds = diff.removedIds || [];
-                    for (const removed of removedIds) {
-                        mergedMap.delete(removed);
-                    }
-
-                    state.imageFiles = Array.from(mergedMap.values());
-
-                    if (!background) {
-                        Utils.updateLoadingProgress((diff.changedIds?.length || 0) + (diff.removedIds?.length || 0), (diff.changedIds?.length || 0) + (diff.removedIds?.length || 0), 'Finishing sync...');
-                    }
-
-                    for (const file of cloudFiles) {
-                        await state.dbManager.saveMetadata(file.id, file, { folderId, providerType: state.providerType });
-                    }
-                    for (const removed of removedIds) {
-                        await state.dbManager.deleteMetadata(removed);
-                    }
-
-                    await this.processAllMetadata(state.imageFiles, false, { navigationToken });
-                    if (!this.isNavigationActive(navigationToken)) {
-                        return false;
-                    }
-                    await state.dbManager.saveFolderCache(folderId, state.imageFiles);
-
-                    const manifestRecord = remoteManifest ? { ...remoteManifest } : { entries: coordinator?.buildManifestFromFiles(folderId, state.imageFiles) };
-                    manifestRecord.requiresFullResync = Boolean(manifestRecord.requiresFullResync || incompleteDelta);
-                    const diffSummary = { changed: changedIds.length, removed: removedIds.length };
-                    const updatedCloudVersion = remoteManifest?.cloudVersion ?? folderState?.cloudVersion ?? 0;
-                    const updatedLocalVersion = Math.max(
-                        folderState?.localVersion ?? 0,
-                        remoteManifest?.localVersion ?? updatedCloudVersion
-                    );
-                    if (this.isNavigationActive(navigationToken)) {
-                        await coordinator?.persistManifest(folderId, manifestRecord, {
-                            cloudVersion: remoteManifest?.cloudVersion ?? folderState?.cloudVersion ?? null,
-                            localVersion: remoteManifest?.localVersion ?? folderState?.localVersion ?? null,
-                            lastDiffSummary: diffSummary
-                        });
-                        await coordinator?.persistFolderState(folderId, {
-                            cloudVersion: updatedCloudVersion,
-                            localVersion: updatedLocalVersion,
-                            lastCloudAck: Date.now()
-                        });
-
-                        const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
-                        state.sessionVisitedFolders.add(key);
-                    }
-
-                    const hasImages = state.imageFiles.length > 0;
-                    if (!background) {
-                        if (!this.isNavigationActive(navigationToken)) {
-                            return false;
-                        }
-                        if (hasImages) {
-                            this.switchToCommonUI();
-                            Core.initializeStacks();
-                            Core.initializeImageDisplay();
-                        } else {
-                            await this.returnToFolderSelection();
-                        }
-                    } else {
-                        if (!this.isNavigationActive(navigationToken)) {
-                            return false;
-                        }
-                        Core.initializeStacks();
-                        Core.updateStackCounts();
-                        if (hasImages) {
-                            await Core.displayCurrentImage();
-                        } else {
-                            Core.showEmptyState();
-                        }
-                    }
-
-                    const summary = [];
-                    if (changedIds.length > 0) summary.push(`${changedIds.length} updated`);
-                    if (removedIds.length > 0) summary.push(`${removedIds.length} removed`);
-                    if (this.isNavigationActive(navigationToken) && summary.length > 0) {
-                        Utils.showToast(`Folder updated (${summary.join(', ')})`, 'info');
-                    }
-                    if (incompleteDelta) {
-                        state.syncLog?.log({ event: 'foldersync:delta-partial', level: 'warn', details: `Delta fetched ${cloudFiles.length}/${changedIds.length} items; marking full resync.` });
-                        await coordinator?.markRequiresFullResync(folderId, 'delta-incomplete');
-                    }
-                    state.syncLog?.log({
-                        event: 'foldersync:delta-apply',
-                        level: 'success',
-                        details: `Delta applied for ${folderId}: ${changedIds.length} updates, ${removedIds.length} removals.`,
-                        data: { cloudVersion: updatedCloudVersion }
-                    });
-                    return hasImages;
-                } catch (error) {
-                    state.syncLog?.log({ event: 'foldersync:delta-error', level: 'error', details: `Delta sync failed: ${error.message}` });
-                    Utils.showToast(`Delta sync failed: ${error.message}`, 'error', true);
-                    await state.folderSyncCoordinator?.markRequiresFullResync(folderId, 'delta-error');
-                    return this.syncFolderFromCloud(cachedFiles, sessionKey, { preparation: { ...preparation, mode: 'full' }, navigationToken });
-                }
-            },
-            async applyDeltaFromCoordinator(payload) {
-                if (!payload) return;
-                const navigationToken = payload.navigationToken || state.navigationToken;
-                if (!this.isNavigationActive(navigationToken)) {
-                    return;
-                }
-                if (payload.forceFullResync) {
-                    await this.loadImages({ forceFullResync: true, navigationToken });
-                    return;
-                }
-                if (!payload.diff?.hasChanges) return;
-                if (payload.folderId !== state.currentFolder?.id) {
-                    state.pendingBackgroundProbe = payload;
-                    return;
-                }
-                const folderId = state.currentFolder.id;
-                const sessionKey = `${state.providerType || 'unknown'}::${folderId}`;
-                const cachedFiles = await state.dbManager.getFolderCache(folderId) || state.imageFiles || [];
-                await this.applyDeltaSync({
-                    cachedFiles,
-                    sessionKey,
-                    preparation: { ...payload, folderState: await state.dbManager.getFolderState({ providerType: state.providerType, folderId }) },
-                    background: true,
-                    navigationToken
-                });
-            },
             async syncFolderFromCloud(cachedFiles, sessionKey, options = {}) {
                 const folderId = state.currentFolder.id;
                 const hadCached = cachedFiles.length > 0;
@@ -4497,13 +4330,14 @@
 
                         if (coordinator) {
                             const manifestEntries = coordinator.buildManifestFromFiles(folderId, []);
-                            const fallbackVersion = preparation?.folderState?.cloudVersion ?? Date.now();
+                            const fallbackVersion = preparation?.localManifest?.cloudVersion ?? preparation?.remoteVersion ?? Date.now();
+                            const fallbackLocalVersion = preparation?.localManifest?.localVersion ?? fallbackVersion;
                             const manifestPayload = {
                                 entries: manifestEntries,
                                 requiresFullResync: false,
                                 cloudVersion: fallbackVersion,
-                                localVersion: preparation?.folderState?.localVersion ?? fallbackVersion,
-                                manifestFileId: preparation?.localManifest?.manifestFileId || null
+                                localVersion: fallbackLocalVersion,
+                                manifestFileId: preparation?.localManifest?.manifestFileId || preparation?.manifestFileId || null
                             };
                             if (this.isNavigationActive(navigationToken)) {
                                 await coordinator.persistManifest(folderId, manifestPayload, {
@@ -4554,35 +4388,31 @@
 
                     if (coordinator) {
                         const manifestEntries = coordinator.buildManifestFromFiles(folderId, state.imageFiles);
-                        let manifestSeed = preparation?.remoteManifest || null;
-                        let manifestFileId = manifestSeed?.manifestFileId || preparation?.localManifest?.manifestFileId || preparation?.manifestFileId || null;
+                        let manifestFileId = preparation?.manifestFileId ?? preparation?.localManifest?.manifestFileId ?? null;
                         if (!manifestFileId && state.provider && typeof state.provider.loadFolderManifest === 'function') {
                             try {
                                 const lookup = await state.provider.loadFolderManifest(folderId, { signal: state.activeRequests?.signal });
                                 if (lookup?.manifestFileId) {
                                     manifestFileId = lookup.manifestFileId;
-                                    if (!manifestSeed) {
-                                        manifestSeed = lookup;
-                                    }
                                 }
                             } catch (error) {
                                 state.syncLog?.log({ event: 'manifest:lookup:pre-save', level: 'warn', details: `Manifest lookup before save failed: ${error.message}` });
                             }
                         }
 
+                        const baseCloudVersion = preparation?.localManifest?.cloudVersion ?? preparation?.remoteVersion ?? Date.now();
+                        const baseLocalVersion = preparation?.localManifest?.localVersion ?? baseCloudVersion;
                         let remoteManifestResponse = null;
                         let manifestRequiresRescan = false;
+
                         if (state.provider && typeof state.provider.saveFolderManifest === 'function' && this.isNavigationActive(navigationToken)) {
                             try {
-                                const manifestCloudVersion = manifestSeed?.cloudVersion ?? preparation?.remoteManifest?.cloudVersion ?? preparation?.folderState?.cloudVersion ?? Date.now();
-                                const manifestLocalVersion = preparation?.folderState?.localVersion ?? manifestCloudVersion;
                                 const manifestOptions = { manifestFileId };
-                                // Manifest persistence must survive folder exits; avoid tying this to the navigation abort controller.
                                 remoteManifestResponse = await state.provider.saveFolderManifest(folderId, {
                                     entries: manifestEntries,
                                     requiresFullResync: false,
-                                    cloudVersion: manifestCloudVersion,
-                                    localVersion: manifestLocalVersion,
+                                    cloudVersion: baseCloudVersion,
+                                    localVersion: baseLocalVersion,
                                     manifestFileId
                                 }, manifestOptions);
                                 state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted manifest for ${folderId}`, data: { entries: Object.keys(manifestEntries).length } });
@@ -4596,16 +4426,15 @@
                             }
                         }
 
-                        const resolvedManifestSeed = remoteManifestResponse || manifestSeed || preparation?.remoteManifest || null;
-                        const remoteCloudVersion = remoteManifestResponse?.cloudVersion ?? resolvedManifestSeed?.cloudVersion ?? preparation?.folderState?.cloudVersion ?? Date.now();
-                        const remoteLocalVersion = remoteManifestResponse?.localVersion ?? resolvedManifestSeed?.localVersion ?? preparation?.remoteManifest?.localVersion ?? preparation?.folderState?.localVersion ?? remoteCloudVersion;
-                        const resolvedManifestFileId = remoteManifestResponse?.manifestFileId || manifestFileId || preparation?.localManifest?.manifestFileId || null;
+                        const finalCloudVersion = remoteManifestResponse?.cloudVersion ?? baseCloudVersion;
+                        const finalLocalVersion = remoteManifestResponse?.localVersion ?? baseLocalVersion;
+                        const finalManifestFileId = remoteManifestResponse?.manifestFileId ?? manifestFileId ?? preparation?.localManifest?.manifestFileId ?? null;
                         const manifestPayload = {
                             entries: manifestEntries,
                             requiresFullResync: manifestRequiresRescan,
-                            cloudVersion: remoteCloudVersion,
-                            localVersion: remoteLocalVersion,
-                            manifestFileId: resolvedManifestFileId
+                            cloudVersion: finalCloudVersion,
+                            localVersion: finalLocalVersion,
+                            manifestFileId: finalManifestFileId
                         };
                         if (this.isNavigationActive(navigationToken)) {
                             await coordinator.persistManifest(folderId, manifestPayload, {
@@ -7145,7 +6974,6 @@ this.updateImageCounters();
                 state.dbManager = new DBManager();
                 await state.dbManager.init();
                 state.folderSyncCoordinator = new FolderSyncCoordinator({ dbManager: state.dbManager, logger: state.syncLog });
-                state.folderSyncCoordinator.setDeltaHandler((payload) => App.applyDeltaFromCoordinator(payload));
                 state.syncManager = new SyncManager({ dbManager: state.dbManager, logger: state.syncLog });
                 state.syncManager.start();
                 state.metadataExtractor = new MetadataExtractor();


### PR DESCRIPTION
## Summary
- streamline FolderSyncCoordinator.prepareFolder to check the cached state, fetch the current remote version, and only hydrate from cache when versions match
- add lightweight version lookups for Google Drive and OneDrive providers and simplify folder loading to drop delta/background probe plumbing
- clean up syncFolderFromCloud manifest persistence to use the new preparation data and remove unused delta-handling code paths

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e390300604832d92bfd580b707ac86