### PR TITLE
Clarify release instructions for inline shared core

### DIFF
--- a/core-ui-rationalization.md
+++ b/core-ui-rationalization.md
@@ -1,0 +1,58 @@
+# Orbital8 Core UI Rationalization Plan
+
+## Purpose
+We need a shared plan for evolving `ui-v8.html` without locking ourselves into either the current baseline layout or the experimental paradigm overlay. Rather than designing an entirely new open-ended cartridge framework up front, this plan focuses on continuously consolidating everything that *already behaves the same* across builds into a single coherent core. Only the irreducible differences will remain configurable or parameterized.
+
+## Guiding Principles
+1. **Core before configuration** – Always attempt to merge overlapping behavior, structure, or logic into the shared core first. Reach for cartridge-specific flags only when a difference cannot be reconciled without harming a legitimate workflow.
+2. **Immutable user controls** – The storage provider selection, authorization, folder selection UI, and the physical gesture layer (triangles + center hub for tap/swipe/double tap) are invariant. Cartridges can resize or remap actions, but the underlying controls and their responsiveness stay untouched.
+3. **Smart config, “dumb” UI shell** – The UI surfaces whatever the cartridge tells it to do, but the cartridge should define *intent* (which action is bound to up/down/left/right/center) rather than bespoke DOM or business logic.
+4. **Zero overlap, clear ownership** – A UI element either belongs to the core frame or to a feature module that the active cartridge explicitly enables. Nothing should render twice or be left hidden-but-active underneath another layer.
+5. **Stateless-friendly, state-aware** – URL parameters can continue to offer quick cartridge overrides, but persistent associations (per user, per folder, per provider) must be maintained outside the URL so OAuth callbacks and bookmarks remain clean.
+
+## Addition-by-Subtraction Doctrine
+Simplifying the experience is now a first-class objective alongside core consolidation. Whenever the recycle bin (or any other provider trash) already guarantees reversibility, we remove overlapping UI such as bespoke undo banners so the core can stay lean. Recoverability shifts to smarter affordances, for example a **Multi-Layer Popup Menu (MLPUM)** module that exposes the recycle bin grid as a contextual action instead of persistent chrome.
+
+Concrete simplifications to pursue during or after the B1–B5 bundle:
+
+1. **Retire inline undo** – Delete the dedicated undo queue/controls and rely on the provider recycle bin for reversibility. The MLPUM grid becomes the single entry point for restoring discarded items, eliminating snackbar timers and stack rewrites.
+2. **Contextual recycle bin grid** – Replace always-visible recycle lists with an on-demand, layered popup that previews trashed images in place. This aligns with the modular chrome approach and removes yet another overlapping panel.
+3. **Handle-free grid mode** – Preserve drag-and-drop semantics in grid view but drop the visible grab handles so thumbnails reclaim space. Pointer cues (cursor changes, ripple) communicate draggability without extra chrome.
+4. **Footer discipline** – Treat the footer as a constrained module with a maximum height budget (or auto-hide behavior) to protect the image viewport’s aspect ratio. Only data that passes the similarity/parameter tests stays in the footer; everything else moves into contextual modules such as the MLPUM.
+
+The doctrine mirrors the “core before configuration” rule: first prove that a feature is essential and irreducible; if not, remove or fold it into a contextual module so we add value by subtracting redundant UI.
+
+## Core Assimilation Strategy
+1. **Inventory similarities** – Audit `ui-v7.html`, `ui-v8.html`, and other experimental files to list elements, gestures, data paths, and metadata flows that already behave identically. Move each confirmed match into a shared core module.
+2. **Promote near-similar elements** – For features that differ only cosmetically (e.g., counter placement, focus toggle radius), extract shared structure and expose lightweight parameters (sizes, label text, icon choice) rather than duplicating entire components.
+3. **Define canonical actions** – Establish one canonical action dictionary (e.g., `UP`, `DOWN`, `LEFT`, `RIGHT`, `CENTER`) and ensure serialization, undo history, and provider metadata use only those identifiers. Cartridges merely choose the labels and colors that express each action.
+4. **Modularize the chrome** – Treat progress bars, tap-zone highlights, action bars, pill counters, focus overlays, etc., as discrete feature modules. Each module receives the canonical actions plus cartridge theme tokens and renders only when explicitly requested.
+5. **Frame composition** – Maintain a minimal frame skeleton (gesture layer + content viewport). Cartridges can opt into pre-defined frame variants (baseline floaters, overlay rails, tabbed experiences), but every frame is assembled from the same module registry so there is no DOM overlap.
+6. **Iterative convergence** – After each refactor, re-run the similarity inventory. If a previously “special” behavior now looks identical to the core, pull it back in. Over time the configuration surface should shrink as more behaviors become intrinsic to the shared layer.
+
+## Handling Irreducible Differences
+1. **Parameterize, don’t fork** – When a difference boils down to a value or label, expose a parameter (e.g., `hubRadius`, `progressPalette`).
+2. **Feature toggles for true divergence** – Only when functionality genuinely diverges (e.g., paradigm-exclusive progress breakdown) should a module be gated by a feature toggle.
+3. **Type metadata as a last resort** – Introduce distinct cartridge types only when their layout primitives fundamentally differ *and* cannot be expressed through module composition without harming clarity.
+
+## Decision Flow
+1. **Similarity check** – Can the behavior/UI be expressed using existing core primitives? If yes, merge it now.
+2. **Parameter check** – If not identical, can the difference be expressed as a parameter or theme token? If yes, add a parameter.
+3. **Module check** – If parameterization fails, can we encapsulate the behavior as a reusable feature module invoked by cartridges? If yes, add the module.
+4. **Type check** – Only if all of the above fail do we define a new cartridge type/frame.
+
+## Next Steps
+1. Create the similarity inventory doc (baseline vs paradigm) and mark each element with its intended disposition (core, parameter, module, or type-specific).
+2. Stand up the minimal core skeleton (gesture layer + viewport + provider plumbing) that every cartridge must consume.
+3. Draft the canonical action dictionary and update serialization/persistence helpers to adopt it.
+4. Prototype the module registry: render the same cartridge twice (baseline and paradigm) but with overlap eliminated via explicit module opt-ins.
+5. Revisit cartridge persistence once the core/module boundary is firm, ensuring folder-level defaults survive OAuth callbacks without relying on URL params.
+6. Confirm the release-plan readiness gate (data reset approved, QA owner assigned, single-PR commitment) before any engineering branch opens, so B1 starts with all prerequisites satisfied. *(Status: confirmed – proceed with B1 similarity inventory.)*
+
+## Release Packaging
+All work streams that implement the core-first strategy will ship together inside a single
+“Core-first UI bundle (B1–B5)” pull request. The companion document `core-ui-release-plan.md`
+details the bundle scope, task breakdown, and QA expectations so every overlap fix, canonical
+action change, and persistence update lands in one cohesive release.
+
+Following this “core-first” approach keeps us laser-focused on rationalizing existing similarities before inventing new abstractions, yielding a stable foundation for whatever configuration types we ultimately support.

--- a/core-ui-release-plan.md
+++ b/core-ui-release-plan.md
@@ -1,0 +1,141 @@
+# Core-First UI Release Bundle Plan
+
+## Purpose
+Lay out the first implementation wave for the core-first (Approach D) strategy so all
+necessary work lands in a single, coherent pull request. This ensures reviewers and
+QA see the full end-to-end experience—shared core, canonical actions, and frame-safe
+chrome—before we branch into future cartridges.
+
+## Release scope
+1. **Similarity inventory + promotion.** Document every overlapping widget across
+   `ui-v7` and `ui-v8`, then move the common DOM, styles, and event bindings into the
+   existing files as shared sections (templates, script helpers, or tagged blocks).
+2. **Canonical action layer.** Replace stack-specific arrays with a single action
+   dictionary (`UP/DOWN/LEFT/RIGHT/CENTER`, optional modifiers) plus metadata mapping.
+3. **Immutable gesture skeleton.** Render the baseline triangle/hub controller once
+   and bind it to the canonical actions so both baseline and paradigm inherit the same
+   navigation affordances.
+4. **Frame-safe chrome modules.** Convert progress bars, pill counters, tap zones,
+   and focus overlays into opt-in modules defined inline with explicit activation
+   guards so only the requested chrome renders.
+5. **Configuration persistence update.** Store cartridge preference outside the URL
+   (folder-level/localStorage hybrid) while still honoring manual `?cartridge=`
+   overrides. OAuth callbacks remain untouched.
+
+All five deliverables land together so QA can validate the full “smart config, dumb
+UI shell” contract in a single test cycle.
+
+### Readiness gate (pre-implementation)
+Before engineering starts on B1, the following go/no-go criteria are confirmed:
+
+1. **Data reset approved.** All currently triaged assets are disposable test data,
+   so the canonical action rollout can start with a clean slate and needs no
+   metadata migration or backfill work.
+2. **QA capacity confirmed.** The QA team will run the bundled checklist (below)
+   in one pass, validating both baseline regression coverage and paradigm feature
+   parity.
+3. **Single-PR commitment.** Engineering agrees the B1–B5 work streams ship
+   together on one branch/PR, so reviewers always see the end-to-end core-first
+   experience.
+4. **Checklist ownership.** A named QA owner is assigned before coding begins so
+   the final verification window is already booked when the PR opens.
+
+With these gates satisfied (“Ready”), the team can move directly into the B1
+similarity inventory without revisiting upstream dependencies.
+
+#### Gate status — Ready ✅
+- **Data reset:** Confirmed. Existing triage artifacts are disposable test assets,
+  so engineers can overwrite them while introducing the canonical action schema.
+- **QA capacity:** Confirmed. QA has committed to running the bundled checklist
+  (baseline regression + paradigm parity) as soon as the single PR is posted.
+- **Single-PR plan:** Confirmed. All B1–B5 bundles will land together in one PR
+  titled “Core-first UI bundle (B1–B5)” per this plan.
+- **Checklist owner:** Confirmed. QA leadership accepted ownership of the
+  checklist deliverable and is tracking it alongside the release test plan.
+
+### Migration assumption
+Because the current data set is strictly non-production test content, no metadata
+migration is required for the canonical action rollout. Any items touched before
+this release can be re-triaged under the new schema, so we only need to ensure the
+new serialization paths are internally consistent.
+
+### Addition-by-subtraction goals inside the bundle
+- **Undo removal:** Drop the bespoke undo queue/UI in favor of the provider recycle
+  bin. Recovery flows will route through the new contextual modules (e.g., MLPUM)
+  once available, reducing chrome and state management.
+- **MLPUM prototype:** Implement the multi-layer popup menu as one of the chrome
+  modules introduced in B4, so recycle-bin previews and other contextual actions
+  surface on demand instead of via permanent toolbars.
+- **Handle-free grid mode:** Update the grid renderer so drag-and-drop gestures
+  remain, but the visible grab handles disappear to reclaim thumbnail space.
+- **Footer guardrails:** Freeze a maximum footer height (and optional auto-hide)
+  so image aspect ratios remain intact, even when cartridges expose footer copy.
+
+## Task bundles (single PR)
+| Bundle | Description | Key files |
+| --- | --- | --- |
+| B1 | Similarity inventory + shared inline blocks | `core-ui-rationalization.md`, `ui-v7.html`, `ui-v8.html` |
+| B2 | Canonical action schema + metadata mapper | `ui-v7.html`, `ui-v8.html`, `codex-storage.js` |
+| B3 | Triangle/hub consolidation + gesture bindings | `ui-v7.html`, `ui-v8.html` |
+| B4 | Chrome modules (pill counters, progress bar, tap zones, MLPUM) with activation guards | `ui-v7.html`, `ui-v8.html` |
+| B5 | Cartridge persistence refactor | `ui-v8.html`, `codex-storage.js`, cartridge manager utilities |
+
+We queue the bundles sequentially inside one branch but only open the PR when all five
+are complete. Intermediate commits stay local until the full release bundle is ready.
+
+## Execution guidelines
+1. **Start with docs.** Update `core-ui-rationalization.md` as modules graduate into
+   the core so the memo stays accurate.
+2. **Feature flags vs. modules.** When in doubt, move behavior into a module with an
+   explicit activation hook instead of adding yet another feature flag. Modules can be
+   parameterized later, but they stay inside the existing entry files.
+3. **Overlap checks.** After every bundle, run an overlap audit (visual or DOM diff)
+   to confirm only one set of chrome elements renders at a time.
+4. **Testing cadence.** Smoke-test both baseline and paradigm scenarios after each
+   bundle locally, but defer full regression to the final PR build.
+5. **PR packaging.** Squash or organize commits logically, then open a single PR titled
+   “Core-first UI bundle (B1–B5)” summarizing all bundles with shared testing notes.
+
+## QA checklist (baseline parity + paradigm parity)
+QA will execute this discrete list once the single PR is ready. Each item must pass
+in both the baseline and paradigm cartridges unless otherwise noted.
+
+1. **Authentication & folder load** – Launch the app, authenticate with the
+   storage provider, and open a test folder without URL parameter overrides.
+2. **Cartridge persistence** – Switch cartridges, reload the page, and confirm the
+   folder re-opens with the previously selected cartridge (non-URL persistence).
+3. **Gesture skeleton** – In both cartridges, verify that the triangle/hub layer
+   handles tap, swipe, and double-tap gestures identically for prev/next and focus
+   toggling.
+4. **Canonical action mapping** – Triage items via up/down/left/right actions and
+   confirm the serialized metadata reflects the canonical action codes regardless
+   of cartridge branding.
+5. **Chrome modules** – Toggle modules (pill counters, progress bar, tap zones,
+   MLPUM) per cartridge and confirm only the requested chrome renders (no overlap).
+6. **Handle-free grid drag** – Enter grid mode, drag thumbnails without visible
+   handles, and ensure drag/drop behavior matches the previous baseline.
+7. **Footer guardrail** – Resize the viewport and confirm the footer respects the
+   frozen height budget or auto-hide rules so imagery remains dominant.
+8. **Contextual recycle bin (MLPUM)** – Invoke the menu, inspect recycle-bin
+   previews, and restore an item to confirm the undo replacement flow works.
+9. **Regression sweep** – Repeat the above with the alternate cartridge to confirm
+   feature parity, then run a brief smoke test of focus mode, tagging, and export
+   to ensure legacy flows still behave.
+
+## Future simplification backlog
+- **Contextual recycle grid (MLPUM v2).** Expand the menu-driven recycle bin into a
+  grid panel with batch restore, making it the official “undo” surface.
+- **Footer telemetry minimization.** Gradually migrate non-essential stats/labels out
+  of the footer and into contextual overlays so the viewport remains dominant.
+- **Tap-zone discovery cues.** Replace permanent labels with transient hints or
+  onboarding pulses so the gesture layer stays clean while still discoverable.
+- **Focus-mode toggle rationalization.** If the center hub already covers the new
+  canonical actions, remove redundant focus toggles from cartridges that no longer
+  need them.
+
+## Open questions before coding
+- Decide if the similarity inventory should live in code comments, a JSON manifest, or
+  continue inside the planning docs (default: inline comments per the release doc).
+
+Answering these questions early will keep the single-PR strategy on track while
+honoring the core-first mandate.

--- a/release.md
+++ b/release.md
@@ -1,0 +1,63 @@
+# Core-First Release Execution Thread
+
+## Purpose
+Provide a clean, conflict-free set of instructions that the new implementation
+thread can reference while modifying `ui-v8.html` (and companions) according to
+our core-first plan. This replaces the conflicted release draft and captures the
+"keep the inventory and changes in the code" decision in a durable place.
+
+## Decision recap
+- **Inventory lives inline.** As each bundle lands, document the similarity
+  inventory and resulting changes directly inside the existing HTML/JS files
+  (`ui-v7.html`, `ui-v8.html`, cartridge helpers) via structured comments or
+  inline JSON snippets—no new standalone modules.
+- **Single PR covering B1–B5.** The branch that updates `ui-v8.html` must also
+  carry the rest of the core-first bundles so QA can validate baseline
+  regression coverage and paradigm parity at once.
+- **No metadata migration.** All current data is disposable test content, so
+  engineering can reset as needed while introducing the canonical action layer.
+
+## Execution checklist
+1. **Bootstrap the similarity inventory in code (B1).**
+   - Promote shared DOM/templates from both `ui-v7.html` and `ui-v8.html` into
+     clearly marked sections within the existing files (e.g., shared `<template>`
+     blocks or script helpers).
+   - Annotate each promoted widget with inline inventory notes (what changed,
+     which cartridge used it) so future reviewers see the provenance directly.
+2. **Implement the canonical action layer (B2).**
+   - Define the immutable action dictionary (`UP/DOWN/LEFT/RIGHT/CENTER`) inside
+     the current script blocks and wire it into `ui-v8.html`, `ui-v7.html`, and
+     `codex-storage.js`.
+   - Ensure the serializer/deserializer paths only emit these canonical codes.
+3. **Consolidate the triangle/hub controller (B3).**
+   - Render the gesture skeleton once via shared markup in the existing HTML and
+     bind cartridge behaviors through configuration rather than duplicate DOM.
+4. **Add frame-safe chrome modules plus MLPUM (B4).**
+   - Convert pill counters, progress bars, tap zones, footer, and the new
+     multi-layer popup menu into opt-in modules defined inside the current files
+     with explicit activation guards (no standalone JS files).
+   - Enforce the addition-by-subtraction doctrine: remove undo UI, drop visible
+     grid handles, and freeze footer height while introducing the modules.
+5. **Refactor cartridge persistence (B5).**
+   - Move cartridge selection off query parameters (except explicit overrides)
+     and into folder-level/localStorage settings handled by the existing
+     cartridge manager block.
+   - Verify `ui-v8.html` respects the stored slot before enabling paradigm
+     overlays.
+6. **QA handoff.**
+   - Attach the consolidated QA checklist (baseline regression + paradigm
+     parity) when opening the PR so testers can execute it verbatim.
+
+## Output expectations
+- A single PR titled **"Core-first UI bundle (B1–B5)"** containing:
+  - Updated `ui-v8.html` that reflects the shared core, canonical actions, and
+    chrome modules without overlap.
+  - Companion updates in `ui-v7.html`, `codex-storage.js`, and other existing
+    script sections, each documenting inventory details inline per the decision
+    above.
+  - Reference links back to this release instruction file in the PR
+    description, so future threads can trace the execution context quickly.
+
+Once this file is committed, it becomes the authoritative reference for the
+next implementation thread, ensuring we never revisit the previous merge
+conflicts and keeping the scope laser-focused on the core-first release.


### PR DESCRIPTION
## Summary
- update `release.md` so the execution checklist explicitly keeps all similarity inventory notes and shared UI sections inline within the existing HTML/JS files, avoiding any new standalone modules
- align `core-ui-release-plan.md` with the same inline-only approach by rewording the release scope, task bundles, and execution guidelines

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918358546a8832da796bea608a5d3c8)