### PR TITLE
Replace SyncManager with idle SimpleSync controller

### DIFF
--- a/ui-v8.html
+++ b/ui-v8.html
@@ -2799,36 +2799,29 @@
                 return nextVersion;
             }
         }
-        class SyncManager {
-            constructor({ dbManager, logger } = {}) {
+        class SimpleSync {
+            constructor({ dbManager, logger, idleDelay = 7000 } = {}) {
                 this.dbManager = dbManager || null;
                 this.logger = logger || null;
-                this.pendingMutations = new Map();
-                this.debounceTimers = new Map();
-                this.debounceDelay = 750;
-                this.syncTimer = null;
-                this.isProcessing = false;
-                this.isActive = false;
-                this.hasPendingWork = false;
+                this.idleDelay = idleDelay;
+                this.pendingChanges = new Map();
                 this.provider = null;
                 this.providerType = null;
-                this.pendingManifestUpdates = new Map();
+                this.idleTimer = null;
+                this.isFlushing = false;
+                this.hasFollowUpFlush = false;
+                this.isActive = false;
                 this.lifecycleHandlers = {
                     visibility: () => this.handleVisibilityChange(),
-                    pagehide: (event) => this.handlePageHide(event),
+                    pagehide: () => this.handlePageHide(),
                     beforeUnload: (event) => this.handleBeforeUnload(event)
                 };
             }
-            setLogger(logger) { this.logger = logger; }
-            setDbManager(dbManager) { this.dbManager = dbManager; }
+            setLogger(logger) { this.logger = logger || null; }
+            setDbManager(dbManager) { this.dbManager = dbManager || null; }
             setProviderContext({ provider, providerType }) {
                 this.provider = provider || null;
                 this.providerType = providerType || null;
-                this.logger?.log({
-                    event: 'provider:context',
-                    level: 'info',
-                    details: this.provider ? `Bound to provider ${this.providerType}` : 'Cleared provider context.'
-                });
             }
             start() {
                 if (this.isActive) return;
@@ -2836,327 +2829,124 @@
                 window.addEventListener('pagehide', this.lifecycleHandlers.pagehide);
                 window.addEventListener('beforeunload', this.lifecycleHandlers.beforeUnload);
                 this.isActive = true;
-                this.resumePendingQueue();
             }
             async stop() {
-                const flushResult = await this.flush({ reason: 'stop' });
-                if (!this.isActive) {
-                    this.provider = null;
-                    this.providerType = null;
-                    this.pendingManifestUpdates.clear();
-                    return flushResult;
-                }
+                await this.flushNow({ reason: 'stop' });
+                if (!this.isActive) return;
                 document.removeEventListener('visibilitychange', this.lifecycleHandlers.visibility);
                 window.removeEventListener('pagehide', this.lifecycleHandlers.pagehide);
                 window.removeEventListener('beforeunload', this.lifecycleHandlers.beforeUnload);
                 this.isActive = false;
-                this.provider = null;
-                this.providerType = null;
-                this.pendingManifestUpdates.clear();
-                return flushResult;
             }
-            async resumePendingQueue() {
-                if (!this.dbManager) return;
+            recordChange(change = {}) {
+                if (!change.fileId) return;
+                const existing = this.pendingChanges.get(change.fileId) || { updates: {}, folderId: null, providerType: null, localUpdatedAt: 0, errorCount: 0 };
+                existing.updates = { ...existing.updates, ...(change.updates || {}) };
+                existing.folderId = change.folderId || existing.folderId || state.currentFolder?.id || null;
+                existing.providerType = change.providerType || existing.providerType || this.providerType || state.providerType || null;
+                existing.localUpdatedAt = change.localUpdatedAt || existing.localUpdatedAt || Date.now();
+                existing.errorCount = 0;
+                this.pendingChanges.set(change.fileId, existing);
+                this.logger?.log({ event: 'sync:queued', level: 'info', fileId: change.fileId, details: 'Queued metadata change.' });
+                this.scheduleIdleFlush();
+            }
+            scheduleIdleFlush(delay = this.idleDelay) {
+                if (delay <= 0) delay = this.idleDelay;
+                this.clearIdleTimer();
+                this.idleTimer = setTimeout(() => {
+                    this.flushNow({ reason: 'idle' });
+                }, delay);
+            }
+            clearIdleTimer() {
+                if (this.idleTimer) {
+                    clearTimeout(this.idleTimer);
+                    this.idleTimer = null;
+                }
+            }
+            async flushNow({ reason = 'manual' } = {}) {
+                this.clearIdleTimer();
+                if (this.pendingChanges.size === 0) return;
+                this.logger?.log({ event: 'sync:flush', level: 'info', details: `Flushing metadata changes (${reason}).` });
+                await this.processPending(reason);
+            }
+            async processPending(reason) {
+                if (this.isFlushing) {
+                    this.hasFollowUpFlush = true;
+                    return;
+                }
+                if (this.pendingChanges.size === 0) return;
+                const activeProvider = this.provider || state.provider;
+                const activeProviderType = this.providerType || state.providerType || null;
+                if (!activeProvider && this.pendingChanges.size > 0) {
+                    this.logger?.log({ event: 'sync:deferred', level: 'warn', details: 'No provider bound. Will retry later.' });
+                    this.scheduleIdleFlush();
+                    return;
+                }
+                this.isFlushing = true;
+                const updatedFileIds = new Set();
                 try {
-                    const queue = await this.dbManager.readSyncQueue();
-                    if (queue.length > 0) {
-                        const pending = queue.filter(item => item.pendingFlush);
-                        if (pending.length > 0) {
-                            await this.dbManager.markPendingFlush(pending.map(item => item.id), false);
-                            this.logger?.log({ event: 'queue:resume', level: 'warn', details: `Resuming ${pending.length} pending flush entries.` });
-                        } else {
-                            this.logger?.log({ event: 'queue:resume', level: 'info', details: `Sync queue contains ${queue.length} entries.` });
+                    for (const [fileId, entry] of this.pendingChanges.entries()) {
+                        const file = state.imageFiles.find(f => f.id === fileId);
+                        if (!file) {
+                            this.pendingChanges.delete(fileId);
+                            continue;
                         }
-                        this.hasPendingWork = true;
-                        this.scheduleProcess('resume');
-                    } else {
-                        this.hasPendingWork = this.pendingMutations.size > 0;
-                    }
-                } catch (error) {
-                    this.logger?.log({ event: 'queue:resume:error', level: 'error', details: `Failed to resume queue: ${error.message}` });
-                }
-            }
-            queueLocalChange(change, options = {}) {
-                if (!change || !change.fileId) return Promise.resolve();
-                const { debounce = true } = options;
-                const fileId = change.fileId;
-                const buffer = this.pendingMutations.get(fileId) || {
-                    updates: {},
-                    operationType: change.operationType || 'metadata:update',
-                    origin: change.origin || 'ui'
-                };
-                const resolvedFolderId = change.folderId || buffer.folderId || state.currentFolder?.id || null;
-                const resolvedProviderType = change.providerType || buffer.providerType || this.providerType || state.providerType || null;
-                const resolvedFolderKey = change.folderKey || buffer.folderKey || (resolvedFolderId && resolvedProviderType ? `${resolvedProviderType}::${resolvedFolderId}` : null);
-                buffer.folderId = resolvedFolderId;
-                buffer.providerType = resolvedProviderType;
-                buffer.folderKey = resolvedFolderKey;
-                buffer.updates = { ...buffer.updates, ...(change.updates || {}) };
-                buffer.operationType = change.operationType || buffer.operationType;
-                buffer.origin = change.origin || buffer.origin;
-                buffer.localUpdatedAt = change.localUpdatedAt || Date.now();
-                if (change.metadataSnapshot) {
-                    buffer.metadataSnapshot = { ...(buffer.metadataSnapshot || {}), ...change.metadataSnapshot };
-                }
-                this.pendingMutations.set(fileId, buffer);
-                this.hasPendingWork = true;
-                const updateKeys = Object.keys(change.updates || {});
-                const descriptorParts = [];
-                if (change.operationType) descriptorParts.push(change.operationType);
-                if (change.updates?.stack) descriptorParts.push(`stack→${change.updates.stack}`);
-                if (change.updates?.stackSequence) descriptorParts.push(`seq=${change.updates.stackSequence}`);
-                if (descriptorParts.length === 0 && updateKeys.length > 0) {
-                    descriptorParts.push(updateKeys.join(', '));
-                }
-                const descriptor = descriptorParts.join(' · ') || 'update';
-                this.logger?.log({
-                    event: 'queue:buffer',
-                    level: 'info',
-                    fileId,
-                    details: `Buffered ${descriptor} (${debounce ? 'debounced' : 'immediate'})`,
-                    data: change
-                });
-
-                if (debounce) {
-                    clearTimeout(this.debounceTimers.get(fileId));
-                    this.debounceTimers.set(fileId, setTimeout(() => this.commitBufferedChange(fileId), this.debounceDelay));
-                    return Promise.resolve();
-                }
-                return this.commitBufferedChange(fileId);
-            }
-            async commitBufferedChange(fileId) {
-                const buffer = this.pendingMutations.get(fileId);
-                if (!buffer) return null;
-                this.pendingMutations.delete(fileId);
-                const timer = this.debounceTimers.get(fileId);
-                if (timer) {
-                    clearTimeout(timer);
-                    this.debounceTimers.delete(fileId);
-                }
-                if (!this.dbManager) return null;
-                const effectiveProviderType = buffer.providerType || this.providerType || state.providerType || null;
-                const effectiveFolderId = buffer.folderId || state.currentFolder?.id || null;
-                const effectiveFolderKey = buffer.folderKey || (effectiveProviderType && effectiveFolderId ? `${effectiveProviderType}::${effectiveFolderId}` : null);
-                const entry = {
-                    fileId,
-                    updates: buffer.updates,
-                    operationType: buffer.operationType,
-                    origin: buffer.origin,
-                    localUpdatedAt: buffer.localUpdatedAt,
-                    metadataSnapshot: buffer.metadataSnapshot,
-                    folderId: effectiveFolderId,
-                    providerType: effectiveProviderType,
-                    folderKey: effectiveFolderKey
-                };
-                try {
-                    const id = await this.dbManager.addToSyncQueue(entry);
-                    const persistDescriptorParts = [];
-                    if (entry.operationType) persistDescriptorParts.push(entry.operationType);
-                    if (entry.updates?.stack) persistDescriptorParts.push(`stack→${entry.updates.stack}`);
-                    if (entry.updates?.stackSequence) persistDescriptorParts.push(`seq=${entry.updates.stackSequence}`);
-                    const persistDescriptor = persistDescriptorParts.join(' · ') || 'mutation';
-                    this.logger?.log({ event: 'queue:persist', level: 'info', fileId, details: `Persisted ${persistDescriptor} to syncQueue (#${id}).`, data: entry });
-                    this.scheduleProcess('buffer-commit');
-                    return id;
-                } catch (error) {
-                    this.logger?.log({ event: 'queue:error', level: 'error', fileId, details: `Failed to persist mutation: ${error.message}` });
-                    return null;
-                }
-            }
-            scheduleProcess(reason = 'auto') {
-                if (this.syncTimer) return;
-                this.syncTimer = setTimeout(() => {
-                    this.syncTimer = null;
-                    this.processQueue(reason);
-                }, 300);
-            }
-            async processQueue(reason = 'auto') {
-                if (!this.dbManager) return 'no-db';
-                if (this.isProcessing) {
-                    this.logger?.log({ event: 'sync:busy', level: 'warn', details: 'Sync loop already in progress.' });
-                    return 'busy';
-                }
-                this.isProcessing = true;
-                this.lastSyncAppliedCount = 0;
-                try {
-                    const queue = await this.dbManager.readSyncQueue();
-                    if (queue.length === 0) {
-                        this.hasPendingWork = this.pendingMutations.size > 0;
-                        this.logger?.log({ event: 'sync:idle', level: 'info', details: `Queue empty (${reason}).` });
-                        return 'empty';
-                    }
-                    this.logger?.log({ event: 'sync:start', level: 'info', details: `Processing ${queue.length} queued entries (${reason}).` });
-                    const merged = this.mergeQueue(queue);
-                    for (const entry of merged) {
-                        const applied = await this.processEntry(entry);
-                        if (applied) {
-                            this.lastSyncAppliedCount += 1;
+                        const providerType = entry.providerType || activeProviderType;
+                        const provider = providerType === this.providerType ? (this.provider || state.provider) : state.provider;
+                        if (!provider || (providerType !== 'onedrive' && typeof provider.updateFileMetadata !== 'function')) {
+                            this.logger?.log({ event: 'sync:deferred', level: 'warn', fileId, details: 'Provider unavailable for entry. Retrying later.' });
+                            this.hasFollowUpFlush = true;
+                            continue;
+                        }
+                        const payload = { ...file, ...entry.updates };
+                        payload.localUpdatedAt = entry.localUpdatedAt || payload.localUpdatedAt || Date.now();
+                        try {
+                            await this.pushToProvider(provider, providerType, fileId, payload);
+                            Object.assign(file, entry.updates, { localUpdatedAt: payload.localUpdatedAt });
+                            if (this.dbManager && entry.folderId) {
+                                await this.dbManager.saveMetadata(fileId, file, { folderId: entry.folderId, providerType });
+                                updatedFileIds.add(fileId);
+                            }
+                            this.pendingChanges.delete(fileId);
+                            this.logger?.log({ event: 'sync:success', level: 'success', fileId, details: `Synced metadata (${reason}).` });
+                        } catch (error) {
+                            entry.errorCount = (entry.errorCount || 0) + 1;
+                            this.pendingChanges.set(fileId, entry);
+                            this.logger?.log({ event: 'sync:error', level: 'error', fileId, details: `Metadata sync failed: ${error.message}` });
+                            if (entry.errorCount > 1) {
+                                Utils.showToast(`Sync failed for ${file.name || fileId}: ${error.message}`, 'error', true);
+                            } else {
+                                this.scheduleIdleFlush(Math.min(this.idleDelay * 2, 15000));
+                            }
                         }
                     }
-                    const remaining = await this.dbManager.readSyncQueue();
-                    this.hasPendingWork = remaining.length > 0 || this.pendingMutations.size > 0;
-                    const result = remaining.length > 0 ? 'partial' : 'done';
-                    if (result === 'done') {
-                        this.logger?.log({ event: 'sync:complete', level: 'success', details: `Sync loop complete (${reason}).` });
-                    } else {
-                        this.logger?.log({ event: 'sync:partial', level: 'warn', details: `Sync loop finished with ${remaining.length} entries remaining.` });
+                    if (updatedFileIds.size > 0 && this.dbManager && state.currentFolder?.id) {
+                        await this.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
                     }
-                    return result;
-                } catch (error) {
-                    this.logger?.log({ event: 'sync:error', level: 'error', details: `Queue processing failed: ${error.message}` });
-                    return 'error';
                 } finally {
-                    this.isProcessing = false;
-                }
-            }
-            mergeQueue(entries) {
-                const map = new Map();
-                entries.forEach(item => {
-                    const existing = map.get(item.fileId);
-                    if (!existing) {
-                        map.set(item.fileId, { ...item, queueIds: [item.id] });
+                    this.isFlushing = false;
+                    if (this.hasFollowUpFlush && this.pendingChanges.size > 0) {
+                        this.hasFollowUpFlush = false;
+                        await this.processPending('follow-up');
                         return;
                     }
-                    existing.queueIds.push(item.id);
-                    existing.updates = { ...existing.updates, ...(item.updates || {}) };
-                    existing.localUpdatedAt = Math.max(existing.localUpdatedAt || 0, item.localUpdatedAt || 0);
-                    existing.pendingFlush = existing.pendingFlush || item.pendingFlush;
-                    existing.folderId = existing.folderId || item.folderId || null;
-                    existing.providerType = existing.providerType || item.providerType || null;
-                    existing.folderKey = existing.folderKey || item.folderKey || null;
-                    if (item.metadataSnapshot) {
-                        existing.metadataSnapshot = { ...(existing.metadataSnapshot || {}), ...item.metadataSnapshot };
+                    this.hasFollowUpFlush = false;
+                    if (this.pendingChanges.size > 0) {
+                        this.scheduleIdleFlush();
                     }
-                });
-                return Array.from(map.values());
-            }
-            async processEntry(entry) {
-                const provider = this.provider || state.provider;
-                const providerType = entry.providerType || this.providerType || state.providerType;
-                if (!provider || !providerType) {
-                    await this.dbManager.markPendingFlush(entry.queueIds, true);
-                    this.logger?.log({ event: 'sync:deferred', level: 'warn', fileId: entry.fileId, details: 'No provider bound. Marked pending flush.' });
-                    return false;
-                }
-                const updates = entry.updates || {};
-                const metadataRecord = state.imageFiles.find(file => file.id === entry.fileId) || entry.metadataSnapshot || {};
-                const folderContext = this.resolveEntryFolderContext(entry, metadataRecord);
-                const payload = { ...metadataRecord, ...updates, localUpdatedAt: entry.localUpdatedAt };
-                payload.id = entry.fileId;
-                const stackLabel = updates.stack ? (STACK_NAMES[updates.stack] || updates.stack) : null;
-                const stackFragment = stackLabel ? ` (${stackLabel})` : '';
-                try {
-                    if (providerType === 'googledrive') {
-                        await provider.updateFileMetadata(entry.fileId, this.serializeGoogleMetadata(payload));
-                    } else if (providerType === 'onedrive') {
-                        await this.upsertOneDriveMetadata(entry.fileId, payload);
-                    } else if (typeof provider.updateFileMetadata === 'function') {
-                        await provider.updateFileMetadata(entry.fileId, payload);
-                    }
-                    if (metadataRecord && metadataRecord !== entry.metadataSnapshot) {
-                        Object.assign(metadataRecord, updates, { localUpdatedAt: entry.localUpdatedAt });
-                    }
-                    await this.dbManager.deleteFromSyncQueue(entry.queueIds);
-                    this.logger?.log({ event: 'sync:success', level: 'success', fileId: entry.fileId, details: `Applied ${entry.operationType}${stackFragment} to ${providerType}.`, data: { updates, stackLabel } });
-                    this.collectManifestUpdate(folderContext, payload);
-                    return true;
-                } catch (error) {
-                    await this.dbManager.markPendingFlush(entry.queueIds, true);
-                    this.logger?.log({ event: 'sync:error', level: 'error', fileId: entry.fileId, details: `Failed to sync ${entry.operationType}: ${error.message}`, data: { updates, stackLabel } });
-                    return false;
                 }
             }
-            resolveEntryFolderContext(entry, metadataRecord = {}) {
-                let providerType = entry?.providerType || metadataRecord.providerType || this.providerType || state.providerType || null;
-                let folderId = entry?.folderId || metadataRecord.folderId || null;
-                if (!folderId && entry?.metadataSnapshot?.folderId) {
-                    folderId = entry.metadataSnapshot.folderId;
-                }
-                if (!folderId && Array.isArray(metadataRecord.parents) && metadataRecord.parents.length > 0) {
-                    folderId = metadataRecord.parents[0];
-                }
-                if (!folderId && metadataRecord.parentReference?.id) {
-                    folderId = metadataRecord.parentReference.id;
-                }
-                if (!folderId && entry?.folderKey) {
-                    const parts = entry.folderKey.split('::');
-                    if (!providerType && parts.length > 0) {
-                        providerType = parts[0] || providerType;
-                    }
-                    folderId = parts.length > 1 ? parts.slice(1).join('::') : parts[0];
-                }
-                if (!folderId && state.currentFolder?.id) {
-                    folderId = state.currentFolder.id;
-                }
-                const folderKey = entry?.folderKey || (providerType && folderId ? `${providerType}::${folderId}` : null);
-                return { folderId, providerType, folderKey };
-            }
-            collectManifestUpdate(context, file) {
-                if (!context || !context.folderId || !context.providerType || !file?.id) {
+            async pushToProvider(provider, providerType, fileId, payload) {
+                if (providerType === 'googledrive') {
+                    await provider.updateFileMetadata(fileId, this.serializeGoogleMetadata(payload));
                     return;
                 }
-                const folderKey = context.folderKey || `${context.providerType}::${context.folderId}`;
-                const existing = this.pendingManifestUpdates.get(folderKey) || { folderId: context.folderId, providerType: context.providerType, folderKey, files: new Map() };
-                const snapshot = { ...file };
-                snapshot.id = snapshot.id || file.fileId;
-                snapshot.localUpdatedAt = snapshot.localUpdatedAt || file.localUpdatedAt || Date.now();
-                if (snapshot.notes == null && snapshot.appProperties?.notes != null) {
-                    snapshot.notes = snapshot.appProperties.notes;
-                }
-                if (snapshot.stack == null && snapshot.appProperties?.slideboxStack) {
-                    snapshot.stack = snapshot.appProperties.slideboxStack;
-                }
-                if (snapshot.favorite == null && snapshot.appProperties?.favorite != null) {
-                    snapshot.favorite = snapshot.appProperties.favorite === 'true';
-                }
-                existing.files.set(snapshot.id, snapshot);
-                this.pendingManifestUpdates.set(folderKey, existing);
-            }
-            async persistPendingManifestUpdates(timestamp = Date.now()) {
-                if (!state.folderSyncCoordinator || this.pendingManifestUpdates.size === 0) {
-                    this.pendingManifestUpdates.clear();
+                if (providerType === 'onedrive') {
+                    await this.upsertOneDriveMetadata(fileId, payload);
                     return;
                 }
-                const coordinator = state.folderSyncCoordinator;
-                try {
-                    for (const [folderKey, payload] of this.pendingManifestUpdates.entries()) {
-                        const files = Array.from(payload.files?.values() || []);
-                        if (!payload.folderId || !payload.providerType || files.length === 0) {
-                            continue;
-                        }
-                        const providerType = payload.providerType || this.providerType || state.providerType || null;
-                        const folderId = payload.folderId;
-                        if (!providerType) continue;
-                        let folderState = null;
-                        try {
-                            folderState = await state.dbManager?.getFolderState({ providerType, folderId });
-                        } catch (error) {
-                            folderState = null;
-                        }
-                        const baseVersion = Number(folderState?.localVersion || 0);
-                        const nextVersion = baseVersion + 1;
-                        let manifestResult = null;
-                        try {
-                            manifestResult = await coordinator.applyLocalManifestUpdates(folderId, files, {
-                                providerType,
-                                targetVersion: nextVersion,
-                                timestamp
-                            });
-                        } catch (error) {
-                            this.logger?.log({ event: 'manifest:update:error', level: 'error', details: `Failed to update manifest for ${folderId}: ${error.message}` });
-                            await coordinator.markRequiresFullResync(folderId, 'manifest-update-failed');
-                            continue;
-                        }
-                        const versionForRecord = manifestResult?.cloudVersion != null ? manifestResult.cloudVersion : nextVersion;
-                        const remoteContext = manifestResult?.manifestFileId ? { manifestFileId: manifestResult.manifestFileId } : {};
-                        await coordinator.recordLocalFlush(folderId, {
-                            timestamp,
-                            targetVersion: versionForRecord,
-                            remoteContext
-                        });
-                    }
-                } finally {
-                    this.pendingManifestUpdates.clear();
+                if (typeof provider.updateFileMetadata === 'function') {
+                    await provider.updateFileMetadata(fileId, payload);
                 }
             }
             serializeGoogleMetadata(payload) {
@@ -3214,69 +3004,17 @@
                 }
                 this.logger?.log({ event: 'onedrive:metadata:upsert', level: 'info', fileId, details: 'Upserted OneDrive metadata document.' });
             }
-            async flush({ reason = 'manual', useBeacon = false } = {}) {
-                this.logger?.log({ event: 'flush:request', level: 'info', details: `Flush requested (${reason}).` });
-                const bufferedIds = Array.from(this.pendingMutations.keys());
-                if (bufferedIds.length > 0) {
-                    await Promise.all(bufferedIds.map(id => this.commitBufferedChange(id)));
-                }
-                if (!this.dbManager) return 'no-db';
-                if (useBeacon && await this.sendBeaconSnapshot(reason)) {
-                    return 'beacon';
-                }
-                const result = await this.processQueue(reason);
-                if (state.folderSyncCoordinator && (this.lastSyncAppliedCount > 0 || this.pendingManifestUpdates.size > 0)) {
-                    const timestamp = Date.now();
-                    if (this.pendingManifestUpdates.size > 0) {
-                        await this.persistPendingManifestUpdates(timestamp);
-                    } else if (this.lastSyncAppliedCount > 0 && state.currentFolder?.id) {
-                        await state.folderSyncCoordinator.recordLocalFlush(state.currentFolder.id, { timestamp });
-                    }
-                }
-                return result;
-            }
-            requestSync(reason = 'manual-request') {
-                this.logger?.log({ event: 'sync:request', level: 'info', details: `Manual sync requested (${reason}).` });
-                this.scheduleProcess(reason);
-            }
             handleVisibilityChange() {
                 if (document.visibilityState === 'hidden') {
-                    this.flush({ reason: 'visibilitychange', useBeacon: true });
+                    this.flushNow({ reason: 'visibilitychange' });
                 }
             }
             handlePageHide() {
-                this.flush({ reason: 'pagehide', useBeacon: true });
+                this.flushNow({ reason: 'pagehide' });
             }
             handleBeforeUnload() {
-                if (!this.hasPendingWork) return;
-                this.flush({ reason: 'beforeunload', useBeacon: true });
-            }
-            async sendBeaconSnapshot(reason) {
-                if (!navigator.sendBeacon) return false;
-                try {
-                    const queue = await this.dbManager.readSyncQueue();
-                    if (queue.length === 0) return false;
-                    const payload = JSON.stringify({
-                        reason,
-                        timestamp: Date.now(),
-                        providerType: this.providerType || state.providerType || null,
-                        entries: this.mergeQueue(queue).map(entry => ({
-                            fileId: entry.fileId,
-                            updates: entry.updates,
-                            operationType: entry.operationType,
-                            localUpdatedAt: entry.localUpdatedAt
-                        }))
-                    });
-                    const ok = navigator.sendBeacon('/orbital8/sync-flush', payload);
-                    if (ok) {
-                        await this.dbManager.markPendingFlush(queue.map(item => item.id), true);
-                        this.logger?.log({ event: 'flush:beacon', level: 'warn', details: `Dispatching ${queue.length} entries via navigator.sendBeacon (${reason}).` });
-                        return true;
-                    }
-                } catch (error) {
-                    this.logger?.log({ event: 'flush:beacon:error', level: 'error', details: `Beacon fallback failed: ${error.message}` });
-                }
-                return false;
+                if (this.pendingChanges.size === 0) return;
+                this.flushNow({ reason: 'beforeunload' });
             }
         }
         class VisualCueManager {
@@ -4150,7 +3888,7 @@
             },
             async backToProviderSelection() {
                 if (state.syncManager) {
-                    await state.syncManager.flush({ reason: 'provider-screen' });
+                    await state.syncManager.flushNow({ reason: 'provider-screen' });
                     await state.syncManager.stop();
                     state.syncManager.setProviderContext({ provider: null, providerType: null });
                 }
@@ -4633,7 +4371,7 @@
 
                 try {
                     if (state.syncManager) {
-                        await state.syncManager.flush({ reason: 'folder-switch' });
+                        await state.syncManager.flushNow({ reason: 'folder-switch' });
                     }
                     state.activeRequests?.abort();
                     // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
@@ -4691,19 +4429,19 @@
                     if (!file) return;
                     const timestamp = Date.now();
                     Object.assign(file, updates, { localUpdatedAt: timestamp });
-                    await state.dbManager.saveMetadata(file.id, file, { folderId: state.currentFolder.id, providerType: state.providerType });
-                    await state.dbManager.saveFolderCache(state.currentFolder.id, state.imageFiles);
                     if (state.syncManager) {
-                        await state.syncManager.queueLocalChange({
+                        state.syncManager.recordChange({
                             fileId,
                             updates,
                             operationType,
                             origin,
                             localUpdatedAt: timestamp,
                             folderId: state.currentFolder.id,
-                            providerType: state.providerType,
-                            metadataSnapshot: { name: file.name, stack: file.stack, stackSequence: file.stackSequence, folderId: state.currentFolder.id }
-                        }, { debounce: !skipDebounce });
+                            providerType: state.providerType
+                        });
+                        if (skipDebounce) {
+                            await state.syncManager.flushNow({ reason: operationType });
+                        }
                     }
                 } catch (error) {
                     Utils.showToast(`Failed to update metadata: ${error.message}`, 'error', true);
@@ -7013,7 +6751,7 @@ this.updateImageCounters();
                 await state.dbManager.init();
                 state.folderSyncCoordinator = new FolderSyncCoordinator({ dbManager: state.dbManager, logger: state.syncLog });
                 state.folderSyncCoordinator.setDeltaHandler((payload) => App.applyDeltaFromCoordinator(payload));
-                state.syncManager = new SyncManager({ dbManager: state.dbManager, logger: state.syncLog });
+                state.syncManager = new SimpleSync({ dbManager: state.dbManager, logger: state.syncLog });
                 state.syncManager.start();
                 state.metadataExtractor = new MetadataExtractor();
                 Utils.showScreen('provider-screen');


### PR DESCRIPTION
## Summary
- replace the old SyncManager queue with a lightweight SimpleSync controller that batches metadata edits in memory and flushes them after an idle delay or key lifecycle events
- update App.updateUserMetadata to rely on SimpleSync for persistence, including optional immediate flushes when debounce is skipped
- wire the new controller into provider and folder transitions so flushes occur on navigation changes and shutdown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3a85d3d4c832d857c66f6edb420af