### PR TITLE
Add history browser and snapshot preview workflow

### DIFF
--- a/view.html
+++ b/view.html
@@ -197,10 +197,88 @@
       font-size: 0.9rem;
     }
 
+    .history-section {
+      margin-top: 24px;
+      padding-top: 18px;
+      border-top: 1px solid rgba(95, 107, 130, 0.18);
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .history-section h3 {
+      margin: 0;
+      font-size: 0.95rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+    }
+
+    .history-results {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      max-height: 320px;
+      overflow-y: auto;
+      padding-right: 6px;
+    }
+
+    .history-empty {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+    }
+
+    .history-commit-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .history-chip {
+      display: inline-flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 2px;
+      min-width: 160px;
+      max-width: 240px;
+      padding: 10px 12px;
+      border-radius: 12px;
+      border: 1px solid rgba(95, 107, 130, 0.22);
+      background: rgba(95, 107, 130, 0.12);
+      cursor: pointer;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, border 0.18s ease;
+      text-align: left;
+    }
+
+    .history-chip strong {
+      font-size: 0.9rem;
+      letter-spacing: 0.04em;
+    }
+
+    .history-chip span {
+      font-size: 0.8rem;
+      color: var(--text-muted);
+    }
+
+    .history-chip:hover {
+      transform: translateY(-2px);
+      border-color: var(--accent);
+      box-shadow: 0 10px 22px rgba(67, 97, 238, 0.18);
+    }
+
     @media (prefers-color-scheme: dark) {
       .status-bar {
         background: rgba(122, 162, 255, 0.14);
         border-color: rgba(122, 162, 255, 0.25);
+      }
+
+      .history-section {
+        border-top-color: rgba(148, 163, 184, 0.22);
+      }
+
+      .history-chip {
+        background: rgba(122, 162, 255, 0.18);
+        border-color: rgba(148, 163, 184, 0.35);
       }
     }
 
@@ -456,6 +534,16 @@
       </div>
       <button id="exportBtn" class="button-secondary">Export checklist JSON</button>
       <button id="clearChecklistBtn" class="button-secondary">Clear local checklist copy</button>
+      <div class="history-section" aria-live="polite">
+        <h3>Historical snapshots</h3>
+        <div class="field">
+          <label for="fileHistoryInput">Repository file (path or filename)</label>
+          <input id="fileHistoryInput" type="search" placeholder="index.html or app/ui/index.html" autocomplete="off" />
+        </div>
+        <button id="loadFileHistoryBtn" class="button-secondary" type="button">Load file history</button>
+        <div id="fileHistoryStatus" class="status-bar" hidden></div>
+        <div id="fileHistoryResults" class="history-results" role="list"></div>
+      </div>
     </section>
 
     <section class="panel" id="resultsPanel">
@@ -516,6 +604,10 @@
     const forgetTokenBtn = document.getElementById('forgetTokenBtn');
     const tokenDialog = document.getElementById('tokenDialog');
     const tokenInput = document.getElementById('tokenInput');
+    const fileHistoryInput = document.getElementById('fileHistoryInput');
+    const loadFileHistoryBtn = document.getElementById('loadFileHistoryBtn');
+    const fileHistoryStatus = document.getElementById('fileHistoryStatus');
+    const fileHistoryResults = document.getElementById('fileHistoryResults');
 
     const state = {
       entries: [],
@@ -531,7 +623,11 @@
       isLoading: false,
       isFetchingRepos: false,
       isFetchingBranches: false,
-      token: null
+      token: null,
+      defaultBranch: '',
+      fileHistory: [],
+      selectedFilePath: '',
+      isLoadingFileHistory: false
     };
 
     function loadSettings() {
@@ -687,6 +783,17 @@
       persistSettings();
     });
 
+    loadFileHistoryBtn.addEventListener('click', () => {
+      loadFileHistory();
+    });
+
+    fileHistoryInput.addEventListener('keydown', event => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        loadFileHistory();
+      }
+    });
+
     exportBtn.addEventListener('click', () => {
       if (!state.entries.length) {
         alert('No checklist entries to export yet.');
@@ -758,6 +865,169 @@
     function setButtonsDisabled(disabled) {
       loadBtn.disabled = disabled;
       refreshBtn.disabled = disabled;
+    }
+
+    function renderFileHistory() {
+      fileHistoryResults.innerHTML = '';
+      if (!state.selectedFilePath) {
+        const empty = document.createElement('div');
+        empty.className = 'history-empty';
+        empty.textContent = 'Enter a filename to load its history.';
+        fileHistoryResults.appendChild(empty);
+        return;
+      }
+      if (!state.fileHistory.length) {
+        const empty = document.createElement('div');
+        empty.className = 'history-empty';
+        empty.textContent = 'No commits found for this file on the selected branch.';
+        fileHistoryResults.appendChild(empty);
+        return;
+      }
+      const list = document.createElement('div');
+      list.className = 'history-commit-list';
+      for (const commit of state.fileHistory) {
+        const chip = document.createElement('button');
+        chip.type = 'button';
+        chip.className = 'history-chip';
+        const sha = commit.sha || commit.id;
+        const message = commit.commit?.message || commit.message || '';
+        const firstLine = message.split('\n')[0].trim();
+        const authorDate = commit.commit?.author?.date || commit.commit?.committer?.date || commit.authoredDate;
+        let formattedDate = authorDate || '';
+        if (authorDate) {
+          try {
+            formattedDate = new Date(authorDate).toLocaleString();
+          } catch (err) {
+            formattedDate = authorDate;
+          }
+        }
+        const safeSha = escapeHtml((sha || '').slice(0, 7));
+        const safeDate = escapeHtml(formattedDate || '');
+        const safeMessage = escapeHtml(firstLine || 'View snapshot');
+        chip.innerHTML = `
+          <strong>${safeSha}</strong>
+          <span>${safeDate}</span>
+          <span>${safeMessage}</span>
+        `;
+        chip.title = `${sha}\n${formattedDate}${firstLine ? `\n${firstLine}` : ''}`;
+        chip.addEventListener('click', () => {
+          openHistoryEntry(commit);
+        });
+        list.appendChild(chip);
+      }
+      fileHistoryResults.appendChild(list);
+    }
+
+    async function loadFileHistory() {
+      if (!state.owner || !state.repo) {
+        alert('Select a repository first.');
+        return;
+      }
+      const filePath = fileHistoryInput.value.trim();
+      if (!filePath) {
+        alert('Enter a filename or path to fetch its history.');
+        return;
+      }
+      if (state.isLoadingFileHistory) return;
+      state.isLoadingFileHistory = true;
+      state.selectedFilePath = filePath;
+      setFileHistoryStatus(`Fetching history for ${filePath}…`, { spinner: true });
+      try {
+        const commits = await fetchFileHistory({
+          owner: state.owner,
+          repo: state.repo,
+          path: filePath,
+          branch: state.selectedBranch || state.defaultBranch || undefined
+        });
+        state.fileHistory = commits;
+        if (commits.length) {
+          setFileHistoryStatus(`Loaded ${commits.length} revision${commits.length === 1 ? '' : 's'} for ${filePath}.`);
+        } else {
+          setFileHistoryStatus(`No revisions found for ${filePath}.`, { tone: 'warning' });
+        }
+        renderFileHistory();
+      } catch (error) {
+        console.error('Failed to load file history', error);
+        setFileHistoryStatus(`Error loading history: ${error.message}`, { tone: 'error' });
+        state.fileHistory = [];
+        renderFileHistory();
+      } finally {
+        state.isLoadingFileHistory = false;
+      }
+    }
+
+    async function fetchFileHistory({ owner, repo, path, branch }) {
+      const commits = [];
+      let page = 1;
+      const encodedPath = encodeURIComponent(path);
+      const branchParam = branch ? `&sha=${encodeURIComponent(branch)}` : '';
+      while (page <= 10) {
+        const response = await githubRest(`/repos/${owner}/${repo}/commits?per_page=100&page=${page}&path=${encodedPath}${branchParam}`);
+        if (!Array.isArray(response) || !response.length) break;
+        commits.push(...response);
+        if (response.length < 100) break;
+        page += 1;
+      }
+      return commits;
+    }
+
+    function openHistoryEntry(commit) {
+      if (!state.owner || !state.repo || !state.selectedFilePath) return;
+      const url = new URL('viewer.html', window.location.href);
+      url.searchParams.set('owner', state.owner);
+      url.searchParams.set('repo', state.repo);
+      const sha = commit.sha || commit.id;
+      if (sha) {
+        url.searchParams.set('sha', sha);
+      }
+      url.searchParams.set('path', state.selectedFilePath);
+      const authorDate = commit.commit?.author?.date || commit.commit?.committer?.date || commit.authoredDate;
+      if (authorDate) {
+        url.searchParams.set('committed_at', authorDate);
+      }
+      const authorName = commit.commit?.author?.name || commit.commit?.committer?.name || commit.author?.name;
+      if (authorName) {
+        url.searchParams.set('author', authorName);
+      }
+      const message = commit.commit?.message || commit.message || '';
+      if (message) {
+        url.searchParams.set('message', message.split('\n')[0]);
+      }
+      if (commit.html_url) {
+        url.searchParams.set('commit_url', commit.html_url);
+      }
+      if (state.selectedBranch) {
+        url.searchParams.set('ref', state.selectedBranch);
+      }
+      if (state.defaultBranch) {
+        url.searchParams.set('default_branch', state.defaultBranch);
+      }
+      window.open(url.toString(), '_blank', 'noopener');
+    }
+
+    function resetFileHistory({ clearInput = false } = {}) {
+      state.fileHistory = [];
+      state.selectedFilePath = '';
+      state.isLoadingFileHistory = false;
+      fileHistoryStatus.hidden = true;
+      if (clearInput) {
+        fileHistoryInput.value = '';
+      }
+      renderFileHistory();
+    }
+
+    function setFileHistoryStatus(message, { tone = 'info', spinner = false } = {}) {
+      if (!message) {
+        fileHistoryStatus.hidden = true;
+        fileHistoryStatus.textContent = '';
+        return;
+      }
+      fileHistoryStatus.hidden = false;
+      fileHistoryStatus.textContent = message;
+      fileHistoryStatus.dataset.tone = tone;
+      if (spinner) {
+        fileHistoryStatus.innerHTML = `<span class="loader"></span> <span>${message}</span>`;
+      }
     }
 
     function disableRepoControls(message) {
@@ -858,6 +1128,7 @@
       branchSelect.disabled = true;
       state.branches = [];
       state.selectedBranch = '';
+      state.defaultBranch = '';
     }
 
     function selectRepository(fullName, { userInitiated = false, fromHydration = false } = {}) {
@@ -880,6 +1151,9 @@
         console.warn('Invalid repository selection', fullName);
         return;
       }
+      const repoInfo = state.repos.find(repo => repo.full_name === fullName);
+      state.defaultBranch = repoInfo?.default_branch || '';
+      resetFileHistory({ clearInput: false });
       const [owner, repo] = fullName.split('/', 2);
       state.owner = owner;
       state.repo = repo;
@@ -945,9 +1219,12 @@
         : state.selectedBranch;
       const availableNames = branches.map(branch => branch.name);
       const fallbackBranch = branches[0].name;
+      const preferredDefault = state.defaultBranch && availableNames.includes(state.defaultBranch)
+        ? state.defaultBranch
+        : null;
       const branchToSelect = desiredBranch && availableNames.includes(desiredBranch)
         ? desiredBranch
-        : fallbackBranch;
+        : (preferredDefault || fallbackBranch);
       state.pendingBranchSelection = '';
       applyBranchSelection(branchToSelect, { fromHydration, userInitiated });
     }
@@ -960,6 +1237,11 @@
       state.selectedBranch = value;
       if (value) {
         applyAutoBranchFilter(value, { force: userInitiated });
+      }
+      if (state.selectedFilePath) {
+        state.fileHistory = [];
+        setFileHistoryStatus('Branch changed. Reload file history to refresh results.');
+        renderFileHistory();
       }
       persistSettings();
     }
@@ -1395,6 +1677,7 @@
     }
 
     loadSettings();
+    renderFileHistory();
     applyFilters();
     render();
   </script>

--- a/viewer.html
+++ b/viewer.html
@@ -142,6 +142,203 @@
       display: none;
     }
 
+    .snapshot-form {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      margin-top: 16px;
+      padding: 18px;
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      background: rgba(79, 70, 229, 0.06);
+    }
+
+    .snapshot-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 12px;
+    }
+
+    .snapshot-grid label {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      font-size: 0.76rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .snapshot-grid input {
+      padding: 10px 12px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      font: inherit;
+      background: rgba(255, 255, 255, 0.9);
+      color: inherit;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .snapshot-form {
+        background: rgba(99, 102, 241, 0.16);
+        border-color: var(--border-dark);
+      }
+
+      .snapshot-grid input {
+        background: rgba(31, 36, 48, 0.9);
+        border-color: var(--border-dark);
+      }
+    }
+
+    .snapshot-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .snapshot-actions button {
+      border: 1px solid var(--border);
+      background: rgba(79, 70, 229, 0.12);
+      color: var(--accent);
+      padding: 10px 16px;
+      border-radius: 12px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s ease, transform 0.2s ease;
+    }
+
+    .snapshot-actions button:hover {
+      background: rgba(79, 70, 229, 0.2);
+      transform: translateY(-1px);
+    }
+
+    .snapshot-status {
+      margin: 18px 0 10px;
+      min-height: 24px;
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+
+    .snapshot-meta {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      font-size: 0.88rem;
+      margin-bottom: 12px;
+    }
+
+    .snapshot-action-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-bottom: 16px;
+    }
+
+    .snapshot-action-row button {
+      border: 1px solid var(--border);
+      background: rgba(34, 197, 94, 0.14);
+      color: var(--success);
+      padding: 10px 16px;
+      border-radius: 12px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s ease, transform 0.2s ease;
+    }
+
+    .snapshot-action-row button.secondary {
+      background: rgba(59, 130, 246, 0.12);
+      color: var(--accent);
+    }
+
+    .snapshot-action-row button.danger {
+      background: rgba(220, 38, 38, 0.12);
+      color: var(--danger);
+    }
+
+    .snapshot-action-row button:hover {
+      transform: translateY(-1px);
+    }
+
+    .snapshot-preview {
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      overflow: hidden;
+      min-height: 420px;
+      background: #ffffff;
+    }
+
+    .snapshot-preview iframe {
+      width: 100%;
+      min-height: 420px;
+      border: none;
+      background: #ffffff;
+    }
+
+    .snapshot-raw {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      margin-top: 16px;
+    }
+
+    .snapshot-raw textarea {
+      width: 100%;
+      min-height: 200px;
+      resize: vertical;
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+      font-size: 0.85rem;
+      padding: 12px;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.9);
+      color: inherit;
+    }
+
+    .snapshot-recent {
+      margin: 18px 0 10px;
+    }
+
+    .history-commit-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .snapshot-recent h4 {
+      margin: 0 0 8px;
+      font-size: 0.9rem;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .history-chip-button {
+      display: inline-flex;
+      flex-direction: column;
+      gap: 2px;
+      padding: 8px 12px;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: rgba(148, 163, 184, 0.12);
+      cursor: pointer;
+      min-width: 180px;
+      transition: transform 0.18s ease, border 0.18s ease;
+    }
+
+    .history-chip-button strong {
+      font-size: 0.88rem;
+    }
+
+    .history-chip-button span {
+      font-size: 0.78rem;
+      color: var(--muted);
+    }
+
+    .history-chip-button:hover {
+      transform: translateY(-2px);
+      border-color: var(--accent);
+    }
+
     #status-bar {
       min-height: 24px;
       font-size: 0.9rem;
@@ -502,6 +699,7 @@
   <div class="app-shell">
     <nav class="tab-bar" role="tablist">
       <button class="tab-button active" id="tab-view" role="tab" aria-selected="true" aria-controls="panel-view">View</button>
+      <button class="tab-button" id="tab-preview" role="tab" aria-selected="false" aria-controls="panel-preview">Snapshot preview</button>
     </nav>
     <section class="tab-panel active" id="panel-view" role="tabpanel" aria-labelledby="tab-view">
       <div class="toolbar">
@@ -516,6 +714,56 @@
       </div>
       <div id="status-bar" role="status" aria-live="polite"></div>
       <div class="entries" id="entry-list"></div>
+    </section>
+    <section class="tab-panel" id="panel-preview" role="tabpanel" aria-labelledby="tab-preview">
+      <form class="snapshot-form" id="snapshotForm">
+        <div class="snapshot-grid">
+          <label>Owner
+            <input id="snapshotOwner" type="text" placeholder="acme" required />
+          </label>
+          <label>Repository
+            <input id="snapshotRepo" type="text" placeholder="perf" required />
+          </label>
+          <label>Commit SHA or ref
+            <input id="snapshotSha" type="text" placeholder="abcdef1" required />
+          </label>
+          <label>Repository path
+            <input id="snapshotPath" type="text" placeholder="index.html" required />
+          </label>
+          <label>New branch name
+            <input id="snapshotBranch" type="text" placeholder="history/abcdef1" />
+          </label>
+          <label>Compare against
+            <input id="snapshotBase" type="text" placeholder="main" />
+          </label>
+          <label>Download as
+            <input id="snapshotFileName" type="text" placeholder="index-history.html" />
+          </label>
+        </div>
+        <div class="snapshot-actions">
+          <button type="submit" id="snapshotFetchButton">Load snapshot</button>
+          <button type="button" id="snapshotResetButton">Reset form</button>
+        </div>
+      </form>
+      <div id="snapshotStatus" class="snapshot-status" role="status" aria-live="polite"></div>
+      <div id="snapshotMeta" class="snapshot-meta" hidden></div>
+      <div id="snapshotActionRow" class="snapshot-action-row" hidden>
+        <button type="button" id="snapshotDownloadButton">Download HTML</button>
+        <button type="button" id="snapshotCopyButton" class="secondary">Copy to clipboard</button>
+        <button type="button" id="snapshotOpenRawButton" class="secondary">Open raw on GitHub</button>
+        <button type="button" id="snapshotPromoteButton" class="secondary">Create branch &amp; open compare</button>
+      </div>
+      <div id="snapshotRecent" class="snapshot-recent" hidden>
+        <h4>Recent snapshots</h4>
+        <div id="snapshotRecentList" class="history-commit-list"></div>
+      </div>
+      <div id="snapshotPreviewShell" class="snapshot-preview" hidden>
+        <iframe id="snapshotFrame" sandbox="allow-scripts allow-forms allow-popups" title="Snapshot preview"></iframe>
+      </div>
+      <div id="snapshotRawShell" class="snapshot-raw" hidden>
+        <label for="snapshotRaw">Raw content</label>
+        <textarea id="snapshotRaw" readonly></textarea>
+      </div>
     </section>
   </div>
   <script src="codex-checklist-shared.js"></script>
@@ -561,6 +809,8 @@
     ];
 
     const codex = window.CodexChecklist;
+    const TOKEN_KEY = 'codexrecall.pat';
+    const SNAPSHOT_HISTORY_KEY = 'codexrecall.snapshotHistory';
 
     const dom = {
       entryList: document.getElementById('entry-list'),
@@ -575,6 +825,35 @@
       statusBar: document.getElementById('status-bar')
     };
 
+    const tabButtons = Array.from(document.querySelectorAll('.tab-button'));
+    const tabPanels = Array.from(document.querySelectorAll('.tab-panel'));
+
+    const previewDom = {
+      form: document.getElementById('snapshotForm'),
+      owner: document.getElementById('snapshotOwner'),
+      repo: document.getElementById('snapshotRepo'),
+      sha: document.getElementById('snapshotSha'),
+      path: document.getElementById('snapshotPath'),
+      branch: document.getElementById('snapshotBranch'),
+      base: document.getElementById('snapshotBase'),
+      fileName: document.getElementById('snapshotFileName'),
+      fetchButton: document.getElementById('snapshotFetchButton'),
+      resetButton: document.getElementById('snapshotResetButton'),
+      status: document.getElementById('snapshotStatus'),
+      meta: document.getElementById('snapshotMeta'),
+      actionRow: document.getElementById('snapshotActionRow'),
+      downloadButton: document.getElementById('snapshotDownloadButton'),
+      copyButton: document.getElementById('snapshotCopyButton'),
+      openRawButton: document.getElementById('snapshotOpenRawButton'),
+      promoteButton: document.getElementById('snapshotPromoteButton'),
+      previewShell: document.getElementById('snapshotPreviewShell'),
+      frame: document.getElementById('snapshotFrame'),
+      rawShell: document.getElementById('snapshotRawShell'),
+      raw: document.getElementById('snapshotRaw'),
+      recentShell: document.getElementById('snapshotRecent'),
+      recentList: document.getElementById('snapshotRecentList')
+    };
+
     const openEntries = new Set();
 
     const derivedState = {
@@ -586,6 +865,46 @@
       csvContent: '',
       pdfBlob: null
     };
+
+    const snapshotState = {
+      owner: '',
+      repo: '',
+      sha: '',
+      path: '',
+      branch: '',
+      base: '',
+      fileName: '',
+      committedAt: '',
+      author: '',
+      message: '',
+      commitUrl: '',
+      content: '',
+      rawUrl: ''
+    };
+
+    tabPanels.forEach(panel => {
+      panel.hidden = !panel.classList.contains('active');
+    });
+
+    tabButtons.forEach(button => {
+      button.addEventListener('click', () => {
+        activateTab(button.id);
+      });
+    });
+
+    function activateTab(buttonId) {
+      const panelId = buttonId.replace('tab-', 'panel-');
+      tabButtons.forEach(button => {
+        const isActive = button.id === buttonId;
+        button.classList.toggle('active', isActive);
+        button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      });
+      tabPanels.forEach(panel => {
+        const isActive = panel.id === panelId;
+        panel.classList.toggle('active', isActive);
+        panel.hidden = !isActive;
+      });
+    }
 
     let currentChecklist = initializeCurrentChecklist();
     let entries = cloneEntries(currentChecklist?.payload?.entries || defaultEntries);
@@ -1570,6 +1889,498 @@
       reader.readAsText(file);
       event.target.value = '';
     }
+
+    function setSnapshotStatus(message, tone = 'info') {
+      if (!previewDom.status) return;
+      if (!message) {
+        previewDom.status.textContent = '';
+        previewDom.status.removeAttribute('data-tone');
+        previewDom.status.style.color = 'var(--muted)';
+        return;
+      }
+      previewDom.status.textContent = message;
+      let color = 'var(--muted)';
+      if (tone === 'error') {
+        color = 'var(--danger)';
+      } else if (tone === 'success') {
+        color = 'var(--success)';
+      }
+      previewDom.status.style.color = color;
+      previewDom.status.dataset.tone = tone;
+    }
+
+    function clearSnapshotView() {
+      if (!previewDom.previewShell) return;
+      snapshotState.content = '';
+      snapshotState.rawUrl = '';
+      previewDom.previewShell.hidden = true;
+      previewDom.frame.srcdoc = '';
+      previewDom.rawShell.hidden = true;
+      previewDom.raw.value = '';
+      previewDom.actionRow.hidden = true;
+      previewDom.meta.hidden = true;
+    }
+
+    function updateSnapshotMeta() {
+      if (!previewDom.meta) return;
+      const rows = [];
+      if (snapshotState.owner && snapshotState.repo) {
+        rows.push(`<div><strong>${escapeHtml(`${snapshotState.owner}/${snapshotState.repo}`)}</strong></div>`);
+      }
+      if (snapshotState.path) {
+        rows.push(`<div>${escapeHtml(snapshotState.path)}</div>`);
+      }
+      if (snapshotState.sha) {
+        rows.push(`<div>Commit: <code>${escapeHtml(snapshotState.sha.slice(0, 12))}</code></div>`);
+      }
+      if (snapshotState.message) {
+        rows.push(`<div>${escapeHtml(snapshotState.message)}</div>`);
+      }
+      if (snapshotState.author || snapshotState.committedAt) {
+        let timestamp = snapshotState.committedAt || '';
+        if (timestamp) {
+          try {
+            timestamp = new Date(timestamp).toLocaleString();
+          } catch (error) {
+            timestamp = snapshotState.committedAt;
+          }
+        }
+        const author = snapshotState.author ? escapeHtml(snapshotState.author) : 'Unknown author';
+        rows.push(`<div>${author}${timestamp ? ` · ${escapeHtml(timestamp)}` : ''}</div>`);
+      }
+      if (snapshotState.commitUrl) {
+        rows.push(`<div><a href="${escapeHtml(snapshotState.commitUrl)}" target="_blank" rel="noopener">View commit on GitHub ↗</a></div>`);
+      }
+      previewDom.meta.innerHTML = rows.join('');
+      previewDom.meta.hidden = !rows.length;
+    }
+
+    function deriveDownloadNameFromPath(path, ref) {
+      const safeRef = (ref || '').slice(0, 7) || 'snapshot';
+      const baseName = (path || 'snapshot.html').split('/').pop() || 'snapshot.html';
+      if (baseName.includes('.')) {
+        const dotIndex = baseName.lastIndexOf('.');
+        const namePart = baseName.slice(0, dotIndex) || 'snapshot';
+        const ext = baseName.slice(dotIndex + 1) || 'html';
+        return `${namePart}-${safeRef}.${ext}`;
+      }
+      return `${baseName}-${safeRef}.html`;
+    }
+
+    function getStoredToken() {
+      try {
+        return localStorage.getItem(TOKEN_KEY);
+      } catch (error) {
+        console.warn('Unable to read stored token', error);
+        return null;
+      }
+    }
+
+    async function githubRest(path, { method = 'GET', body, headers } = {}) {
+      const token = getStoredToken();
+      const requestHeaders = {
+        'Accept': 'application/vnd.github+json',
+        ...headers
+      };
+      if (body && !requestHeaders['Content-Type']) {
+        requestHeaders['Content-Type'] = 'application/json';
+      }
+      if (token) {
+        requestHeaders.Authorization = `Bearer ${token}`;
+      }
+      const response = await fetch(`https://api.github.com${path}`, {
+        method,
+        headers: requestHeaders,
+        body
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        let message = text;
+        try {
+          const parsed = JSON.parse(text);
+          message = parsed.message || message;
+        } catch (error) {
+          // ignore JSON parse errors
+        }
+        const error = new Error(message || `GitHub API error ${response.status}`);
+        error.status = response.status;
+        throw error;
+      }
+      if (response.status === 204) {
+        return null;
+      }
+      const text = await response.text();
+      return text ? JSON.parse(text) : null;
+    }
+
+    async function fetchSnapshotContent({ owner, repo, ref, path }) {
+      const token = getStoredToken();
+      const normalizedPath = path.replace(/^\/+/, '');
+      const encodedPath = encodePathSegments(normalizedPath);
+      const url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(ref)}`;
+      const headers = { 'Accept': 'application/vnd.github.v3.raw' };
+      if (token) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+      const response = await fetch(url, { headers });
+      if (!response.ok) {
+        const errorText = await response.text();
+        let message = `GitHub returned ${response.status}`;
+        try {
+          const parsed = JSON.parse(errorText);
+          message = parsed.message || message;
+        } catch (error) {
+          // ignore JSON parse errors
+        }
+        throw new Error(message);
+      }
+      return response.text();
+    }
+
+    async function fetchCommitMetadata({ owner, repo, ref }) {
+      try {
+        return await githubRest(`/repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}`);
+      } catch (error) {
+        if (error.status !== 404) {
+          console.warn('Failed to fetch commit metadata', error);
+        }
+        return null;
+      }
+    }
+
+    function loadSnapshotHistory() {
+      try {
+        const raw = localStorage.getItem(SNAPSHOT_HISTORY_KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch (error) {
+        console.warn('Unable to parse snapshot history', error);
+        return [];
+      }
+    }
+
+    function rememberSnapshot() {
+      const history = loadSnapshotHistory();
+      const key = `${snapshotState.owner}/${snapshotState.repo}/${snapshotState.sha}/${snapshotState.path}`;
+      const entry = {
+        key,
+        owner: snapshotState.owner,
+        repo: snapshotState.repo,
+        sha: snapshotState.sha,
+        path: snapshotState.path,
+        branch: snapshotState.branch,
+        base: snapshotState.base,
+        fileName: snapshotState.fileName,
+        committedAt: snapshotState.committedAt,
+        author: snapshotState.author,
+        message: snapshotState.message,
+        commitUrl: snapshotState.commitUrl
+      };
+      const filtered = history.filter(item => item.key !== key);
+      filtered.unshift(entry);
+      if (filtered.length > 8) {
+        filtered.length = 8;
+      }
+      try {
+        localStorage.setItem(SNAPSHOT_HISTORY_KEY, JSON.stringify(filtered));
+      } catch (error) {
+        console.warn('Unable to persist snapshot history', error);
+      }
+      renderRecentSnapshots(filtered);
+    }
+
+    function renderRecentSnapshots(history = null) {
+      if (!previewDom.recentList) return;
+      const snapshots = Array.isArray(history) ? history : loadSnapshotHistory();
+      previewDom.recentList.innerHTML = '';
+      if (!snapshots.length) {
+        previewDom.recentShell.hidden = true;
+        return;
+      }
+      snapshots.forEach(item => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'history-chip-button';
+        button.innerHTML = `
+          <strong>${escapeHtml(`${item.owner}/${item.repo}`)}</strong>
+          <span>${escapeHtml(item.path || '')}</span>
+          <span>${escapeHtml((item.sha || '').slice(0, 7))}</span>
+        `;
+        button.title = `${item.owner}/${item.repo}\n${item.path}\n${item.sha}`;
+        button.addEventListener('click', () => {
+          previewDom.owner.value = item.owner || '';
+          previewDom.repo.value = item.repo || '';
+          previewDom.sha.value = item.sha || '';
+          previewDom.path.value = item.path || '';
+          previewDom.branch.value = item.branch || '';
+          previewDom.base.value = item.base || '';
+          previewDom.fileName.value = item.fileName || deriveDownloadNameFromPath(item.path || '', item.sha || '');
+          const seedMeta = {
+            message: item.message || '',
+            committedAt: item.committedAt || '',
+            author: item.author || '',
+            commitUrl: item.commitUrl || ''
+          };
+          activateTab('tab-preview');
+          loadSnapshot({ remember: false, seedMeta });
+        });
+        previewDom.recentList.appendChild(button);
+      });
+      previewDom.recentShell.hidden = false;
+    }
+
+    function resetSnapshotForm() {
+      if (!previewDom.form) return;
+      previewDom.form.reset();
+      Object.assign(snapshotState, {
+        owner: '',
+        repo: '',
+        sha: '',
+        path: '',
+        branch: '',
+        base: '',
+        fileName: '',
+        committedAt: '',
+        author: '',
+        message: '',
+        commitUrl: '',
+        content: '',
+        rawUrl: ''
+      });
+      clearSnapshotView();
+      setSnapshotStatus('');
+    }
+
+    async function loadSnapshot({ remember = true, seedMeta = null } = {}) {
+      if (!previewDom.form) return;
+      const owner = previewDom.owner.value.trim();
+      const repo = previewDom.repo.value.trim();
+      const refInput = previewDom.sha.value.trim();
+      const pathInput = previewDom.path.value.trim();
+      if (!owner || !repo || !refInput || !pathInput) {
+        setSnapshotStatus('Fill out owner, repository, commit, and path to load a snapshot.', 'error');
+        return;
+      }
+      const branchInput = previewDom.branch.value.trim();
+      const baseInput = previewDom.base.value.trim();
+      const normalizedPath = pathInput.replace(/^\/+/, '');
+      const downloadName = previewDom.fileName.value.trim() || deriveDownloadNameFromPath(normalizedPath, refInput);
+      previewDom.fileName.value = downloadName;
+      const metaSeed = seedMeta || {};
+      Object.assign(snapshotState, {
+        owner,
+        repo,
+        sha: refInput,
+        path: normalizedPath,
+        branch: branchInput,
+        base: baseInput,
+        fileName: downloadName,
+        content: '',
+        rawUrl: '',
+        message: metaSeed.message || '',
+        committedAt: metaSeed.committedAt || '',
+        author: metaSeed.author || '',
+        commitUrl: metaSeed.commitUrl || ''
+      });
+      clearSnapshotView();
+      setSnapshotStatus(`Loading ${normalizedPath} from ${refInput.slice(0, 12)}…`);
+      try {
+        const content = await fetchSnapshotContent({ owner, repo, ref: refInput, path: normalizedPath });
+        snapshotState.content = content;
+        previewDom.raw.value = content;
+        previewDom.rawShell.hidden = false;
+        previewDom.previewShell.hidden = false;
+        previewDom.frame.srcdoc = content;
+        previewDom.actionRow.hidden = false;
+        const commitData = await fetchCommitMetadata({ owner, repo, ref: refInput });
+        if (commitData) {
+          snapshotState.sha = commitData.sha || snapshotState.sha;
+          previewDom.sha.value = commitData.sha || refInput;
+          snapshotState.commitUrl = snapshotState.commitUrl || commitData.html_url || '';
+          snapshotState.message = snapshotState.message || (commitData.commit?.message ? commitData.commit.message.split('\n')[0] : '');
+          snapshotState.committedAt = snapshotState.committedAt || commitData.commit?.author?.date || commitData.commit?.committer?.date || '';
+          snapshotState.author = snapshotState.author || commitData.commit?.author?.name || commitData.commit?.committer?.name || '';
+        }
+        const rawRef = snapshotState.sha || refInput;
+        snapshotState.rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${rawRef}/${encodePathSegments(normalizedPath)}`;
+        updateSnapshotMeta();
+        setSnapshotStatus(`Snapshot loaded for ${normalizedPath}.`, 'success');
+        if (remember) {
+          rememberSnapshot();
+        } else {
+          renderRecentSnapshots();
+        }
+      } catch (error) {
+        console.error('Snapshot load failed', error);
+        setSnapshotStatus(`Failed to load snapshot: ${error.message}`, 'error');
+        clearSnapshotView();
+      }
+    }
+
+    function downloadSnapshot() {
+      if (!snapshotState.content) {
+        setSnapshotStatus('Load a snapshot first.', 'error');
+        return;
+      }
+      const desiredName = previewDom.fileName.value.trim() || deriveDownloadNameFromPath(snapshotState.path, snapshotState.sha);
+      const safeName = desiredName.replace(/[\\/:*?"<>|]+/g, '-');
+      const blob = new Blob([snapshotState.content], { type: 'text/html' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = safeName;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      setSnapshotStatus(`Downloaded ${safeName}.`, 'success');
+    }
+
+    async function copySnapshotToClipboard() {
+      if (!snapshotState.content) {
+        setSnapshotStatus('Load a snapshot first.', 'error');
+        return;
+      }
+      if (!navigator.clipboard) {
+        setSnapshotStatus('Clipboard access unavailable. Copy directly from the raw text area.', 'error');
+        return;
+      }
+      try {
+        await navigator.clipboard.writeText(snapshotState.content);
+        setSnapshotStatus('Snapshot copied to clipboard.', 'success');
+      } catch (error) {
+        console.warn('Unable to copy snapshot', error);
+        setSnapshotStatus('Unable to copy snapshot. Copy from the raw text area instead.', 'error');
+      }
+    }
+
+    function openRawSnapshot() {
+      if (!snapshotState.rawUrl) {
+        setSnapshotStatus('Load a snapshot first.', 'error');
+        return;
+      }
+      window.open(snapshotState.rawUrl, '_blank', 'noopener');
+    }
+
+    function encodeGitRef(ref) {
+      return ref.split('/').map(segment => encodeURIComponent(segment)).join('/');
+    }
+
+    async function ensureSnapshotBranch({ owner, repo, branchName, sourceSha }) {
+      const token = getStoredToken();
+      if (!token) {
+        throw new Error('Set a GitHub token in Codex Recall to promote snapshots.');
+      }
+      const encodedBranch = encodeGitRef(branchName);
+      try {
+        const existing = await githubRest(`/repos/${owner}/${repo}/git/refs/heads/${encodedBranch}`);
+        if (existing?.object?.sha === sourceSha) {
+          return { created: false, updated: false };
+        }
+        const confirmReset = confirm(`Branch ${branchName} already exists. Reset it to ${sourceSha.slice(0, 7)}?`);
+        if (!confirmReset) {
+          throw new Error('Branch promotion cancelled.');
+        }
+        await githubRest(`/repos/${owner}/${repo}/git/refs/heads/${encodedBranch}`, {
+          method: 'PATCH',
+          body: JSON.stringify({ sha: sourceSha, force: true })
+        });
+        return { created: false, updated: true };
+      } catch (error) {
+        if (error.status === 404) {
+          await githubRest(`/repos/${owner}/${repo}/git/refs`, {
+            method: 'POST',
+            body: JSON.stringify({ ref: `refs/heads/${branchName}`, sha: sourceSha })
+          });
+          return { created: true, updated: false };
+        }
+        throw error;
+      }
+    }
+
+    async function promoteSnapshot() {
+      if (!snapshotState.content) {
+        setSnapshotStatus('Load a snapshot first.', 'error');
+        return;
+      }
+      const owner = snapshotState.owner;
+      const repo = snapshotState.repo;
+      if (!owner || !repo) {
+        setSnapshotStatus('Owner and repository are required to promote a snapshot.', 'error');
+        return;
+      }
+      const branchName = previewDom.branch.value.trim() || `history/${(snapshotState.sha || 'snapshot').slice(0, 7)}`;
+      const baseBranch = previewDom.base.value.trim() || 'main';
+      if (!snapshotState.sha) {
+        setSnapshotStatus('Resolve the commit before promoting the snapshot.', 'error');
+        return;
+      }
+      if (!/^[0-9a-f]{7,40}$/i.test(snapshotState.sha)) {
+        setSnapshotStatus('The commit reference must resolve to a full commit SHA before promotion.', 'error');
+        return;
+      }
+      try {
+        setSnapshotStatus(`Preparing branch ${branchName}…`);
+        const result = await ensureSnapshotBranch({ owner, repo, branchName, sourceSha: snapshotState.sha });
+        const action = result.created ? 'created' : (result.updated ? 'reset' : 'reused');
+        setSnapshotStatus(`Branch ${branchName} ${action}. Opening compare view…`, 'success');
+        const compareUrl = `https://github.com/${owner}/${repo}/compare/${encodeURIComponent(baseBranch)}...${encodeURIComponent(branchName)}?expand=1`;
+        window.open(compareUrl, '_blank', 'noopener');
+      } catch (error) {
+        console.error('Snapshot promotion failed', error);
+        setSnapshotStatus(`Promotion failed: ${error.message}`, 'error');
+      }
+    }
+
+    function hydrateSnapshotFromQuery() {
+      if (!previewDom.form) return;
+      const params = new URLSearchParams(window.location.search);
+      const owner = params.get('owner') || '';
+      const repo = params.get('repo') || '';
+      const path = params.get('path') || '';
+      const shaParam = params.get('sha') || params.get('ref') || '';
+      if (!owner || !repo || !path || !shaParam) {
+        renderRecentSnapshots();
+        return;
+      }
+      previewDom.owner.value = owner;
+      previewDom.repo.value = repo;
+      previewDom.sha.value = shaParam;
+      previewDom.path.value = path;
+      const branch = params.get('ref') || '';
+      if (branch) {
+        previewDom.branch.value = branch;
+      }
+      const base = params.get('default_branch') || '';
+      if (base) {
+        previewDom.base.value = base;
+      }
+      const downloadName = deriveDownloadNameFromPath(path, shaParam);
+      previewDom.fileName.value = downloadName;
+      const seedMeta = {
+        message: params.get('message') || '',
+        committedAt: params.get('committed_at') || '',
+        author: params.get('author') || '',
+        commitUrl: params.get('commit_url') || ''
+      };
+      activateTab('tab-preview');
+      loadSnapshot({ remember: false, seedMeta });
+    }
+
+    previewDom.form?.addEventListener('submit', event => {
+      event.preventDefault();
+      loadSnapshot();
+    });
+    previewDom.resetButton?.addEventListener('click', resetSnapshotForm);
+    previewDom.downloadButton?.addEventListener('click', downloadSnapshot);
+    previewDom.copyButton?.addEventListener('click', copySnapshotToClipboard);
+    previewDom.openRawButton?.addEventListener('click', openRawSnapshot);
+    previewDom.promoteButton?.addEventListener('click', promoteSnapshot);
+
+    resetSnapshotForm();
+    hydrateSnapshotFromQuery();
+    renderRecentSnapshots();
 
     if (codex) {
       window.addEventListener('codexrecall:checklist-updated', event => {


### PR DESCRIPTION
## Summary
- add a file-scoped history browser to Codex Recall so a repository path can be inspected across commits and opened in the viewer
- extend the viewer with a snapshot preview tab that fetches raw content, renders it, and offers download/copy/promotion helpers
- persist recent snapshots and GitHub token-powered utilities so historical versions can be promoted into editable branches quickly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e58e855f84832da62704e4be3537b7