### PR TITLE
Fix Omni search counter and tighten folder picker header

### DIFF
--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -77,7 +77,7 @@
         
         .folder-button {
             flex: 1; padding: 12px 24px; border: 1px solid var(--border); background: var(--glass);
-            font-size: 14px; backdrop-filter: blur(10px); width: auto;
+            font-size: 14px; backdrop-filter: blur(10px); width: auto; margin-bottom: 0;
         }
         .folder-button.danger { border-color: rgba(239, 68, 68, 0.3); color: #ef4444; }
         .folder-button.danger:hover { background: rgba(239, 68, 68, 0.1); }
@@ -150,6 +150,59 @@
         .last-folder-meta {
             font-size: 12px;
             color: rgba(255, 255, 255, 0.7);
+        }
+        .folder-card {
+            max-height: 84vh;
+            display: flex;
+            flex-direction: column;
+            padding: 14px 20px 16px;
+            text-align: left;
+            gap: 8px;
+        }
+        .folder-card .title {
+            margin-bottom: 0;
+            font-size: 18px;
+            line-height: 1.3;
+        }
+        .folder-card .subtitle {
+            margin-bottom: 0;
+            color: rgba(255, 255, 255, 0.6);
+            font-size: 12px;
+            line-height: 1.35;
+        }
+        .folder-card .last-folder-banner {
+            align-items: flex-start;
+            text-align: left;
+            gap: 4px;
+            padding: 8px 10px;
+            margin-bottom: 6px;
+        }
+        .folder-card .last-folder-row {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            flex-wrap: wrap;
+            width: 100%;
+        }
+        .folder-card .last-folder-meta {
+            margin-top: 0;
+        }
+        .folder-card .omni-search-container { margin-bottom: 6px; }
+        .folder-card .folder-list {
+            flex: 1;
+            overflow-y: auto;
+            margin-bottom: 6px;
+            max-height: none;
+            min-height: 0;
+        }
+        .folder-controls {
+            display: flex;
+            gap: 12px;
+            margin-top: 8px;
+        }
+        .folder-controls .folder-button {
+            padding: 10px 16px;
+            font-size: 13px;
         }
         .omni-search-container {
             position: relative;
@@ -373,16 +426,25 @@
         #grid-size-value { font-size: 14px; color: #4b5563; min-width: 20px; }
         
         .grid-row-3 {
-            padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px; position: relative;
+            padding: 8px 16px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 8px;
+        }
+        .omni-search-input-wrapper {
+            position: relative; flex: 1; display: flex; align-items: center;
         }
         #omni-search {
-            flex-grow: 1; padding: 6px 30px 6px 10px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 14px;
+            width: 100%; padding: 6px 30px 6px 10px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 14px;
         }
         #clear-search-btn {
-            position: absolute; right: 24px; top: 50%; transform: translateY(-50%);
-            color: #9ca3af; cursor: pointer; display: none;
+            position: absolute; right: 10px; top: 50%; transform: translateY(-50%);
+            color: #9ca3af; cursor: pointer; display: none; background: transparent; border: none; padding: 0;
         }
         #clear-search-btn:hover { color: #6b7280; }
+        .omni-search-count {
+            margin-left: auto; font-size: 12px; color: #6b7280; background: #f3f4f6; padding: 2px 10px;
+            border-radius: 9999px; line-height: 1.4; font-weight: 600; display: inline-flex; align-items: center;
+            white-space: nowrap;
+        }
+        .omni-search-count.is-filtered { color: #1d4ed8; background: #dbeafe; }
         
         /* NEW: Search Helper */
         .search-helper { position: relative; display: flex; align-items: center; }
@@ -805,12 +867,14 @@
     
     <!-- Unified Folder Screen -->
     <div class="screen hidden" id="folder-screen">
-        <div class="card" style="max-height: 80vh; display: flex; flex-direction: column;">
+        <div class="card folder-card">
             <h2 class="title" id="folder-title">Select Folder</h2>
             <div class="subtitle" id="folder-subtitle">Choose a folder containing images</div>
             <div class="last-folder-banner hidden" id="last-folder-banner">
-                <span>Last folder:</span>
-                <a class="last-folder-link" id="last-folder-link" href="#"></a>
+                <div class="last-folder-row">
+                    <span class="last-folder-label">Last folder:</span>
+                    <a class="last-folder-link" id="last-folder-link" href="#"></a>
+                </div>
                 <span class="last-folder-meta" id="last-folder-meta"></span>
             </div>
             <div class="omni-search-container hidden" id="folder-search-container">
@@ -818,7 +882,7 @@
                 <div class="omni-search-results hidden" id="folder-search-results" role="listbox"></div>
             </div>
             <div class="folder-list" id="folder-list"></div>
-            <div class="folder-actions">
+            <div class="folder-controls">
                 <button class="folder-button" id="folder-refresh-button">Refresh</button>
                 <button class="folder-button" id="folder-back-button">← Provider</button>
                 <button class="folder-button danger" id="folder-logout-button">Disconnect</button>
@@ -948,7 +1012,12 @@
                 </div>
                 
                 <div class="grid-row-3">
-                    <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
+                    <div class="omni-search-input-wrapper">
+                        <input type="text" id="omni-search" class="input" placeholder="Search with terms, -exclusions, #modifiers..." style="margin-bottom: 0;">
+                        <button id="clear-search-btn">
+                             <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                        </button>
+                    </div>
                     <div class="search-helper" id="search-helper">
                         <button type="button" class="search-helper-icon" id="search-helper-icon" aria-label="Search modifiers" aria-haspopup="true" aria-expanded="false">
                             <svg style="width: 20px; height: 20px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
@@ -965,9 +1034,7 @@
                             <a class="modifier-link" data-modifier="#content:5">#content:1-5</a>
                         </div>
                     </div>
-                    <button id="clear-search-btn">
-                         <svg style="width: 16px; height: 16px;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
-                    </button>
+                    <span class="omni-search-count" id="omni-search-count" aria-live="polite">All: 0</span>
                 </div>
                 
                 <div class="grid-row-4">
@@ -1112,8 +1179,15 @@
             isFocusMode: false, stacks: { in: [], out: [], priority: [], trash: [] },
             isDragging: false, isPinching: false, initialDistance: 0, currentScale: 1,
             maxScale: 4, minScale: 0.3, panOffset: { x: 0, y: 0 },
-            grid: { stack: null, selected: [], filtered: [], isDirty: false,
-                lazyLoadState: { allFiles: [], renderedCount: 0, observer: null, batchSize: 20 } },
+            grid: {
+                stack: null,
+                selected: [],
+                filtered: [],
+                isDirty: false,
+                searchActive: false,
+                lastSearchCount: null,
+                lazyLoadState: { allFiles: [], renderedCount: 0, observer: null, batchSize: 20 }
+            },
             tags: new Set(), loadingProgress: { current: 0, total: 0 },
             folderMoveMode: { active: false, files: [] },
             isReturningToFolders: false,
@@ -1314,9 +1388,10 @@
                     closeGrid: document.getElementById('close-grid'),
                     gridSize: document.getElementById('grid-size'),
                     gridSizeValue: document.getElementById('grid-size-value'),
-                    
+
                     omniSearch: document.getElementById('omni-search'),
                     clearSearchBtn: document.getElementById('clear-search-btn'),
+                    omniSearchCount: document.getElementById('omni-search-count'),
                     searchHelper: document.getElementById('search-helper'),
                     searchHelperIcon: document.getElementById('search-helper-icon'),
                     searchHelperPopup: document.getElementById('search-helper-popup'),
@@ -5256,9 +5331,11 @@ this.updateImageCounters();
                 Utils.elements.gridTitle.textContent = STACK_NAMES[stack] || stack;
                 state.grid.stack = stack;
                 state.grid.isDirty = false;
+                state.grid.lastSearchCount = null;
                 const value = Utils.elements.gridSize.value;
                 Utils.elements.gridContainer.style.gridTemplateColumns = `repeat(${value}, 1fr)`;
                 state.grid.selected = []; state.grid.filtered = [];
+                state.grid.searchActive = false;
                 Utils.elements.gridContainer.innerHTML = '';
                 this.initializeLazyLoad(stack);
                 this.updateSelectionUI();
@@ -5297,7 +5374,11 @@ this.updateImageCounters();
                     : (state.grid.filtered.length > 0 ? state.grid.filtered : state.stacks[stack]);
                 lazyState.allFiles = sourceFiles;
                 lazyState.renderedCount = 0;
+                if (state.grid.searchActive) {
+                    state.grid.lastSearchCount = sourceFiles.length;
+                }
                 Utils.elements.selectAllBtn.textContent = sourceFiles.length;
+                this.updateResultCounter(sourceFiles.length, state.grid.searchActive);
                 this.renderBatch();
                 if (lazyState.observer) lazyState.observer.disconnect();
                 lazyState.observer = new IntersectionObserver(this.handleIntersection.bind(this), {
@@ -5311,6 +5392,33 @@ this.updateImageCounters();
                 const lazyState = state.grid.lazyLoadState;
                 if (lazyState.observer) { lazyState.observer.disconnect(); lazyState.observer = null; }
                 lazyState.allFiles = []; lazyState.renderedCount = 0;
+            },
+
+            updateResultCounter(count, isFiltered = false) {
+                const badge = Utils.elements.omniSearchCount;
+                if (!badge) return;
+                const stackName = state.grid.stack;
+                const totalCount = stackName && state.stacks[stackName] ? state.stacks[stackName].length : 0;
+                const normalizedCount = (typeof count === 'number' && !Number.isNaN(count)) ? count : null;
+                const storedCount = (typeof state.grid.lastSearchCount === 'number') ? state.grid.lastSearchCount : null;
+                const filteredLength = state.grid.filtered ? state.grid.filtered.length : 0;
+                const lazyCount = state.grid.lazyLoadState?.allFiles?.length || 0;
+                const matchCandidates = [normalizedCount, storedCount, filteredLength, lazyCount]
+                    .filter(value => typeof value === 'number' && value >= 0);
+                const matchCount = matchCandidates.length > 0 ? Math.max(...matchCandidates) : 0;
+                const showMatches = isFiltered || state.grid.searchActive;
+                const displayTotal = Math.max(totalCount, lazyCount, matchCount);
+
+                if (showMatches) {
+                    badge.textContent = `Matches: ${matchCount} / ${displayTotal}`;
+                } else {
+                    badge.textContent = `All: ${displayTotal}`;
+                }
+
+                badge.classList.toggle('is-filtered', showMatches);
+                badge.setAttribute('aria-label', showMatches
+                    ? `${matchCount} matches out of ${displayTotal}`
+                    : `Showing all ${displayTotal} images`);
             },
 
             renderBatch() {
@@ -5385,16 +5493,21 @@ this.updateImageCounters();
             
             performSearch() {
                 const query = Utils.elements.omniSearch.value.trim();
-                Utils.elements.clearSearchBtn.style.display = query ? 'block' : 'none';
-                if (!query) { this.resetSearch(); return; }
+                const hasQuery = query.length > 0;
+                state.grid.searchActive = hasQuery;
+                Utils.elements.clearSearchBtn.style.display = hasQuery ? 'block' : 'none';
+                if (!hasQuery) { this.resetSearch(); return; }
 
                 const results = this.searchImages(query);
                 state.grid.filtered = results;
+                const resultCount = results.length;
+                state.grid.lastSearchCount = resultCount;
+                Utils.elements.selectAllBtn.textContent = String(resultCount);
+                this.updateResultCounter(resultCount, true);
 
-                if (results.length === 0) {
+                if (resultCount === 0) {
                     state.grid.selected = [];
                     Utils.elements.gridEmptyState.classList.remove('hidden');
-                    Utils.elements.selectAllBtn.textContent = '0';
                 } else {
                     state.grid.selected = results.map(file => file.id);
                     Utils.elements.gridEmptyState.classList.add('hidden');
@@ -5411,6 +5524,8 @@ this.updateImageCounters();
                 Utils.elements.clearSearchBtn.style.display = 'none';
                 Utils.elements.gridEmptyState.classList.add('hidden');
                 state.grid.filtered = [];
+                state.grid.searchActive = false;
+                state.grid.lastSearchCount = null;
                 Utils.elements.gridContainer.innerHTML = '';
                 this.initializeLazyLoad(state.grid.stack);
                 Core.updateStackCounts();


### PR DESCRIPTION
## Summary
- ensure the grid Omni search badge reports match counts against the active stack total with resilient fallback logic
- reduce folder picker header padding and typography so more folders fit in the scroll viewport

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f738a48378832d83428ba0eece00ab