### PR TITLE
Simplify v9b cloud loading and metadata syncing

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -1009,7 +1009,7 @@
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const state = {
             provider: null, providerType: null, dbManager: null, metadataExtractor: null,
-            syncManager: null, syncLog: null, visualCues: null, haptic: null, export: null, folderSyncCoordinator: null,
+            syncLog: null, visualCues: null, haptic: null, export: null,
             currentFolder: { id: null, name: '' },
             imageFiles: [], currentImageLoadId: null, currentStack: 'in', currentStackPosition: 0,
             isFocusMode: false, stacks: { in: [], out: [], priority: [], trash: [] },
@@ -1024,7 +1024,8 @@
             activeRequests: new AbortController(),
             sessionVisitedFolders: new Set(),
             isImageTransitioning: false,
-            showDebugToasts: true
+            showDebugToasts: true,
+            pendingCloudWrites: new Set()
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -2090,47 +2091,26 @@
             }
             async init() {
                 return new Promise((resolve, reject) => {
-                    const request = indexedDB.open('Orbital8-Goji-V1', 4);
+                    const request = indexedDB.open('Orbital8-Goji-V1', 5);
                     request.onupgradeneeded = (event) => {
                         const db = event.target.result;
-                        const oldVersion = event.oldVersion || 0;
-
-                        if (oldVersion < 1 && !db.objectStoreNames.contains('folderCache')) {
+                        if (!db.objectStoreNames.contains('folderCache')) {
                             db.createObjectStore('folderCache', { keyPath: 'folderId' });
                         }
-
-                        if (oldVersion < 2) {
-                            let metadataStore;
-                            if (!db.objectStoreNames.contains('metadata')) {
-                                metadataStore = db.createObjectStore('metadata', { keyPath: 'id' });
-                            } else {
-                                metadataStore = request.transaction.objectStore('metadata');
-                            }
-                            if (metadataStore && !metadataStore.indexNames.contains('folderKey')) {
-                                metadataStore.createIndex('folderKey', 'folderKey', { unique: false });
-                            }
-                            if (!db.objectStoreNames.contains('syncQueue')) {
-                                db.createObjectStore('syncQueue', { keyPath: 'id', autoIncrement: true });
-                            }
+                        let metadataStore;
+                        if (!db.objectStoreNames.contains('metadata')) {
+                            metadataStore = db.createObjectStore('metadata', { keyPath: 'id' });
+                        } else {
+                            metadataStore = event.target.transaction.objectStore('metadata');
                         }
-
-                        if (oldVersion < 3 && !db.objectStoreNames.contains('folderState')) {
-                            const folderState = db.createObjectStore('folderState', { keyPath: 'folderKey' });
-                            folderState.createIndex('provider', 'provider', { unique: false });
-                            folderState.createIndex('folderId', 'folderId', { unique: false });
+                        if (metadataStore && !metadataStore.indexNames.contains('folderKey')) {
+                            metadataStore.createIndex('folderKey', 'folderKey', { unique: false });
                         }
-
-                        if (oldVersion < 4 && !db.objectStoreNames.contains('folderManifests')) {
-                            const manifestStore = db.createObjectStore('folderManifests', { keyPath: 'folderKey' });
-                            manifestStore.createIndex('provider', 'provider', { unique: false });
-                            manifestStore.createIndex('folderId', 'folderId', { unique: false });
-                        }
-                        if (db.objectStoreNames.contains('metadata')) {
-                            const metadataStore = request.transaction.objectStore('metadata');
-                            if (metadataStore && !metadataStore.indexNames.contains('folderKey')) {
-                                metadataStore.createIndex('folderKey', 'folderKey', { unique: false });
+                        ['syncQueue', 'folderState', 'folderManifests'].forEach(storeName => {
+                            if (db.objectStoreNames.contains(storeName)) {
+                                db.deleteObjectStore(storeName);
                             }
-                        }
+                        });
                     };
                     request.onsuccess = (event) => {
                         this.db = event.target.result;
@@ -2222,787 +2202,31 @@
                     const transaction = this.db.transaction('metadata', 'readwrite');
                     const store = transaction.objectStore('metadata');
                     const index = store.index('folderKey');
-                    transaction.oncomplete = () => resolve();
                     const request = index.getAllKeys(IDBKeyRange.only(folderKey));
                     request.onsuccess = () => {
                         const keys = request.result || [];
                         keys.forEach(key => store.delete(key));
+                        resolve();
                     };
-                    request.onerror = () => reject(request.error);
-                });
-            }
-            async addToSyncQueue(operation) {
-                if (!this.db) return null;
-                const entry = {
-                    fileId: operation.fileId,
-                    updates: operation.updates || {},
-                    operationType: operation.operationType || 'metadata:update',
-                    origin: operation.origin || 'ui',
-                    localUpdatedAt: operation.localUpdatedAt || Date.now(),
-                    pendingFlush: Boolean(operation.pendingFlush),
-                    metadataSnapshot: operation.metadataSnapshot || null,
-                    retryCount: operation.retryCount || 0,
-                    folderId: operation.folderId || null,
-                    providerType: operation.providerType || null,
-                    folderKey: operation.folderKey || null
-                };
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('syncQueue', 'readwrite');
-                    const store = transaction.objectStore('syncQueue');
-                    const request = store.add(entry);
-                    request.onsuccess = () => resolve(request.result);
-                    request.onerror = () => reject(request.error);
-                });
-            }
-            async readSyncQueue() {
-                if (!this.db) return [];
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('syncQueue', 'readonly');
-                    const store = transaction.objectStore('syncQueue');
-                    const request = store.getAll();
-                    request.onsuccess = () => {
-                        const results = request.result || [];
-                        results.sort((a, b) => (a.localUpdatedAt || 0) - (b.localUpdatedAt || 0));
-                        resolve(results);
-                    };
-                    request.onerror = () => reject(request.error);
-                });
-            }
-            async deleteFromSyncQueue(ids) {
-                if (!this.db) return;
-                const targetIds = Array.isArray(ids) ? ids : [ids];
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('syncQueue', 'readwrite');
-                    const store = transaction.objectStore('syncQueue');
-                    targetIds.forEach(id => { store.delete(id); });
-                    transaction.oncomplete = () => resolve();
-                    transaction.onerror = () => reject(transaction.error);
-                });
-            }
-            async updateSyncQueueEntry(id, updates) {
-                if (!this.db) return false;
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('syncQueue', 'readwrite');
-                    const store = transaction.objectStore('syncQueue');
-                    const getRequest = store.get(id);
-                    getRequest.onsuccess = () => {
-                        const entry = getRequest.result;
-                        if (!entry) { resolve(false); return; }
-                        Object.assign(entry, updates);
-                        const putRequest = store.put(entry);
-                        putRequest.onsuccess = () => resolve(true);
-                        putRequest.onerror = () => reject(putRequest.error);
-                    };
-                    getRequest.onerror = () => reject(getRequest.error);
-                });
-            }
-            async markPendingFlush(ids, pending = true) {
-                if (!this.db) return;
-                const targetIds = Array.isArray(ids) ? ids : [ids];
-                await Promise.all(targetIds.map(id => this.updateSyncQueueEntry(id, { pendingFlush: pending })));
-            }
-            async getFolderState(context) {
-                if (!this.db) return null;
-                const folderKey = this.resolveFolderKey(context);
-                if (!folderKey) return null;
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('folderState', 'readonly');
-                    const store = transaction.objectStore('folderState');
-                    const request = store.get(folderKey);
-                    request.onsuccess = () => resolve(request.result || null);
-                    request.onerror = () => reject(request.error);
-                });
-            }
-            async saveFolderState(record) {
-                if (!this.db || !record) return;
-                const folderKey = this.resolveFolderKey(record);
-                if (!folderKey) return;
-                const payload = {
-                    folderKey,
-                    provider: record.providerType || record.provider || null,
-                    folderId: record.folderId,
-                    localVersion: record.localVersion ?? 0,
-                    cloudVersion: record.cloudVersion ?? 0,
-                    lastLocalMutation: record.lastLocalMutation || null,
-                    lastCloudAck: record.lastCloudAck || null,
-                    updatedAt: Date.now()
-                };
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('folderState', 'readwrite');
-                    const store = transaction.objectStore('folderState');
-                    const request = store.put(payload);
-                    request.onsuccess = () => resolve(payload);
-                    request.onerror = () => reject(request.error);
-                });
-            }
-            async deleteFolderState(context) {
-                if (!this.db) return;
-                const folderKey = this.resolveFolderKey(context);
-                if (!folderKey) return;
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('folderState', 'readwrite');
-                    const store = transaction.objectStore('folderState');
-                    const request = store.delete(folderKey);
-                    request.onsuccess = () => resolve();
-                    request.onerror = () => reject(request.error);
-                });
-            }
-            async getFolderManifest(context) {
-                if (!this.db) return null;
-                const folderKey = this.resolveFolderKey(context);
-                if (!folderKey) return null;
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('folderManifests', 'readonly');
-                    const store = transaction.objectStore('folderManifests');
-                    const request = store.get(folderKey);
-                    request.onsuccess = () => resolve(request.result || null);
-                    request.onerror = () => reject(request.error);
-                });
-            }
-            async saveFolderManifest(record) {
-                if (!this.db || !record) return;
-                const folderKey = this.resolveFolderKey(record);
-                if (!folderKey) return;
-                const payload = {
-                    folderKey,
-                    provider: record.providerType || record.provider || null,
-                    folderId: record.folderId,
-                    entries: record.entries || {},
-                    cloudVersion: record.cloudVersion ?? null,
-                    localVersion: record.localVersion ?? null,
-                    requiresFullResync: Boolean(record.requiresFullResync),
-                    lastUpdated: record.lastUpdated || Date.now(),
-                    lastRemoteUpdate: record.lastRemoteUpdate || null,
-                    lastDiffSummary: record.lastDiffSummary || null
-                };
-                if (record.manifestFileId) {
-                    payload.manifestFileId = record.manifestFileId;
-                }
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('folderManifests', 'readwrite');
-                    const store = transaction.objectStore('folderManifests');
-                    const request = store.put(payload);
-                    request.onsuccess = () => resolve(payload);
-                    request.onerror = () => reject(request.error);
-                });
-            }
-            async deleteFolderManifest(context) {
-                if (!this.db) return;
-                const folderKey = this.resolveFolderKey(context);
-                if (!folderKey) return;
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('folderManifests', 'readwrite');
-                    const store = transaction.objectStore('folderManifests');
-                    const request = store.delete(folderKey);
-                    request.onsuccess = () => resolve();
                     request.onerror = () => reject(request.error);
                 });
             }
             async clearFolderData(context, fileIds = []) {
-                const folderKey = this.resolveFolderKey(context);
-                if (!folderKey) return;
-                await Promise.all([
-                    this.deleteFolderCache(context.folderId || context),
-                    this.deleteFolderState(context),
-                    this.deleteFolderManifest(context),
-                    fileIds.length > 0 ? Promise.all(fileIds.map(id => this.deleteMetadata(id))) : this.deleteMetadataByFolder(context)
-                ]);
+                const folderId = typeof context === 'object' ? (context.folderId || null) : context;
+                const tasks = [];
+                if (folderId) {
+                    tasks.push(this.deleteFolderCache(folderId));
+                }
+                if (fileIds.length > 0) {
+                    tasks.push(Promise.all(fileIds.map(id => this.deleteMetadata(id))));
+                } else if (context) {
+                    tasks.push(this.deleteMetadataByFolder(context));
+                }
+                await Promise.all(tasks);
             }
         }
-        class FolderSyncCoordinator {
-            constructor({ dbManager, logger } = {}) {
-                this.dbManager = dbManager || null;
-                this.logger = logger || null;
-                this.provider = null;
-                this.providerType = null;
-                this.lastSyncAppliedCount = 0;
-            }
-            setDbManager(dbManager) { this.dbManager = dbManager; }
-            setLogger(logger) { this.logger = logger; }
-            setProviderContext({ provider, providerType }) {
-                this.provider = provider || null;
-                this.providerType = providerType || null;
-                this.logger?.log({
-                    event: 'foldersync:context',
-                    level: 'info',
-                    details: this.provider ? `Coordinator bound to ${providerType}` : 'Cleared provider context.'
-                });
-            }
-            buildContext(folderId) {
-                return { providerType: this.providerType || state.providerType || null, folderId };
-            }
-            async prepareFolder(folderId, options = {}) {
-                const { forceFullResync = false } = options;
-                if (!this.dbManager) {
-                    return { mode: 'full', reason: 'no-db' };
-                }
-
-                const context = this.buildContext(folderId);
-                let [folderState, localManifest] = await Promise.all([
-                    this.dbManager.getFolderState(context),
-                    this.dbManager.getFolderManifest(context)
-                ]);
-
-                if (forceFullResync && localManifest) {
-                    await this.dbManager.saveFolderManifest({ ...localManifest, ...context, requiresFullResync: true });
-                }
-
-                let remoteVersion = null;
-                let manifestFileId = localManifest?.manifestFileId || null;
-
-                if (this.provider && typeof this.provider.getFolderVersion === 'function') {
-                    try {
-                        const versionInfo = await this.provider.getFolderVersion(folderId, options);
-                        if (versionInfo) {
-                            const numericVersion = Number(versionInfo.cloudVersion ?? versionInfo.version ?? versionInfo.localVersion ?? versionInfo);
-                            remoteVersion = Number.isFinite(numericVersion) ? numericVersion : null;
-                            if (versionInfo.manifestFileId) {
-                                manifestFileId = versionInfo.manifestFileId;
-                            }
-                            if (remoteVersion != null) {
-                                this.logger?.log({
-                                    event: 'foldersync:version-check',
-                                    level: 'info',
-                                    details: `Remote version ${remoteVersion} reported for ${folderId}.`
-                                });
-                            }
-                        }
-                    } catch (error) {
-                        this.logger?.log({ event: 'foldersync:version-check:error', level: 'warn', details: `Version probe failed for ${folderId}: ${error.message}` });
-                    }
-                }
-
-                const hasState = Boolean(folderState);
-                const hasManifest = Boolean(localManifest);
-                const manifestFlagged = Boolean(localManifest?.requiresFullResync);
-                const localVersion = Number(folderState?.cloudVersion ?? localManifest?.cloudVersion ?? 0) || 0;
-                const requiresManifest = forceFullResync || manifestFlagged || !hasState || !hasManifest || (remoteVersion != null && remoteVersion !== localVersion);
-
-                if (requiresManifest) {
-                    const reason = forceFullResync ? 'force' : (!hasState || !hasManifest ? 'cold-start' : manifestFlagged ? 'manifest-flag' : 'version-mismatch');
-                    let remoteManifest = null;
-                    try {
-                        remoteManifest = await this.fetchRemoteManifest(folderId, { manifestFileId });
-                    } catch (error) {
-                        this.logger?.log({ event: 'foldersync:manifest-fetch:error', level: 'warn', details: `Manifest fetch failed during prepare for ${folderId}: ${error.message}` });
-                    }
-
-                    if (remoteManifest) {
-                        manifestFileId = remoteManifest.manifestFileId || manifestFileId || null;
-                        localManifest = await this.persistManifest(folderId, { ...remoteManifest, manifestFileId }, {
-                            cloudVersion: remoteManifest.cloudVersion,
-                            localVersion: remoteManifest.localVersion ?? remoteManifest.cloudVersion
-                        }) || remoteManifest;
-                        const updatedState = await this.persistFolderState(folderId, {
-                            cloudVersion: remoteManifest.cloudVersion ?? remoteVersion ?? Date.now(),
-                            localVersion: remoteManifest.localVersion ?? remoteManifest.cloudVersion ?? remoteVersion ?? localVersion,
-                            lastCloudAck: Date.now()
-                        });
-                        if (updatedState) {
-                            folderState = updatedState;
-                        }
-                        return {
-                            mode: 'full',
-                            folderState,
-                            localManifest,
-                            remoteVersion: remoteManifest.cloudVersion ?? remoteVersion,
-                            manifestFileId,
-                            reason
-                        };
-                    }
-
-                    if (!hasManifest) {
-                        this.logger?.log({ event: 'foldersync:manifest-missing', level: 'error', details: `No manifest available for ${folderId}; full sync required.` });
-                        return { mode: 'full', folderState, localManifest: null, remoteVersion, manifestFileId, reason: 'manifest-missing' };
-                    }
-
-                    return { mode: 'full', folderState, localManifest, remoteVersion, manifestFileId, reason };
-                }
-
-                if (remoteVersion != null && remoteVersion === localVersion) {
-                    const updatedState = await this.persistFolderState(folderId, {
-                        cloudVersion: remoteVersion,
-                        lastCloudAck: Date.now()
-                    });
-                    if (updatedState) {
-                        folderState = updatedState;
-                    }
-                }
-
-                this.logger?.log({
-                    event: 'foldersync:cache-hydrate',
-                    level: 'info',
-                    details: `Hydrating ${folderId} from cache at version ${localVersion}.`
-                });
-
-                if (localManifest && manifestFileId && !localManifest.manifestFileId) {
-                    localManifest = { ...localManifest, manifestFileId };
-                }
-
-                return { mode: 'cache', folderState, localManifest, remoteVersion, manifestFileId };
-            }
-            async fetchRemoteManifest(folderId, options = {}) {
-                if (!this.provider || typeof this.provider.loadFolderManifest !== 'function') {
-                    this.logger?.log({ event: 'manifest:fetch:skip', level: 'warn', details: `Provider missing manifest loader for ${folderId}.` });
-                    return null;
-                }
-                try {
-                    const manifest = await this.provider.loadFolderManifest(folderId, options);
-                    if (manifest) {
-                        this.logger?.log({
-                            event: 'manifest:fetch',
-                            level: 'info',
-                            details: `Fetched manifest for ${folderId}.`,
-                            data: { cloudVersion: manifest.cloudVersion ?? null, entries: Object.keys(manifest.entries || {}).length }
-                        });
-                    }
-                    return manifest;
-                } catch (error) {
-                    this.logger?.log({
-                        event: 'manifest:fetch:error',
-                        level: 'error',
-                        details: `Manifest fetch failed for ${folderId}: ${error.message}`,
-                        data: { status: error.status || null }
-                    });
-                    return null;
-                }
-            }
-            buildManifestFromFiles(folderId, files = []) {
-                const entries = {};
-                files.forEach(file => {
-                    entries[file.id] = {
-                        changeNumber: this.computeChangeNumber(file),
-                        stack: file.stack || file.appProperties?.slideboxStack || 'in',
-                        notesHash: this.hashString(file.notes || file.appProperties?.notes || ''),
-                        lastCloudUpdate: file.modifiedTime || file.createdTime || new Date().toISOString(),
-                        flags: this.computeFlags(file)
-                    };
-                });
-                this.logger?.log({
-                    event: 'manifest:build',
-                    level: 'info',
-                    details: `Built manifest with ${Object.keys(entries).length} entries for ${folderId}.`
-                });
-                return entries;
-            }
-            computeChangeNumber(file) {
-                if (file.changeNumber != null) {
-                    const numeric = Number(file.changeNumber);
-                    if (!Number.isNaN(numeric)) return numeric;
-                }
-                if (file.version != null) {
-                    const numeric = Number(file.version);
-                    if (!Number.isNaN(numeric)) return numeric;
-                }
-                const timestamp = Date.parse(file.modifiedTime || file.createdTime || 0);
-                return Number.isNaN(timestamp) ? Date.now() : timestamp;
-            }
-            computeFlags(file) {
-                const flags = [];
-                const stack = file.stack || file.appProperties?.slideboxStack;
-                if (stack === 'trash') flags.push('trash');
-                if (Utils.isFavorite(file)) flags.push('fav');
-                return flags.join(',');
-            }
-            hashString(value) {
-                if (!value) return '0';
-                let hash = 0;
-                for (let i = 0; i < value.length; i++) {
-                    hash = ((hash << 5) - hash) + value.charCodeAt(i);
-                    hash |= 0;
-                }
-                return String(hash >>> 0);
-            }
-            async persistManifest(folderId, manifestRecord, extras = {}) {
-                if (!this.dbManager) return null;
-                const context = this.buildContext(folderId);
-                const payload = {
-                    ...context,
-                    entries: manifestRecord.entries || {},
-                    cloudVersion: manifestRecord.cloudVersion ?? extras.cloudVersion ?? null,
-                    localVersion: manifestRecord.localVersion ?? extras.localVersion ?? null,
-                    requiresFullResync: Boolean(manifestRecord.requiresFullResync),
-                    lastRemoteUpdate: manifestRecord.lastRemoteUpdate || Date.now(),
-                    lastDiffSummary: extras.lastDiffSummary || null
-                };
-                if (manifestRecord.manifestFileId) {
-                    payload.manifestFileId = manifestRecord.manifestFileId;
-                }
-                const saved = await this.dbManager.saveFolderManifest(payload);
-                return saved;
-            }
-            async persistFolderState(folderId, updates = {}) {
-                if (!this.dbManager) return null;
-                const context = this.buildContext(folderId);
-                const existing = await this.dbManager.getFolderState(context) || { ...context, folderId, localVersion: 0, cloudVersion: 0 };
-                const payload = {
-                    ...existing,
-                    ...context,
-                    folderId,
-                    localVersion: updates.localVersion ?? existing.localVersion ?? 0,
-                    cloudVersion: updates.cloudVersion ?? existing.cloudVersion ?? 0,
-                    lastLocalMutation: updates.lastLocalMutation ?? existing.lastLocalMutation ?? null,
-                    lastCloudAck: updates.lastCloudAck ?? existing.lastCloudAck ?? null
-                };
-                return await this.dbManager.saveFolderState(payload);
-            }
-            async markRequiresFullResync(folderId, reason = 'manual') {
-                this.logger?.log({ event: 'foldersync:flag', level: 'warn', details: `Flagging ${folderId} for full resync (${reason}).` });
-                const context = this.buildContext(folderId);
-                const existing = await this.dbManager.getFolderManifest(context);
-                await this.dbManager.saveFolderManifest({ ...existing, ...context, requiresFullResync: true });
-            }
-            async applyLocalManifestUpdates(folderId, files = [], options = {}) {
-                if (!this.dbManager || !Array.isArray(files) || files.length === 0) {
-                    return null;
-                }
-                const providerType = options.providerType || this.providerType || state.providerType || null;
-                const context = { providerType, folderId };
-                const manifestRecord = await this.dbManager.getFolderManifest(context) || { ...context, folderId, entries: {}, requiresFullResync: false };
-                const entries = { ...(manifestRecord.entries || {}) };
-                const timestamp = options.timestamp || Date.now();
-                const isoTimestamp = new Date(timestamp).toISOString();
-                const updatedIds = [];
-                files.forEach(file => {
-                    if (!file || !file.id) return;
-                    const existing = entries[file.id] || {};
-                    const notesValue = file.notes ?? file.appProperties?.notes ?? '';
-                    const stackValue = file.stack || file.appProperties?.slideboxStack || existing.stack || 'in';
-                    const changeNumber = Number(file.localUpdatedAt || file.changeNumber || existing.changeNumber || timestamp);
-                    entries[file.id] = {
-                        ...existing,
-                        changeNumber,
-                        stack: stackValue,
-                        notesHash: this.hashString(notesValue),
-                        lastCloudUpdate: file.modifiedTime || existing.lastCloudUpdate || isoTimestamp,
-                        flags: this.computeFlags({ ...file, stack: stackValue })
-                    };
-                    updatedIds.push(file.id);
-                });
-                const manifestPayload = {
-                    ...manifestRecord,
-                    ...context,
-                    folderId,
-                    entries,
-                    requiresFullResync: Boolean(manifestRecord.requiresFullResync),
-                    cloudVersion: options.targetVersion ?? manifestRecord.cloudVersion ?? null,
-                    localVersion: options.targetVersion ?? manifestRecord.localVersion ?? null,
-                    manifestFileId: manifestRecord.manifestFileId || options.manifestFileId || null,
-                    lastRemoteUpdate: timestamp,
-                    lastDiffSummary: manifestRecord.lastDiffSummary || null
-                };
-                await this.dbManager.saveFolderManifest(manifestPayload);
-                let remoteResponse = null;
-                if (this.provider && typeof this.provider.saveFolderManifest === 'function') {
-                    try {
-                        remoteResponse = await this.provider.saveFolderManifest(folderId, {
-                            entries,
-                            requiresFullResync: manifestPayload.requiresFullResync,
-                            cloudVersion: options.targetVersion ?? manifestPayload.cloudVersion ?? Date.now(),
-                            localVersion: options.targetVersion ?? manifestPayload.localVersion ?? null,
-                            manifestFileId: manifestPayload.manifestFileId
-                        }, { manifestFileId: manifestPayload.manifestFileId });
-                        if (remoteResponse?.manifestFileId) {
-                            manifestPayload.manifestFileId = remoteResponse.manifestFileId;
-                        }
-                        if (remoteResponse?.cloudVersion != null) {
-                            manifestPayload.cloudVersion = remoteResponse.cloudVersion;
-                        } else if (options.targetVersion != null) {
-                            manifestPayload.cloudVersion = options.targetVersion;
-                        }
-                        if (remoteResponse?.localVersion != null) {
-                            manifestPayload.localVersion = remoteResponse.localVersion;
-                        } else if (options.targetVersion != null) {
-                            manifestPayload.localVersion = options.targetVersion;
-                        }
-                        await this.dbManager.saveFolderManifest(manifestPayload);
-                        this.logger?.log({ event: 'manifest:update', level: 'info', details: `Updated manifest entries for ${updatedIds.length} item(s) in ${folderId}.`, data: { updatedIds } });
-                    } catch (error) {
-                        this.logger?.log({ event: 'manifest:update:error', level: 'error', details: `Failed to update manifest for ${folderId}: ${error.message}` });
-                        await this.dbManager.saveFolderManifest({ ...manifestPayload, requiresFullResync: true });
-                        throw error;
-                    }
-                } else {
-                    this.logger?.log({ event: 'manifest:update:local', level: 'info', details: `Cached manifest update for ${updatedIds.length} item(s) in ${folderId}.`, data: { updatedIds } });
-                }
-                return { manifestFileId: manifestPayload.manifestFileId, cloudVersion: manifestPayload.cloudVersion };
-            }
-            async recordLocalFlush(folderId, options = {}) {
-                const timestamp = options.timestamp || Date.now();
-                const context = this.buildContext(folderId);
-                const existing = await this.dbManager.getFolderState(context) || { ...context, folderId, localVersion: 0, cloudVersion: 0 };
-                const currentLocalVersion = Number(existing.localVersion || 0);
-                const currentCloudVersion = Number(existing.cloudVersion || 0);
-                const baselineVersion = Math.max(currentLocalVersion, currentCloudVersion);
-                let nextVersion = Math.max(Date.now(), baselineVersion + 1);
-                if (options.targetVersion != null) {
-                    const numericTarget = Number(options.targetVersion);
-                    if (!Number.isNaN(numericTarget)) {
-                        nextVersion = Math.max(nextVersion, numericTarget);
-                    }
-                }
-                await this.dbManager.saveFolderState({ ...existing, ...context, folderId, localVersion: nextVersion, cloudVersion: nextVersion, lastLocalMutation: timestamp, lastCloudAck: timestamp });
-                let manifestRecord = null;
-                if ((!options.remoteContext || !options.remoteContext.manifestFileId) && this.dbManager) {
-                    manifestRecord = await this.dbManager.getFolderManifest(context);
-                }
-                if (this.provider && typeof this.provider.updateFolderVersionMarker === 'function') {
-                    try {
-                        const remoteContext = { ...(options.remoteContext || {}), manifestFileId: manifestRecord?.manifestFileId };
-                        await this.provider.updateFolderVersionMarker(folderId, nextVersion, remoteContext);
-                        this.logger?.log({ event: 'foldersync:version:bump', level: 'info', details: `Pushed folder version ${nextVersion} to cloud.`, data: { folderId } });
-                    } catch (error) {
-                        this.logger?.log({ event: 'foldersync:version:error', level: 'error', details: `Failed to push folder version: ${error.message}` });
-                    }
-                }
-                return nextVersion;
-            }
-        }
-        class SyncManager {
-            constructor({ dbManager, logger } = {}) {
-                this.dbManager = dbManager || null;
-                this.logger = logger || null;
-                this.pendingMutations = new Map();
-                this.debounceTimers = new Map();
-                this.debounceDelay = 750;
-                this.isActive = false;
-                this.hasPendingWork = false;
-                this.provider = null;
-                this.providerType = null;
-                this.offlineQueue = new Map();
-            }
-            setLogger(logger) { this.logger = logger; }
-            setDbManager(dbManager) { this.dbManager = dbManager; }
-            setProviderContext({ provider, providerType }) {
-                this.provider = provider || null;
-                this.providerType = providerType || null;
-                this.logger?.log({
-                    event: 'provider:context',
-                    level: 'info',
-                    details: this.provider ? `Bound to provider ${this.providerType}` : 'Cleared provider context.'
-                });
-            }
-            start() {
-                if (this.isActive) return;
-                this.isActive = true;
-                this.retryOfflineQueue('start').catch(error => {
-                    this.logger?.log({ event: 'offline:retry:error', level: 'error', details: `Failed to retry offline queue on start: ${error.message}` });
-                });
-            }
-            async stop() {
-                const flushResult = await this.flush({ reason: 'stop' });
-                this.isActive = false;
-                this.provider = null;
-                this.providerType = null;
-                return flushResult;
-            }
-            async retryOfflineQueue(reason = 'manual') {
-                if (this.offlineQueue.size === 0) {
-                    this.updatePendingState();
-                    return 'empty';
-                }
-                const entries = [];
-                for (const folderEntries of this.offlineQueue.values()) {
-                    for (const entry of folderEntries.values()) {
-                        entries.push(entry);
-                    }
-                }
-                this.offlineQueue.clear();
-                this.updatePendingState();
-                let applied = 0;
-                for (const entry of entries) {
-                    const metadataRecord = state.imageFiles.find(file => file.id === entry.fileId) || entry.metadataSnapshot || {};
-                    const context = this.resolveEntryFolderContext(entry, metadataRecord);
-                    const enrichedEntry = { ...entry, ...context };
-                    const success = await this.processEntry(enrichedEntry, metadataRecord, context);
-                    if (!success) {
-                        this.enqueueOfflineEntry(enrichedEntry, context);
-                    } else {
-                        applied += 1;
-                    }
-                }
-                const status = this.offlineQueue.size === 0 ? 'done' : 'partial';
-                if (entries.length > 0) {
-                    const message = `Retried ${entries.length} offline entr${entries.length === 1 ? 'y' : 'ies'} (${applied} applied) [${reason}].`;
-                    const level = applied > 0 ? 'info' : 'warn';
-                    this.logger?.log({ event: 'offline:retry', level, details: message });
-                }
-                this.updatePendingState();
-                return status;
-            }
-            queueLocalChange(change, options = {}) {
-                if (!change || !change.fileId) return Promise.resolve();
-                const { debounce = true } = options;
-                const fileId = change.fileId;
-                const buffer = this.pendingMutations.get(fileId) || {
-                    updates: {},
-                    operationType: change.operationType || 'metadata:update',
-                    origin: change.origin || 'ui'
-                };
-                const resolvedFolderId = change.folderId || buffer.folderId || state.currentFolder?.id || null;
-                const resolvedProviderType = change.providerType || buffer.providerType || this.providerType || state.providerType || null;
-                const resolvedFolderKey = change.folderKey || buffer.folderKey || (resolvedFolderId && resolvedProviderType ? `${resolvedProviderType}::${resolvedFolderId}` : null);
-                buffer.folderId = resolvedFolderId;
-                buffer.providerType = resolvedProviderType;
-                buffer.folderKey = resolvedFolderKey;
-                buffer.updates = { ...buffer.updates, ...(change.updates || {}) };
-                buffer.operationType = change.operationType || buffer.operationType;
-                buffer.origin = change.origin || buffer.origin;
-                buffer.localUpdatedAt = change.localUpdatedAt || Date.now();
-                if (change.metadataSnapshot) {
-                    buffer.metadataSnapshot = { ...(buffer.metadataSnapshot || {}), ...change.metadataSnapshot };
-                }
-                this.pendingMutations.set(fileId, buffer);
-                this.updatePendingState();
-                const updateKeys = Object.keys(change.updates || {});
-                const descriptorParts = [];
-                if (change.operationType) descriptorParts.push(change.operationType);
-                if (change.updates?.stack) descriptorParts.push(`stack→${change.updates.stack}`);
-                if (change.updates?.stackSequence) descriptorParts.push(`seq=${change.updates.stackSequence}`);
-                if (descriptorParts.length === 0 && updateKeys.length > 0) {
-                    descriptorParts.push(updateKeys.join(', '));
-                }
-                const descriptor = descriptorParts.join(' · ') || 'update';
-                this.logger?.log({
-                    event: 'queue:buffer',
-                    level: 'info',
-                    fileId,
-                    details: `Buffered ${descriptor} (${debounce ? 'debounced' : 'immediate'})`,
-                    data: change
-                });
-
-                if (debounce) {
-                    clearTimeout(this.debounceTimers.get(fileId));
-                    this.debounceTimers.set(fileId, setTimeout(() => this.commitBufferedChange(fileId), this.debounceDelay));
-                    return Promise.resolve();
-                }
-                return this.commitBufferedChange(fileId);
-            }
-            async commitBufferedChange(fileId) {
-                const buffer = this.pendingMutations.get(fileId);
-                if (!buffer) return null;
-                this.pendingMutations.delete(fileId);
-                const timer = this.debounceTimers.get(fileId);
-                if (timer) {
-                    clearTimeout(timer);
-                    this.debounceTimers.delete(fileId);
-                }
-                const effectiveProviderType = buffer.providerType || this.providerType || state.providerType || null;
-                const effectiveFolderId = buffer.folderId || state.currentFolder?.id || null;
-                const effectiveFolderKey = buffer.folderKey || (effectiveProviderType && effectiveFolderId ? `${effectiveProviderType}::${effectiveFolderId}` : null);
-                const entry = {
-                    fileId,
-                    updates: buffer.updates,
-                    operationType: buffer.operationType,
-                    origin: buffer.origin,
-                    localUpdatedAt: buffer.localUpdatedAt,
-                    metadataSnapshot: buffer.metadataSnapshot,
-                    folderId: effectiveFolderId,
-                    providerType: effectiveProviderType,
-                    folderKey: effectiveFolderKey
-                };
-                const metadataRecord = state.imageFiles.find(file => file.id === fileId) || entry.metadataSnapshot || {};
-                const context = this.resolveEntryFolderContext(entry, metadataRecord);
-                const enrichedEntry = { ...entry, ...context };
-                const success = await this.processEntry(enrichedEntry, metadataRecord, context);
-                if (!success) {
-                    this.enqueueOfflineEntry(enrichedEntry, context);
-                }
-                this.updatePendingState();
-                return success;
-            }
-            async processEntry(entry, metadataRecord = null, folderContext = null) {
-                const provider = this.provider || state.provider;
-                const providerType = entry.providerType || this.providerType || state.providerType;
-                if (!provider || !providerType) {
-                    this.logger?.log({ event: 'sync:deferred', level: 'warn', fileId: entry.fileId, details: 'No provider bound. Will retry later.' });
-                    return false;
-                }
-                const updates = entry.updates || {};
-                const resolvedMetadata = metadataRecord || state.imageFiles.find(file => file.id === entry.fileId) || entry.metadataSnapshot || {};
-                const context = folderContext || this.resolveEntryFolderContext(entry, resolvedMetadata);
-                const payload = { ...resolvedMetadata, ...updates, localUpdatedAt: entry.localUpdatedAt };
-                payload.id = entry.fileId;
-                const stackLabel = updates.stack ? (STACK_NAMES[updates.stack] || updates.stack) : null;
-                const stackFragment = stackLabel ? ` (${stackLabel})` : '';
-                try {
-                    if (providerType === 'googledrive') {
-                        await provider.updateFileMetadata(entry.fileId, this.serializeGoogleMetadata(payload));
-                    } else if (providerType === 'onedrive') {
-                        await this.upsertOneDriveMetadata(entry.fileId, payload);
-                    } else if (typeof provider.updateFileMetadata === 'function') {
-                        await provider.updateFileMetadata(entry.fileId, payload);
-                    }
-                    if (resolvedMetadata && resolvedMetadata !== entry.metadataSnapshot) {
-                        Object.assign(resolvedMetadata, updates, { localUpdatedAt: entry.localUpdatedAt });
-                    }
-                    this.logger?.log({ event: 'sync:success', level: 'success', fileId: entry.fileId, details: `Applied ${entry.operationType}${stackFragment} to ${providerType}.`, data: { updates, stackLabel } });
-                    await this.recordFolderVersion(context);
-                    return true;
-                } catch (error) {
-                    this.logger?.log({ event: 'sync:error', level: 'error', fileId: entry.fileId, details: `Failed to sync ${entry.operationType}: ${error.message}`, data: { updates, stackLabel } });
-                    return false;
-                }
-            }
-            resolveEntryFolderContext(entry, metadataRecord = {}) {
-                let providerType = entry?.providerType || metadataRecord.providerType || this.providerType || state.providerType || null;
-                let folderId = entry?.folderId || metadataRecord.folderId || null;
-                if (!folderId && entry?.metadataSnapshot?.folderId) {
-                    folderId = entry.metadataSnapshot.folderId;
-                }
-                if (!folderId && Array.isArray(metadataRecord.parents) && metadataRecord.parents.length > 0) {
-                    folderId = metadataRecord.parents[0];
-                }
-                if (!folderId && metadataRecord.parentReference?.id) {
-                    folderId = metadataRecord.parentReference.id;
-                }
-                if (!folderId && entry?.folderKey) {
-                    const parts = entry.folderKey.split('::');
-                    if (!providerType && parts.length > 0) {
-                        providerType = parts[0] || providerType;
-                    }
-                    folderId = parts.length > 1 ? parts.slice(1).join('::') : parts[0];
-                }
-                if (!folderId && state.currentFolder?.id) {
-                    folderId = state.currentFolder.id;
-                }
-                const folderKey = entry?.folderKey || (providerType && folderId ? `${providerType}::${folderId}` : null);
-                return { folderId, providerType, folderKey };
-            }
-            enqueueOfflineEntry(entry, context = null) {
-                const resolvedContext = context || this.resolveEntryFolderContext(entry, entry.metadataSnapshot || {});
-                const providerType = resolvedContext.providerType || entry.providerType || this.providerType || state.providerType || 'unknown';
-                const folderId = resolvedContext.folderId || 'global';
-                const folderKey = resolvedContext.folderKey || `${providerType}::${folderId}`;
-                if (!this.offlineQueue.has(folderKey)) {
-                    this.offlineQueue.set(folderKey, new Map());
-                }
-                const folderEntries = this.offlineQueue.get(folderKey);
-                folderEntries.set(entry.fileId, { ...entry, ...resolvedContext });
-                this.logger?.log({ event: 'offline:queue', level: 'warn', fileId: entry.fileId, details: `Queued offline mutation for ${folderKey}.` });
-                this.updatePendingState();
-            }
-            async recordFolderVersion(context) {
-                if (!context?.folderId || !state.folderSyncCoordinator) {
-                    return;
-                }
-                try {
-                    await state.folderSyncCoordinator.recordLocalFlush(context.folderId, {
-                        timestamp: Date.now(),
-                        providerType: context.providerType || this.providerType || state.providerType || null
-                    });
-                } catch (error) {
-                    this.logger?.log({ event: 'foldersync:version:error', level: 'error', details: `Failed to record folder flush: ${error.message}` });
-                }
-            }
-            updatePendingState() {
-                let offlineCount = 0;
-                for (const entries of this.offlineQueue.values()) {
-                    offlineCount += entries.size;
-                }
-                this.hasPendingWork = this.pendingMutations.size > 0 || offlineCount > 0;
-            }
-            serializeGoogleMetadata(payload) {
+        class CloudWriter {
+            static serializeGoogleMetadata(payload) {
                 const tags = Array.isArray(payload.tags) ? payload.tags : [];
                 return {
                     slideboxStack: payload.stack || 'in',
@@ -3014,7 +2238,7 @@
                     favorite: payload.favorite ? 'true' : 'false'
                 };
             }
-            serializeGenericMetadata(payload) {
+            static serializeGenericMetadata(payload) {
                 return {
                     stack: payload.stack || 'in',
                     tags: Array.isArray(payload.tags) ? payload.tags : [],
@@ -3026,20 +2250,20 @@
                     localUpdatedAt: payload.localUpdatedAt || Date.now()
                 };
             }
-            async upsertOneDriveMetadata(fileId, payload) {
-                const provider = this.provider || state.provider;
+            static async upsertOneDriveMetadata(file, payload) {
+                const provider = state.provider;
                 if (!provider || typeof provider.getAccessToken !== 'function') {
                     throw new Error('Active provider missing access token helper');
                 }
                 const token = await provider.getAccessToken();
-                const endpoint = `https://graph.microsoft.com/v1.0/me/drive/special/approot:/${fileId}.json:/content`;
+                const endpoint = `https://graph.microsoft.com/v1.0/me/drive/special/approot:/${file.id}.json:/content`;
                 const headers = { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' };
                 let existing = null;
                 try {
                     const response = await fetch(endpoint, { method: 'GET', headers });
                     if (response.ok) {
                         existing = await response.json();
-                        this.logger?.log({ event: 'onedrive:metadata:get', level: 'info', fileId, details: 'Fetched existing metadata file.' });
+                        state.syncLog?.log({ event: 'onedrive:metadata:get', level: 'info', fileId: file.id, details: 'Fetched existing metadata file.' });
                     } else if (response.status !== 404) {
                         const text = await response.text();
                         throw new Error(`GET ${response.status}: ${text}`);
@@ -3055,23 +2279,47 @@
                     const text = await putResponse.text();
                     throw new Error(`PUT ${putResponse.status}: ${text}`);
                 }
-                this.logger?.log({ event: 'onedrive:metadata:upsert', level: 'info', fileId, details: 'Upserted OneDrive metadata document.' });
+                state.syncLog?.log({ event: 'onedrive:metadata:upsert', level: 'info', fileId: file.id, details: 'Upserted OneDrive metadata document.' });
             }
-            async flush({ reason = 'manual' } = {}) {
-                this.logger?.log({ event: 'flush:request', level: 'info', details: `Flush requested (${reason}).` });
-                const bufferedIds = Array.from(this.pendingMutations.keys());
-                if (bufferedIds.length > 0) {
-                    await Promise.all(bufferedIds.map(id => this.commitBufferedChange(id)));
+            static async pushFileToCloud(file) {
+                if (!file || !state.provider) return;
+                const provider = state.provider;
+                if (state.providerType === 'googledrive') {
+                    const metadata = this.serializeGoogleMetadata(file);
+                    await provider.updateFileMetadata(file.id, metadata);
+                } else if (state.providerType === 'onedrive') {
+                    await this.upsertOneDriveMetadata(file, file);
+                } else if (typeof provider.updateFileMetadata === 'function') {
+                    await provider.updateFileMetadata(file.id, file);
                 }
-                const result = await this.retryOfflineQueue(reason);
-                this.updatePendingState();
-                return result;
             }
-            requestSync(reason = 'manual-request') {
-                this.logger?.log({ event: 'sync:request', level: 'info', details: `Manual sync requested (${reason}).` });
-                this.flush({ reason }).catch(error => {
-                    this.logger?.log({ event: 'sync:request:error', level: 'error', details: `Sync request failed: ${error.message}` });
-                });
+            static async flushPending(reason = 'manual') {
+                if (!state.provider || state.pendingCloudWrites.size === 0) {
+                    return { status: 'idle', reason };
+                }
+                const ids = Array.from(state.pendingCloudWrites);
+                const failures = [];
+                state.syncLog?.log({ event: 'cloudwriter:flush:start', level: 'info', details: `Flushing ${ids.length} update(s) to cloud [${reason}]` });
+                for (const id of ids) {
+                    const file = state.imageFiles.find(item => item.id === id);
+                    if (!file) {
+                        state.pendingCloudWrites.delete(id);
+                        continue;
+                    }
+                    try {
+                        await this.pushFileToCloud(file);
+                        state.pendingCloudWrites.delete(id);
+                        state.syncLog?.log({ event: 'cloudwriter:flush:success', level: 'success', fileId: id, details: `Applied updates to ${state.providerType}` });
+                    } catch (error) {
+                        failures.push({ id, error });
+                        state.syncLog?.log({ event: 'cloudwriter:flush:error', level: 'error', fileId: id, details: error.message });
+                    }
+                }
+                const status = failures.length === 0 ? 'complete' : 'partial';
+                if (failures.length > 0) {
+                    failures.forEach(({ id }) => state.pendingCloudWrites.add(id));
+                }
+                return { status, failures, reason };
             }
         }
         class VisualCueManager {
@@ -3930,8 +3178,6 @@
                 state.providerType = type;
                 const isGoogle = type === 'googledrive';
                 state.provider = isGoogle ? new GoogleDriveProvider() : new OneDriveProvider();
-                state.syncManager?.setProviderContext({ provider: state.provider, providerType: state.providerType });
-                state.folderSyncCoordinator?.setProviderContext({ provider: state.provider, providerType: state.providerType });
 
                 if (state.provider.isAuthenticated) {
                     Utils.showScreen('folder-screen');
@@ -3983,12 +3229,8 @@
                 }
             },
             async backToProviderSelection() {
-                if (state.syncManager) {
-                    await state.syncManager.flush({ reason: 'provider-screen' });
-                    await state.syncManager.stop();
-                    state.syncManager.setProviderContext({ provider: null, providerType: null });
-                }
-                state.folderSyncCoordinator?.setProviderContext({ provider: null, providerType: null });
+                await CloudWriter.flushPending('provider-screen');
+                state.pendingCloudWrites.clear();
                 state.provider = null;
                 state.providerType = null;
                 state.navigationToken = Symbol('navigation');
@@ -4007,11 +3249,6 @@
                     const loaded = await this.loadImages({ navigationToken });
                     if (loaded) {
                         this.switchToCommonUI();
-                        if (state.syncManager) {
-                            state.syncManager.setProviderContext({ provider: state.provider, providerType: state.providerType });
-                            state.syncManager.start();
-                        }
-                        state.folderSyncCoordinator?.setProviderContext({ provider: state.provider, providerType: state.providerType });
                     }
                 } catch (error) {
                     Utils.showToast(`Initialization failed: ${error.message}`, 'error', true);
@@ -4033,39 +3270,21 @@
                 }
 
                 const sessionKey = `${state.providerType || 'unknown'}::${folderId}`;
-                const cachedFiles = await state.dbManager.getFolderCache(folderId) || [];
-                if (!this.isNavigationActive(navigationToken)) {
-                    return false;
-                }
-                const isFirstSessionVisit = !state.sessionVisitedFolders.has(sessionKey);
-                const coordinator = state.folderSyncCoordinator;
-                let preparation = null;
+                Utils.showScreen('loading-screen');
+                Utils.updateLoadingProgress(0, 0, 'Fetching from cloud...');
 
                 try {
-                    if (coordinator) {
-                        preparation = await coordinator.prepareFolder(folderId, { forceFullResync: Boolean(options.forceFullResync) });
-                        if (!this.isNavigationActive(navigationToken)) {
-                            return false;
-                        }
+                    const result = await state.provider.getFilesAndMetadata(folderId);
+                    if (!this.isNavigationActive(navigationToken)) {
+                        return false;
                     }
 
-                    const shouldFullSync = Boolean(
-                        preparation?.mode === 'full' ||
-                        cachedFiles.length === 0 ||
-                        isFirstSessionVisit ||
-                        options.forceFullResync
-                    );
+                    const files = Array.isArray(result?.files) ? result.files : [];
+                    state.imageFiles = files;
+                    state.pendingCloudWrites.clear();
 
-                    const mustRefreshFromCloud = true; // Always refresh to capture latest cloud changes per folder load.
-                    const canUseCache = !mustRefreshFromCloud && !shouldFullSync && (preparation?.mode === 'cache' || !coordinator);
-
-                    if (!canUseCache) {
-                        const synced = await this.syncFolderFromCloud(cachedFiles, sessionKey, { preparation, navigationToken });
-                        return synced !== false;
-                    }
-
-                    state.imageFiles = cachedFiles;
-                    await this.processAllMetadata(state.imageFiles, false, { navigationToken });
+                    await state.dbManager.saveFolderCache(folderId, state.imageFiles);
+                    await this.processAllMetadata(state.imageFiles, true, { navigationToken });
                     if (!this.isNavigationActive(navigationToken)) {
                         return false;
                     }
@@ -4075,20 +3294,6 @@
                     Core.initializeImageDisplay();
                     state.sessionVisitedFolders.add(sessionKey);
 
-                    if (!this.isNavigationActive(navigationToken)) {
-                        return false;
-                    }
-
-                    const cacheLog = {
-                        event: 'foldersync:cache-hit',
-                        level: 'info',
-                        details: `Hydrated ${folderId} from cache`
-                    };
-                    if (preparation?.remoteVersion != null) {
-                        cacheLog.data = { cloudVersion: preparation.remoteVersion };
-                    }
-                    state.syncLog?.log(cacheLog);
-
                     return state.imageFiles.length > 0;
                 } catch (error) {
                     if (error?.name !== 'AbortError') {
@@ -4097,296 +3302,7 @@
                     await this.returnToFolderSelection();
                     return false;
                 }
-            },
-            mergeCloudWithCache(cloudFiles, cachedFiles) {
-                const cachedMap = new Map(cachedFiles.map(file => [file.id, file]));
-                const merged = [];
-                const newIds = [];
-                const updatedIds = [];
-                const removedIds = [];
-
-                const normalizeForComparison = (value) => {
-                    if (value === null || value === undefined) return null;
-                    if (Array.isArray(value)) {
-                        return value.map(item => normalizeForComparison(item));
-                    }
-                    if (typeof value === 'object') {
-                        const normalized = {};
-                        Object.keys(value)
-                            .sort()
-                            .forEach(key => {
-                                normalized[key] = normalizeForComparison(value[key]);
-                            });
-                        return normalized;
-                    }
-                    return value;
-                };
-
-                const hasProviderDifferences = (cached = {}, cloud = {}) => {
-                    const primitiveFields = [
-                        'name', 'size', 'mimeType', 'createdTime', 'modifiedTime',
-                        'thumbnailLink', 'webContentLink', 'webViewLink', 'downloadUrl',
-                        'md5Checksum', 'checksum', 'width', 'height'
-                    ];
-                    for (const field of primitiveFields) {
-                        if ((cached?.[field] ?? null) !== (cloud?.[field] ?? null)) {
-                            return true;
-                        }
-                    }
-
-                    const structuredFields = [
-                        'appProperties', 'shortcutDetails', 'parents',
-                        'imageMediaMetadata', 'videoMediaMetadata', 'thumbnails'
-                    ];
-                    for (const field of structuredFields) {
-                        const cachedValue = normalizeForComparison(cached?.[field]);
-                        const cloudValue = normalizeForComparison(cloud?.[field]);
-                        if (JSON.stringify(cachedValue) !== JSON.stringify(cloudValue)) {
-                            return true;
-                        }
-                    }
-
-                    return false;
-                };
-
-                for (const cloudFile of cloudFiles) {
-                    const cached = cachedMap.get(cloudFile.id);
-                    if (!cached) {
-                        merged.push({ ...cloudFile });
-                        newIds.push(cloudFile.id);
-                    } else {
-                        const mergedFile = { ...cached, ...cloudFile };
-                        if (hasProviderDifferences(cached, cloudFile)) {
-                            updatedIds.push(cloudFile.id);
-                        }
-                        merged.push(mergedFile);
-                        cachedMap.delete(cloudFile.id);
-                    }
-                }
-
-                for (const removedId of cachedMap.keys()) {
-                    removedIds.push(removedId);
-                }
-
-                return {
-                    mergedFiles: merged,
-                    newIds,
-                    updatedIds,
-                    removedIds,
-                    hasChanges: newIds.length > 0 || updatedIds.length > 0 || removedIds.length > 0
-                };
-            },
-            async syncFolderFromCloud(cachedFiles, sessionKey, options = {}) {
-                const folderId = state.currentFolder.id;
-                const hadCached = cachedFiles.length > 0;
-                const coordinator = state.folderSyncCoordinator;
-                const preparation = options.preparation || null;
-                const navigationToken = options.navigationToken || state.navigationToken;
-                if (!this.isNavigationActive(navigationToken)) {
-                    return false;
-                }
-                Utils.showScreen('loading-screen');
-                Utils.updateLoadingProgress(0, hadCached ? cachedFiles.length : 0, hadCached ? 'Syncing with cloud...' : 'Fetching from cloud...');
-
-                try {
-                    const result = await state.provider.getFilesAndMetadata(folderId);
-                    if (!this.isNavigationActive(navigationToken)) {
-                        return false;
-                    }
-                    const cloudFiles = result.files || [];
-                    const { mergedFiles, newIds, updatedIds, removedIds, hasChanges } = this.mergeCloudWithCache(cloudFiles, cachedFiles);
-
-                    if (mergedFiles.length === 0) {
-                        await state.dbManager.saveFolderCache(folderId, []);
-                        state.imageFiles = [];
-                        const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
-                        if (!this.isNavigationActive(navigationToken)) {
-                            return false;
-                        }
-                        state.sessionVisitedFolders.add(key);
-                        this.switchToCommonUI();
-                        Core.initializeStacks();
-                        Core.showEmptyState();
-                        Core.updateStackCounts();
-
-                        if (coordinator) {
-                            const manifestEntries = coordinator.buildManifestFromFiles(folderId, []);
-                            const fallbackVersion = preparation?.localManifest?.cloudVersion ?? preparation?.remoteVersion ?? Date.now();
-                            const fallbackLocalVersion = preparation?.localManifest?.localVersion ?? fallbackVersion;
-                            const manifestPayload = {
-                                entries: manifestEntries,
-                                requiresFullResync: false,
-                                cloudVersion: fallbackVersion,
-                                localVersion: fallbackLocalVersion,
-                                manifestFileId: preparation?.localManifest?.manifestFileId || preparation?.manifestFileId || null
-                            };
-                            if (this.isNavigationActive(navigationToken)) {
-                                await coordinator.persistManifest(folderId, manifestPayload, {
-                                    cloudVersion: manifestPayload.cloudVersion,
-                                    localVersion: manifestPayload.localVersion,
-                                    lastDiffSummary: { new: 0, updated: 0, removed: cachedFiles.length }
-                                });
-                                await coordinator.persistFolderState(folderId, {
-                                    cloudVersion: manifestPayload.cloudVersion,
-                                    localVersion: manifestPayload.localVersion,
-                                    lastCloudAck: Date.now()
-                                });
-                            }
-                        }
-
-                        Utils.showToast('No images found in this folder', 'info', true);
-                        return true;
-                    }
-
-                    for (const updatedId of updatedIds) {
-                        const updatedFile = mergedFiles.find(file => file.id === updatedId);
-                        if (updatedFile) {
-                            await state.dbManager.saveMetadata(updatedId, updatedFile, { folderId, providerType: state.providerType });
-                        }
-                    }
-                    if (removedIds.length > 0) {
-                        await Promise.all(removedIds.map(id => state.dbManager.deleteMetadata(id)));
-                    }
-
-                    state.imageFiles = mergedFiles;
-                    await this.processAllMetadata(state.imageFiles, !hadCached, { navigationToken });
-                    if (!this.isNavigationActive(navigationToken)) {
-                        return false;
-                    }
-                    if (hasChanges || !hadCached) {
-                        await state.dbManager.saveFolderCache(folderId, state.imageFiles);
-                    }
-
-                    const key = sessionKey || `${state.providerType || 'unknown'}::${folderId}`;
-                    if (this.isNavigationActive(navigationToken)) {
-                        state.sessionVisitedFolders.add(key);
-                        this.switchToCommonUI();
-                        Core.initializeStacks();
-                        Core.initializeImageDisplay();
-                    } else {
-                        return false;
-                    }
-
-                    if (coordinator) {
-                        const manifestEntries = coordinator.buildManifestFromFiles(folderId, state.imageFiles);
-                        let manifestFileId = preparation?.manifestFileId ?? preparation?.localManifest?.manifestFileId ?? null;
-                        if (!manifestFileId && state.provider && typeof state.provider.loadFolderManifest === 'function') {
-                            try {
-                                const lookup = await state.provider.loadFolderManifest(folderId, { signal: state.activeRequests?.signal });
-                                if (lookup?.manifestFileId) {
-                                    manifestFileId = lookup.manifestFileId;
-                                }
-                            } catch (error) {
-                                state.syncLog?.log({ event: 'manifest:lookup:pre-save', level: 'warn', details: `Manifest lookup before save failed: ${error.message}` });
-                            }
-                        }
-
-                        const baseCloudVersion = preparation?.localManifest?.cloudVersion ?? preparation?.remoteVersion ?? Date.now();
-                        const baseLocalVersion = preparation?.localManifest?.localVersion ?? baseCloudVersion;
-                        let remoteManifestResponse = null;
-                        let manifestRequiresRescan = false;
-
-                        if (state.provider && typeof state.provider.saveFolderManifest === 'function' && this.isNavigationActive(navigationToken)) {
-                            try {
-                                const manifestOptions = { manifestFileId };
-                                remoteManifestResponse = await state.provider.saveFolderManifest(folderId, {
-                                    entries: manifestEntries,
-                                    requiresFullResync: false,
-                                    cloudVersion: baseCloudVersion,
-                                    localVersion: baseLocalVersion,
-                                    manifestFileId
-                                }, manifestOptions);
-                                state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted manifest for ${folderId}`, data: { entries: Object.keys(manifestEntries).length } });
-                            } catch (error) {
-                                if (error?.name === 'AbortError') {
-                                    state.syncLog?.log({ event: 'manifest:save:aborted', level: 'warn', details: `Manifest save cancelled: ${error.message}` });
-                                } else {
-                                    manifestRequiresRescan = true;
-                                    state.syncLog?.log({ event: 'manifest:save:error', level: 'error', details: `Manifest save failed: ${error.message}` });
-                                }
-                            }
-                        }
-
-                        const finalCloudVersion = remoteManifestResponse?.cloudVersion ?? baseCloudVersion;
-                        const finalLocalVersion = remoteManifestResponse?.localVersion ?? baseLocalVersion;
-                        const finalManifestFileId = remoteManifestResponse?.manifestFileId ?? manifestFileId ?? preparation?.localManifest?.manifestFileId ?? null;
-                        const manifestPayload = {
-                            entries: manifestEntries,
-                            requiresFullResync: manifestRequiresRescan,
-                            cloudVersion: finalCloudVersion,
-                            localVersion: finalLocalVersion,
-                            manifestFileId: finalManifestFileId
-                        };
-                        if (this.isNavigationActive(navigationToken)) {
-                            await coordinator.persistManifest(folderId, manifestPayload, {
-                                cloudVersion: manifestPayload.cloudVersion,
-                                localVersion: manifestPayload.localVersion,
-                                lastDiffSummary: { new: newIds.length, updated: updatedIds.length, removed: removedIds.length }
-                            });
-                            await coordinator.persistFolderState(folderId, {
-                                cloudVersion: manifestPayload.cloudVersion,
-                                localVersion: Math.max(manifestPayload.localVersion ?? 0, manifestPayload.cloudVersion ?? 0),
-                                lastCloudAck: Date.now()
-                            });
-                            if (manifestPayload.requiresFullResync) {
-                                await coordinator.markRequiresFullResync(folderId, 'manifest-save-failed');
-                            }
-                        }
-                    }
-
-                    if (hadCached && hasChanges) {
-                        const diffSummary = [];
-                        if (newIds.length > 0) diffSummary.push(`${newIds.length} new`);
-                        if (updatedIds.length > 0) diffSummary.push(`${updatedIds.length} updated`);
-                        if (removedIds.length > 0) diffSummary.push(`${removedIds.length} removed`);
-                        const summaryText = diffSummary.length > 0 ? diffSummary.join(', ') : 'changes';
-                        Utils.showToast(`Folder updated with cloud changes (${summaryText})`, 'info');
-                    }
-                } catch (error) {
-                    if (error.name !== 'AbortError') {
-                        Utils.showToast(`Error loading images: ${error.message}`, 'error', true);
-                    }
-                    this.returnToFolderSelection();
-                }
-            },
-            async refreshFolderInBackground() {
-                try {
-                    const navigationToken = state.navigationToken;
-                    const folderId = state.currentFolder.id;
-                    const cachedFiles = await state.dbManager.getFolderCache(folderId) || [];
-                    const result = await state.provider.getFilesAndMetadata(folderId);
-                    const cloudFiles = result.files || [];
-                    const { mergedFiles, updatedIds, removedIds, hasChanges } = this.mergeCloudWithCache(cloudFiles, cachedFiles);
-
-                    if (!hasChanges) {
-                        return;
-                    }
-
-                    for (const updatedId of updatedIds) {
-                        const updatedFile = mergedFiles.find(file => file.id === updatedId);
-                        if (updatedFile) {
-                        await state.dbManager.saveMetadata(updatedId, updatedFile, { folderId, providerType: state.providerType });
-                        }
-                    }
-                    if (removedIds.length > 0) {
-                        await Promise.all(removedIds.map(id => state.dbManager.deleteMetadata(id)));
-                    }
-
-                    await this.processAllMetadata(mergedFiles, false, { navigationToken });
-                    if (!this.isNavigationActive(navigationToken)) {
-                        return;
-                    }
-                    await state.dbManager.saveFolderCache(folderId, mergedFiles);
-                    state.imageFiles = mergedFiles;
-                    Core.initializeStacks();
-                    Core.updateStackCounts();
-                    if (state.imageFiles.length > 0) Core.displayCurrentImage();
-                    else Core.showEmptyState();
-                    Utils.showToast('Folder updated in background', 'info');
-                } catch (error) {
-                    console.warn("Background refresh failed:", error.message);
-                }
-            },
+            }
             async processAllMetadata(files, isFirstLoad = false, options = {}) {
                  const { navigationToken = null } = options;
                  if (isFirstLoad) Utils.updateLoadingProgress(0, files.length, 'Processing files...');
@@ -4486,9 +3402,8 @@
                 Utils.showScreen('folder-screen');
 
                 try {
-                    if (state.syncManager) {
-                        await state.syncManager.flush({ reason: 'folder-switch' });
-                    }
+                    await CloudWriter.flushPending('folder-switch');
+                    state.pendingCloudWrites.clear();
                     state.activeRequests?.abort();
                     // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
                     state.activeRequests = new AbortController();
@@ -4547,17 +3462,9 @@
                     Object.assign(file, updates, { localUpdatedAt: timestamp });
                     await state.dbManager.saveMetadata(file.id, file, { folderId: state.currentFolder.id, providerType: state.providerType });
                     await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
-                    if (state.syncManager) {
-                        await state.syncManager.queueLocalChange({
-                            fileId,
-                            updates,
-                            operationType,
-                            origin,
-                            localUpdatedAt: timestamp,
-                            folderId: state.currentFolder.id,
-                            providerType: state.providerType,
-                            metadataSnapshot: { name: file.name, stack: file.stack, stackSequence: file.stackSequence, folderId: state.currentFolder.id }
-                        }, { debounce: !skipDebounce });
+                    state.pendingCloudWrites.add(fileId);
+                    if (skipDebounce) {
+                        await CloudWriter.flushPending('immediate-update');
                     }
                 } catch (error) {
                     Utils.showToast(`Failed to update metadata: ${error.message}`, 'error', true);
@@ -4667,8 +3574,8 @@
                     state.syncLog?.log({ event: 'foldersync:reset', level: 'warn', details: `Resetting folder ${folderId}.` });
                     const cachedFiles = await state.dbManager.getFolderCache(folderId) || [];
                     const fileIds = cachedFiles.map(file => file.id);
+                    await CloudWriter.flushPending('folder-reset');
                     await state.dbManager.clearFolderData({ providerType, folderId }, fileIds);
-                    await state.folderSyncCoordinator?.markRequiresFullResync(folderId, 'user-reset');
                     state.sessionVisitedFolders.delete(`${providerType || 'unknown'}::${folderId}`);
                     Utils.showToast('Folder cache cleared. Resyncing...', 'info');
                     const navigationToken = Symbol('navigation');
@@ -6854,13 +5761,8 @@ this.updateImageCounters();
                 state.export = new ExportSystem();
                 state.dbManager = new DBManager();
                 await state.dbManager.init();
-                state.folderSyncCoordinator = new FolderSyncCoordinator({ dbManager: state.dbManager, logger: state.syncLog });
-                state.syncManager = new SyncManager({ dbManager: state.dbManager, logger: state.syncLog });
                 window.__orbitalAppState = state;
-                window.__orbitalFolderSyncCoordinator = state.folderSyncCoordinator;
                 window.__orbitalDbManager = state.dbManager;
-                window.__orbitalSyncManager = state.syncManager;
-                state.syncManager.start();
                 state.metadataExtractor = new MetadataExtractor();
                 Utils.showScreen('provider-screen');
                 Events.init();


### PR DESCRIPTION
## Summary
- replace the complex IndexedDB sync stores with a leaner DB manager and a new CloudWriter helper
- always reload folder contents directly from the cloud when v9b opens a folder and clear any pending write queue
- batch up metadata edits locally and flush them to the provider only when leaving a folder, switching providers, or when explicitly required

## Testing
- not run (HTML change only)

------
https://chatgpt.com/codex/tasks/task_e_68e3a7085e20832d90e5fbd42e3ae081