### PR TITLE
Simplify SimpleSync persistence state

### DIFF
--- a/index.html
+++ b/index.html
@@ -1926,102 +1926,50 @@
 
         class SimpleSyncCoordinator {
             constructor({ dbManager, logger }) {
-                this.db = dbManager;
-                this.log = logger;
+                this.db = dbManager || null;
+                this.log = logger || null;
                 this.providerType = null;
                 this.provider = null;
             }
             setProviderContext({ provider, providerType }) {
-                this.provider = provider;
-                this.providerType = providerType;
-                this.log?.log({ event: 'sync:context', level: 'info', details: `Coordinator bound to ${providerType || 'cleared'}` });
+                this.provider = provider || null;
+                this.providerType = providerType || null;
+                this.log?.log({ event: 'sync:context', level: 'info', details: `Coordinator bound to ${this.providerType || 'cleared'}` });
             }
-            buildContext(folderId) {
-                return { providerType: this.providerType || state.providerType || null, folderId };
+            async getCachedFiles(folderId) {
+                if (!this.db || !folderId) return [];
+                try {
+                    const cached = await this.db.getFolderCache(folderId);
+                    return Array.isArray(cached) ? cached : [];
+                } catch (error) {
+                    this.log?.log({ event: 'sync:cache-error', level: 'error', details: error.message, data: { folderId } });
+                    return [];
+                }
             }
             async shouldSync(folderId) {
-                if (!this.db) {
-                    this.log?.log({ event: 'sync:no-db', level: 'warn', details: 'No database manager available' });
-                    return { needsSync: true, fullSync: true };
+                const providerType = this.providerType || state.providerType || 'unknown';
+                const cachedFiles = await this.getCachedFiles(folderId);
+                if (cachedFiles.length === 0) {
+                    this.log?.log({ event: 'sync:cache-miss', level: 'info', details: `No cached data for ${folderId}` });
+                    return { needsSync: true, fullSync: true, cachedFiles };
                 }
-                const context = this.buildContext(folderId);
-                const localState = await this.db.getFolderState(context);
-                if (!localState) {
-                    this.log?.log({ event: 'sync:first-time', level: 'info', details: `First sync for ${folderId}` });
-                    return { needsSync: true, fullSync: true };
+                const sessionKey = `${providerType}::${folderId}`;
+                const hasVisited = state.sessionVisitedFolders?.has(sessionKey);
+                if (!hasVisited) {
+                    this.log?.log({ event: 'sync:first-session', level: 'info', details: `Refreshing cache for ${folderId}` });
+                    return { needsSync: true, fullSync: true, cachedFiles };
                 }
-                let cloudTimestamp = 0;
+                this.log?.log({ event: 'sync:cache-hit', level: 'info', details: `Using cached data for ${folderId}`, data: { entries: cachedFiles.length } });
+                return { needsSync: false, fullSync: false, cachedFiles };
+            }
+            async cacheFolderSnapshot(folderId, files = []) {
+                if (!this.db || !folderId) return;
                 try {
-                    const provider = this.provider || state.provider;
-                    if (provider && typeof provider.loadFolderManifest === 'function') {
-                        const manifest = await provider.loadFolderManifest(folderId);
-                        cloudTimestamp = manifest?.cloudVersion || 0;
-                    }
-                } catch (e) {
-                    this.log?.log({ event: 'sync:timestamp-check-failed', level: 'warn', details: e.message });
+                    await this.db.saveFolderCache(folderId, files);
+                    this.log?.log({ event: 'sync:cache-save', level: 'info', details: `Stored ${files.length} entries for ${folderId}` });
+                } catch (error) {
+                    this.log?.log({ event: 'sync:cache-save-error', level: 'error', details: error.message, data: { folderId } });
                 }
-                const localTimestamp = localState.localVersion || 0;
-                if (cloudTimestamp > localTimestamp) {
-                    this.log?.log({ event: 'sync:cloud-newer', level: 'info', details: `Cloud: ${cloudTimestamp}, Local: ${localTimestamp}` });
-                    return { needsSync: true, fullSync: false };
-                }
-                this.log?.log({ event: 'sync:cache-fresh', level: 'info', details: 'Using cached data' });
-                return { needsSync: false, fullSync: false };
-            }
-            async updateTimestamp(folderId, timestamp) {
-                if (!this.db) return;
-                const context = this.buildContext(folderId);
-                const existing = await this.db.getFolderState(context) || context;
-                await this.db.saveFolderState({ ...existing, ...context, folderId, localVersion: timestamp, cloudVersion: timestamp });
-            }
-            async saveManifest(folderId, files) {
-                if (!this.db) return;
-                files = files || [];
-                const timestamp = Date.now();
-                try {
-                    const provider = this.provider || state.provider;
-                    if (provider && typeof provider.saveFolderManifest === 'function') {
-                        await provider.saveFolderManifest(folderId, { entries: this.buildEntries(files), cloudVersion: timestamp, requiresFullResync: false });
-                        await this.updateTimestamp(folderId, timestamp);
-                        this.log?.log({ event: 'manifest:saved', level: 'success', details: `Saved for ${folderId}` });
-                    }
-                } catch (e) {
-                    this.log?.log({ event: 'manifest:save-failed', level: 'error', details: e.message });
-                }
-            }
-            buildEntries(files) {
-                const entries = {};
-                files.forEach(f => {
-                    if (f?.id) {
-                        entries[f.id] = { stack: f.stack || f.appProperties?.slideboxStack || 'in', changeNumber: f.localUpdatedAt || Date.now(), notesHash: this.hashString(f.notes || ''), flags: this.computeFlags(f) };
-                    }
-                });
-                return entries;
-            }
-            hashString(value) {
-                if (!value) return '0';
-                let hash = 0;
-                for (let i = 0; i < value.length; i++) {
-                    hash = ((hash << 5) - hash) + value.charCodeAt(i);
-                    hash |= 0;
-                }
-                return String(hash >>> 0);
-            }
-            computeFlags(file) {
-                const flags = [];
-                const stack = file.stack || file.appProperties?.slideboxStack;
-                if (stack === 'trash') flags.push('trash');
-                if (file.favorite || file.appProperties?.favorite === 'true') flags.push('fav');
-                return flags.join(',');
-            }
-            buildManifestFromFiles(folderId, files) {
-                return this.buildEntries(files);
-            }
-            async recordLocalFlush(folderId, options = {}) {
-                await this.saveManifest(folderId, state.imageFiles || []);
-            }
-            async applyLocalManifestUpdates(folderId, files, options = {}) {
-                return null;
             }
             setDbManager(dbManager) {
                 this.db = dbManager;
@@ -2069,6 +2017,26 @@
                 this.pendingChanges.set(fileId, { fileId, updates, metadata, operationType, timestamp: Date.now() });
                 this.scheduleSync();
             }
+            async queueLocalChange(change, options = {}) {
+                if (!change || !change.fileId) return;
+                const { debounce = true } = options;
+                const descriptor = change.operationType || 'metadata:update';
+                this.log?.log({
+                    event: 'sync:queue',
+                    level: 'info',
+                    fileId: change.fileId,
+                    details: `Queued ${descriptor}${debounce ? '' : ' (immediate)'}`
+                });
+                this.buffer(
+                    change.fileId,
+                    change.updates || {},
+                    change.operationType || 'metadata:update',
+                    { metadataSnapshot: change.metadataSnapshot || {} }
+                );
+                if (!debounce) {
+                    await this.flush({ reason: change.reason || 'immediate' });
+                }
+            }
             scheduleSync() {
                 if (this.timer) clearTimeout(this.timer);
                 this.timer = setTimeout(() => this.flush({ reason: 'auto' }), 300);
@@ -2115,7 +2083,7 @@
                     }
                 }
                 if (state.currentFolder?.id && state.folderSyncCoordinator && this.lastSyncAppliedCount > 0) {
-                    await state.folderSyncCoordinator.saveManifest(
+                    await state.folderSyncCoordinator.cacheFolderSnapshot(
                         state.currentFolder.id,
                         state.imageFiles || []
                     );
@@ -2322,47 +2290,30 @@
             }
             async init() {
                 return new Promise((resolve, reject) => {
-                    const request = indexedDB.open('Orbital8-Goji-V1', 4);
+                    const request = indexedDB.open('Orbital8-Goji-V1', 5);
                     request.onupgradeneeded = (event) => {
                         const db = event.target.result;
-                        const oldVersion = event.oldVersion || 0;
 
-                        if (oldVersion < 1 && !db.objectStoreNames.contains('folderCache')) {
+                        if (!db.objectStoreNames.contains('folderCache')) {
                             db.createObjectStore('folderCache', { keyPath: 'folderId' });
                         }
 
-                        if (oldVersion < 2) {
-                            let metadataStore;
-                            if (!db.objectStoreNames.contains('metadata')) {
-                                metadataStore = db.createObjectStore('metadata', { keyPath: 'id' });
-                            } else {
-                                metadataStore = request.transaction.objectStore('metadata');
-                            }
-                            if (metadataStore && !metadataStore.indexNames.contains('folderKey')) {
-                                metadataStore.createIndex('folderKey', 'folderKey', { unique: false });
-                            }
-                            if (!db.objectStoreNames.contains('syncQueue')) {
-                                db.createObjectStore('syncQueue', { keyPath: 'id', autoIncrement: true });
-                            }
+                        let metadataStore;
+                        if (!db.objectStoreNames.contains('metadata')) {
+                            metadataStore = db.createObjectStore('metadata', { keyPath: 'id' });
+                        } else if (event.target.transaction) {
+                            metadataStore = event.target.transaction.objectStore('metadata');
                         }
 
-                        if (oldVersion < 3 && !db.objectStoreNames.contains('folderState')) {
-                            const folderState = db.createObjectStore('folderState', { keyPath: 'folderKey' });
-                            folderState.createIndex('provider', 'provider', { unique: false });
-                            folderState.createIndex('folderId', 'folderId', { unique: false });
+                        if (metadataStore && !metadataStore.indexNames.contains('folderKey')) {
+                            metadataStore.createIndex('folderKey', 'folderKey', { unique: false });
                         }
 
-                        if (oldVersion < 4 && !db.objectStoreNames.contains('folderManifests')) {
-                            const manifestStore = db.createObjectStore('folderManifests', { keyPath: 'folderKey' });
-                            manifestStore.createIndex('provider', 'provider', { unique: false });
-                            manifestStore.createIndex('folderId', 'folderId', { unique: false });
-                        }
-                        if (db.objectStoreNames.contains('metadata')) {
-                            const metadataStore = request.transaction.objectStore('metadata');
-                            if (metadataStore && !metadataStore.indexNames.contains('folderKey')) {
-                                metadataStore.createIndex('folderKey', 'folderKey', { unique: false });
+                        ['syncQueue', 'folderState', 'folderManifests'].forEach(storeName => {
+                            if (db.objectStoreNames.contains(storeName)) {
+                                db.deleteObjectStore(storeName);
                             }
-                        }
+                        });
                     };
                     request.onsuccess = (event) => {
                         this.db = event.target.result;
@@ -2463,181 +2414,13 @@
                     request.onerror = () => reject(request.error);
                 });
             }
-            async addToSyncQueue(operation) {
-                if (!this.db) return null;
-                const entry = {
-                    fileId: operation.fileId,
-                    updates: operation.updates || {},
-                    operationType: operation.operationType || 'metadata:update',
-                    origin: operation.origin || 'ui',
-                    localUpdatedAt: operation.localUpdatedAt || Date.now(),
-                    pendingFlush: Boolean(operation.pendingFlush),
-                    metadataSnapshot: operation.metadataSnapshot || null,
-                    retryCount: operation.retryCount || 0,
-                    folderId: operation.folderId || null,
-                    providerType: operation.providerType || null,
-                    folderKey: operation.folderKey || null
-                };
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('syncQueue', 'readwrite');
-                    const store = transaction.objectStore('syncQueue');
-                    const request = store.add(entry);
-                    request.onsuccess = () => resolve(request.result);
-                    request.onerror = () => reject(request.error);
-                });
-            }
-            async readSyncQueue() {
-                if (!this.db) return [];
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('syncQueue', 'readonly');
-                    const store = transaction.objectStore('syncQueue');
-                    const request = store.getAll();
-                    request.onsuccess = () => {
-                        const results = request.result || [];
-                        results.sort((a, b) => (a.localUpdatedAt || 0) - (b.localUpdatedAt || 0));
-                        resolve(results);
-                    };
-                    request.onerror = () => reject(request.error);
-                });
-            }
-            async deleteFromSyncQueue(ids) {
-                if (!this.db) return;
-                const targetIds = Array.isArray(ids) ? ids : [ids];
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('syncQueue', 'readwrite');
-                    const store = transaction.objectStore('syncQueue');
-                    targetIds.forEach(id => { store.delete(id); });
-                    transaction.oncomplete = () => resolve();
-                    transaction.onerror = () => reject(transaction.error);
-                });
-            }
-            async updateSyncQueueEntry(id, updates) {
-                if (!this.db) return false;
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('syncQueue', 'readwrite');
-                    const store = transaction.objectStore('syncQueue');
-                    const getRequest = store.get(id);
-                    getRequest.onsuccess = () => {
-                        const entry = getRequest.result;
-                        if (!entry) { resolve(false); return; }
-                        Object.assign(entry, updates);
-                        const putRequest = store.put(entry);
-                        putRequest.onsuccess = () => resolve(true);
-                        putRequest.onerror = () => reject(putRequest.error);
-                    };
-                    getRequest.onerror = () => reject(getRequest.error);
-                });
-            }
-            async markPendingFlush(ids, pending = true) {
-                if (!this.db) return;
-                const targetIds = Array.isArray(ids) ? ids : [ids];
-                await Promise.all(targetIds.map(id => this.updateSyncQueueEntry(id, { pendingFlush: pending })));
-            }
-            async getFolderState(context) {
-                if (!this.db) return null;
-                const folderKey = this.resolveFolderKey(context);
-                if (!folderKey) return null;
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('folderState', 'readonly');
-                    const store = transaction.objectStore('folderState');
-                    const request = store.get(folderKey);
-                    request.onsuccess = () => resolve(request.result || null);
-                    request.onerror = () => reject(request.error);
-                });
-            }
-            async saveFolderState(record) {
-                if (!this.db || !record) return;
-                const folderKey = this.resolveFolderKey(record);
-                if (!folderKey) return;
-                const payload = {
-                    folderKey,
-                    provider: record.providerType || record.provider || null,
-                    folderId: record.folderId,
-                    localVersion: record.localVersion ?? 0,
-                    cloudVersion: record.cloudVersion ?? 0,
-                    lastLocalMutation: record.lastLocalMutation || null,
-                    lastCloudAck: record.lastCloudAck || null,
-                    updatedAt: Date.now()
-                };
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('folderState', 'readwrite');
-                    const store = transaction.objectStore('folderState');
-                    const request = store.put(payload);
-                    request.onsuccess = () => resolve(payload);
-                    request.onerror = () => reject(request.error);
-                });
-            }
-            async deleteFolderState(context) {
-                if (!this.db) return;
-                const folderKey = this.resolveFolderKey(context);
-                if (!folderKey) return;
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('folderState', 'readwrite');
-                    const store = transaction.objectStore('folderState');
-                    const request = store.delete(folderKey);
-                    request.onsuccess = () => resolve();
-                    request.onerror = () => reject(request.error);
-                });
-            }
-            async getFolderManifest(context) {
-                if (!this.db) return null;
-                const folderKey = this.resolveFolderKey(context);
-                if (!folderKey) return null;
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('folderManifests', 'readonly');
-                    const store = transaction.objectStore('folderManifests');
-                    const request = store.get(folderKey);
-                    request.onsuccess = () => resolve(request.result || null);
-                    request.onerror = () => reject(request.error);
-                });
-            }
-            async saveFolderManifest(record) {
-                if (!this.db || !record) return;
-                const folderKey = this.resolveFolderKey(record);
-                if (!folderKey) return;
-                const payload = {
-                    folderKey,
-                    provider: record.providerType || record.provider || null,
-                    folderId: record.folderId,
-                    entries: record.entries || {},
-                    cloudVersion: record.cloudVersion ?? null,
-                    localVersion: record.localVersion ?? null,
-                    requiresFullResync: Boolean(record.requiresFullResync),
-                    lastUpdated: record.lastUpdated || Date.now(),
-                    lastRemoteUpdate: record.lastRemoteUpdate || null,
-                    lastDiffSummary: record.lastDiffSummary || null
-                };
-                if (record.manifestFileId) {
-                    payload.manifestFileId = record.manifestFileId;
-                }
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('folderManifests', 'readwrite');
-                    const store = transaction.objectStore('folderManifests');
-                    const request = store.put(payload);
-                    request.onsuccess = () => resolve(payload);
-                    request.onerror = () => reject(request.error);
-                });
-            }
-            async deleteFolderManifest(context) {
-                if (!this.db) return;
-                const folderKey = this.resolveFolderKey(context);
-                if (!folderKey) return;
-                return new Promise((resolve, reject) => {
-                    const transaction = this.db.transaction('folderManifests', 'readwrite');
-                    const store = transaction.objectStore('folderManifests');
-                    const request = store.delete(folderKey);
-                    request.onsuccess = () => resolve();
-                    request.onerror = () => reject(request.error);
-                });
-            }
             async clearFolderData(context, fileIds = []) {
-                const folderKey = this.resolveFolderKey(context);
-                if (!folderKey) return;
+                const folderId = typeof context === 'string' ? context : context?.folderId;
                 await Promise.all([
-                    this.deleteFolderCache(context.folderId || context),
-                    this.deleteFolderState(context),
-                    this.deleteFolderManifest(context),
-                    fileIds.length > 0 ? Promise.all(fileIds.map(id => this.deleteMetadata(id))) : this.deleteMetadataByFolder(context)
+                    folderId ? this.deleteFolderCache(folderId) : Promise.resolve(),
+                    fileIds.length > 0
+                        ? Promise.all(fileIds.map(id => this.deleteMetadata(id)))
+                        : this.deleteMetadataByFolder(context)
                 ]);
             }
         }
@@ -2939,145 +2722,6 @@
 
                 return { folders: [], files: allFiles };
             }
-            async loadFolderManifest(folderId, options = {}) {
-                try {
-                    const query = `'${folderId}' in parents and name = '.orbital8-state.json' and trashed=false`;
-                    const url = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,modifiedTime,appProperties,parents)&supportsAllDrives=true&includeItemsFromAllDrives=true&pageSize=1`;
-                    const response = await this.makeApiCall(url, { signal: options.signal });
-                    const manifestFile = response.files && response.files[0];
-                    if (!manifestFile) {
-                        return null;
-                    }
-                    const fileId = manifestFile.id;
-                    let manifestData = {};
-                    try {
-                        const mediaResponse = await this.makeApiCall(`/files/${fileId}?alt=media`, { method: 'GET', signal: options.signal }, false);
-                        const text = await mediaResponse.text();
-                        manifestData = text ? JSON.parse(text) : {};
-                    } catch (error) {
-                        if (/403|404/.test(error.message || '')) {
-                            state.syncLog?.log({ event: 'manifest:fetch:forbidden', level: 'error', details: `Drive denied manifest content for ${folderId}: ${error.message}` });
-                            return { entries: {}, requiresFullResync: true, cloudVersion: Date.now(), manifestFileId: fileId };
-                        }
-                        throw error;
-                    }
-                    const cloudVersion = Number(manifestData.cloudVersion || manifestFile.appProperties?.orbital8CloudVersion || Date.now());
-                    return {
-                        entries: manifestData.entries || {},
-                        requiresFullResync: Boolean(manifestData.requiresFullResync),
-                        cloudVersion,
-                        manifestFileId: fileId
-                    };
-                } catch (error) {
-                    if (/403|404/.test(error.message || '')) {
-                        state.syncLog?.log({ event: 'manifest:fetch:fallback', level: 'warn', details: `Manifest lookup failed for ${folderId}: ${error.message}` });
-                        return { entries: {}, requiresFullResync: true, cloudVersion: Date.now() };
-                    }
-                    throw error;
-                }
-            }
-            async saveFolderManifest(folderId, manifest, options = {}) {
-                const cloudVersion = manifest.cloudVersion ?? Date.now();
-                const payload = {
-                    folderId,
-                    provider: 'googledrive',
-                    cloudVersion,
-                    requiresFullResync: Boolean(manifest.requiresFullResync),
-                    entries: manifest.entries || {},
-                    updatedAt: new Date().toISOString()
-                };
-                const metadata = {
-                    name: '.orbital8-state.json',
-                    parents: [folderId],
-                    mimeType: 'application/json',
-                    appProperties: { orbital8CloudVersion: String(cloudVersion) }
-                };
-                const headers = { 'Content-Type': 'application/json' };
-                let fileId = manifest.manifestFileId || options.manifestFileId || null;
-                let discoveredManifests = null;
-                if (!fileId) {
-                    try {
-                        const query = `'${folderId}' in parents and name = '.orbital8-state.json' and trashed=false`;
-                        const lookupUrl = `/files?q=${encodeURIComponent(query)}&fields=files(id,name,modifiedTime)&orderBy=modifiedTime%20desc&supportsAllDrives=true&includeItemsFromAllDrives=true&pageSize=10`;
-                        const lookupResponse = await this.makeApiCall(lookupUrl, { signal: options.signal });
-                        const files = Array.isArray(lookupResponse?.files) ? lookupResponse.files : [];
-                        if (files.length > 0) {
-                            fileId = files[0].id;
-                            discoveredManifests = files;
-                        }
-                    } catch (error) {
-                        state.syncLog?.log({ event: 'manifest:lookup:fallback', level: 'warn', details: `Failed to locate existing manifest for ${folderId}: ${error.message}` });
-                    }
-                }
-                if (!fileId) {
-                    const createResponse = await this.makeApiCall('/files?supportsAllDrives=true&includeItemsFromAllDrives=true', { method: 'POST', body: JSON.stringify(metadata) });
-                    fileId = createResponse.id;
-                }
-                await this.makeApiCall(`/files/${fileId}?supportsAllDrives=true&includeItemsFromAllDrives=true`, { method: 'PATCH', body: JSON.stringify({ appProperties: metadata.appProperties }) });
-                if (Array.isArray(discoveredManifests) && discoveredManifests.length > 1) {
-                    const duplicateIds = discoveredManifests.slice(1).map(file => file.id);
-                    state.syncLog?.log({ event: 'manifest:duplicates', level: 'warn', details: `Detected ${duplicateIds.length} duplicate manifest files for ${folderId}.`, data: { duplicates: duplicateIds } });
-                }
-                const uploadUrl = `/upload/drive/v3/files/${fileId}?uploadType=media&supportsAllDrives=true&includeItemsFromAllDrives=true`;
-                await this.makeApiCall(uploadUrl, { method: 'PATCH', body: JSON.stringify(payload), headers, signal: options.signal }, false);
-                state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted Drive manifest for ${folderId}`, data: { provider: 'googledrive', entries: Object.keys(payload.entries || {}).length, cloudVersion } });
-                return { cloudVersion, manifestFileId: fileId };
-            }
-            async updateFolderVersionMarker(folderId, version, options = {}) {
-                let fileId = options.manifestFileId;
-                if (!fileId) {
-                    const manifest = await this.loadFolderManifest(folderId, { signal: options.signal });
-                    fileId = manifest?.manifestFileId;
-                }
-                if (!fileId) {
-                    await this.saveFolderManifest(folderId, { entries: {}, cloudVersion: version, requiresFullResync: false });
-                    return;
-                }
-                await this.makeApiCall(`/files/${fileId}?supportsAllDrives=true&includeItemsFromAllDrives=true`, {
-                    method: 'PATCH',
-                    body: JSON.stringify({ appProperties: { orbital8CloudVersion: String(version) } })
-                });
-            }
-            async fetchFilesByIds(folderId, fileIds = [], options = {}) {
-                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
-                const rawFiles = await this.fetchRawFilesByIds(fileIds, { signal: options.signal });
-                const directImages = [];
-                const shortcutCandidates = [];
-
-                for (const file of rawFiles) {
-                    if (file?.mimeType?.startsWith('image/')) {
-                        directImages.push(file);
-                    } else if (file?.mimeType === 'application/vnd.google-apps.shortcut' && file.shortcutDetails?.targetMimeType?.startsWith('image/')) {
-                        shortcutCandidates.push(file);
-                    }
-                }
-
-                const normalized = directImages.map(file => this.normalizeDriveFileMetadata(file));
-
-                if (shortcutCandidates.length === 0) {
-                    return normalized;
-                }
-
-                const targetIds = [...new Set(shortcutCandidates
-                    .map(file => file.shortcutDetails?.targetId)
-                    .filter(Boolean))];
-
-                if (targetIds.length === 0) {
-                    return normalized;
-                }
-
-                const targetFiles = await this.fetchRawFilesByIds(targetIds, { signal: options.signal });
-                const targetMap = new Map(targetFiles.map(target => [target.id, target]));
-                const resolvedShortcuts = shortcutCandidates
-                    .map(shortcut => {
-                        const target = targetMap.get(shortcut.shortcutDetails?.targetId);
-                        if (!target || !target.mimeType?.startsWith('image/')) { return null; }
-                        return this.normalizeDriveFileMetadata(shortcut, { target, useShortcutId: true });
-                    })
-                    .filter(Boolean);
-
-                return [...normalized, ...resolvedShortcuts];
-            }
             async drillIntoFolder(folder) {
                 // Not applicable for Google Drive's flat folder structure, but fulfills the interface.
                 return Promise.resolve([]);
@@ -3191,101 +2835,6 @@
                     if (this.onProgressCallback) { this.onProgressCallback(allFiles.length); }
                 }
                 return { folders: [], files: allFiles };
-            }
-            async loadFolderManifest(folderId, options = {}) {
-                try {
-                    const manifestResponse = await this.makeApiCall(`/me/drive/special/approot:/manifests/${folderId}.json:/content`, { method: 'GET', signal: options.signal });
-                    const manifestData = await manifestResponse.json();
-                    let cloudVersion = manifestData.cloudVersion ?? null;
-                    try {
-                        const stateResponse = await this.makeApiCall(`/me/drive/special/approot:/state/${folderId}.json:/content`, { method: 'GET', signal: options.signal });
-                        const stateData = await stateResponse.json();
-                        if (stateData && stateData.cloudVersion != null) {
-                            cloudVersion = stateData.cloudVersion;
-                        }
-                    } catch (stateError) {
-                        if (!/404/.test(String(stateError.message))) {
-                            throw stateError;
-                        }
-                    }
-                    return {
-                        entries: manifestData.entries || {},
-                        requiresFullResync: Boolean(manifestData.requiresFullResync),
-                        cloudVersion: Number(cloudVersion ?? Date.now())
-                    };
-                } catch (error) {
-                    if (/404/.test(String(error.message))) {
-                        return null;
-                    }
-                    if (/401/.test(String(error.message))) {
-                        throw error;
-                    }
-                    if (/403/.test(String(error.message))) {
-                        state.syncLog?.log({ event: 'manifest:fetch:forbidden', level: 'error', details: `OneDrive manifest forbidden: ${error.message}` });
-                        return { entries: {}, requiresFullResync: true, cloudVersion: Date.now() };
-                    }
-                    throw error;
-                }
-            }
-            async saveFolderManifest(folderId, manifest, options = {}) {
-                const headers = { 'Content-Type': 'application/json' };
-                const cloudVersion = manifest.cloudVersion ?? Date.now();
-                const manifestPayload = {
-                    folderId,
-                    cloudVersion,
-                    requiresFullResync: Boolean(manifest.requiresFullResync),
-                    entries: manifest.entries || {},
-                    updatedAt: new Date().toISOString()
-                };
-                await this.makeApiCall(`/me/drive/special/approot:/manifests/${folderId}.json:/content`, {
-                    method: 'PUT',
-                    headers,
-                    body: JSON.stringify(manifestPayload),
-                    signal: options.signal
-                });
-                await this.makeApiCall(`/me/drive/special/approot:/state/${folderId}.json:/content`, {
-                    method: 'PUT',
-                    headers,
-                    body: JSON.stringify({ folderId, cloudVersion, updatedAt: new Date().toISOString() }),
-                    signal: options.signal
-                });
-                state.syncLog?.log({ event: 'manifest:save', level: 'info', details: `Persisted OneDrive manifest for ${folderId}`, data: { provider: 'onedrive', entries: Object.keys(manifestPayload.entries || {}).length, cloudVersion } });
-                return { cloudVersion };
-            }
-            async updateFolderVersionMarker(folderId, version, options = {}) {
-                const headers = { 'Content-Type': 'application/json' };
-                try {
-                    await this.makeApiCall(`/me/drive/special/approot:/state/${folderId}.json:/content`, {
-                        method: 'PUT',
-                        headers,
-                        body: JSON.stringify({ folderId, cloudVersion: version, updatedAt: new Date().toISOString() }),
-                        signal: options.signal
-                    });
-                } catch (error) {
-                    if (/404/.test(String(error.message))) {
-                        await this.saveFolderManifest(folderId, { entries: {}, cloudVersion: version, requiresFullResync: false }, options);
-                    } else {
-                        throw error;
-                    }
-                }
-            }
-            async fetchFilesByIds(folderId, fileIds = [], options = {}) {
-                if (!Array.isArray(fileIds) || fileIds.length === 0) return [];
-                const requests = fileIds.map(id => this.makeApiCall(`/me/drive/items/${id}`, { signal: options.signal }));
-                const results = await Promise.allSettled(requests);
-                const fulfilled = results.filter(result => result.status === 'fulfilled').map(result => result.value);
-                const items = await Promise.all(fulfilled.map(response => response.json()));
-                return items.map(item => ({
-                    id: item.id,
-                    name: item.name,
-                    type: 'file',
-                    mimeType: item.file?.mimeType || 'application/octet-stream',
-                    size: item.size || 0,
-                    createdTime: item.createdDateTime,
-                    modifiedTime: item.lastModifiedDateTime,
-                    thumbnails: item.thumbnails && item.thumbnails.length > 0 ? { large: item.thumbnails[0].large } : null,
-                    downloadUrl: item['@microsoft.graph.downloadUrl']
-                }));
             }
             async getDownloadsFolder() {
                 const response = await this.makeApiCall('/me/drive/root/children');
@@ -3508,20 +3057,24 @@
                     return false;
                 }
                 const sessionKey = `${state.providerType}::${folderId}`;
+                const forceFullResync = Boolean(options.forceFullResync);
+                if (forceFullResync) {
+                    state.sessionVisitedFolders.delete(sessionKey);
+                }
                 try {
                     const syncCheck = await coordinator.shouldSync(folderId);
-                    let files = await state.dbManager.getFolderCache(folderId) || [];
-                    if (syncCheck.needsSync) {
+                    let files = Array.isArray(syncCheck.cachedFiles) ? [...syncCheck.cachedFiles] : await state.dbManager.getFolderCache(folderId) || [];
+                    const shouldFetch = forceFullResync || syncCheck.needsSync || files.length === 0;
+                    if (shouldFetch) {
                         Utils.showScreen('loading-screen');
                         Utils.updateLoadingProgress(0, 100, 'Syncing with cloud...');
                         try {
                             const result = await state.provider.getFilesAndMetadata(folderId);
                             files = result.files || [];
-                            await state.dbManager.saveFolderCache(folderId, files);
+                            await state.folderSyncCoordinator?.cacheFolderSnapshot(folderId, files);
                             for (const file of files) {
                                 await state.dbManager.saveMetadata(file.id, file, { folderId, providerType: state.providerType });
                             }
-                            await coordinator.updateTimestamp(folderId, Date.now());
                             Utils.updateLoadingProgress(100, 100, 'Complete');
                         } catch (error) {
                             Utils.showToast(`Sync failed: ${error.message}`, 'error', true);
@@ -3553,7 +3106,7 @@
                     const folderId = state.currentFolder.id;
                     const result = await state.provider.getFilesAndMetadata(folderId);
                     const files = result.files || [];
-                    await state.dbManager.saveFolderCache(folderId, files);
+                    await state.folderSyncCoordinator?.cacheFolderSnapshot(folderId, files);
                     for (const file of files) {
                         await state.dbManager.saveMetadata(file.id, file, { folderId, providerType: state.providerType });
                     }
@@ -3563,7 +3116,6 @@
                     Core.updateStackCounts();
                     if (state.imageFiles.length > 0) Core.displayCurrentImage();
                     else Core.showEmptyState();
-                    await state.folderSyncCoordinator?.updateTimestamp(folderId, Date.now());
                     Utils.showToast('Folder updated in background', 'info');
                 } catch (error) {
                     console.warn("Background refresh failed:", error.message);


### PR DESCRIPTION
## Summary
- collapse the IndexedDB schema to metadata and optional folder cache entries
- streamline the SimpleSync coordinator/manager to only cache folders and flush metadata through updateFileMetadata
- remove manifest-related helpers from the Google Drive and OneDrive providers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3a8632fc0832d8a487002e6244673