### PR TITLE
Always refresh v9b folders from cloud

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -4056,7 +4056,8 @@
                         options.forceFullResync
                     );
 
-                    const canUseCache = !shouldFullSync && (preparation?.mode === 'cache' || !coordinator);
+                    const mustRefreshFromCloud = true; // Always refresh to capture latest cloud changes per folder load.
+                    const canUseCache = !mustRefreshFromCloud && !shouldFullSync && (preparation?.mode === 'cache' || !coordinator);
 
                     if (!canUseCache) {
                         const synced = await this.syncFolderFromCloud(cachedFiles, sessionKey, { preparation, navigationToken });


### PR DESCRIPTION
## Summary
- ensure the v9b folder loader always refreshes from the cloud by disabling cache shortcuts
- document the behavior so each folder selection retrieves the latest remote changes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e39fdd360c832dbbb0dd40c494528b