### PR TITLE
Fix folder return ghost screen transition

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -4618,40 +4618,29 @@
                 if (state.isReturningToFolders) return;
 
                 state.isReturningToFolders = true;
-                const { backButton, backButtonSpinner, emptyState } = Utils.elements;
 
-                if (backButton) {
-                    backButton.disabled = true;
-                }
-                if (backButtonSpinner) {
-                    backButtonSpinner.style.display = 'inline-block';
-                }
-                if (emptyState) {
-                    emptyState.classList.add('hidden');
-                }
                 Utils.showScreen('folder-screen');
+                this.resetViewState({ skipEmptyState: true });
 
                 try {
                     if (state.syncManager) {
                         await state.syncManager.flush({ reason: 'folder-switch' });
                     }
+                } catch (error) {
+                    Utils.showToast(`Error syncing before returning to folders: ${error.message}`, 'error', true);
+                }
+
+                try {
                     state.activeRequests?.abort();
                     // Abort pending navigation/network calls; manifest persistence deliberately avoids this controller to finish saving.
                     state.activeRequests = new AbortController();
-                    this.resetViewState({ skipEmptyState: true });
                     await Folders.load();
                 } catch (error) {
                     Utils.showToast(`Error returning to folders: ${error.message}`, 'error', true);
                     Utils.showScreen('folder-screen');
-                } finally {
-                    if (backButton) {
-                        backButton.disabled = false;
-                    }
-                    if (backButtonSpinner) {
-                        backButtonSpinner.style.display = 'none';
-                    }
-                    state.isReturningToFolders = false;
                 }
+
+                state.isReturningToFolders = false;
             },
             resetViewState(options = {}) {
                 const { skipEmptyState = false } = options;


### PR DESCRIPTION
## Summary
- simplify the folder return handler to immediately switch away from the app view
- reset the sorting view state right away to clear stale counters
- keep sync flushing and folder loading asynchronous with resilient error handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4e5c392c0832dbf451f27136ec484