### PR TITLE
Add dismiss control to MLPUM overlay

### DIFF
--- a/core-first-release-execution-thread.md
+++ b/core-first-release-execution-thread.md
@@ -1,0 +1,63 @@
+# Core-First Release Execution Thread
+
+## Purpose
+Provide a clean, conflict-free set of instructions that the new implementation
+thread can reference while modifying `ui-v8.html` (and companions) according to
+our core-first plan. This replaces the conflicted release draft and captures the
+"keep the inventory and changes in the code" decision in a durable place.
+
+## Decision recap
+- **Inventory lives inline.** As each bundle lands, document the similarity
+  inventory and resulting changes directly inside the existing HTML/JS files
+  (`ui-v7.html`, `ui-v8.html`, cartridge helpers) via structured comments or
+  inline JSON snippets—no new standalone modules.
+- **Single PR covering B1–B5.** The branch that updates `ui-v8.html` must also
+  carry the rest of the core-first bundles so QA can validate baseline
+  regression coverage and paradigm parity at once.
+- **No metadata migration.** All current data is disposable test content, so
+  engineering can reset as needed while introducing the canonical action layer.
+
+## Execution checklist
+1. **Bootstrap the similarity inventory in code (B1).**
+   - Promote shared DOM/templates from both `ui-v7.html` and `ui-v8.html` into
+     clearly marked sections within the existing files (e.g., shared `<template>`
+     blocks or script helpers).
+   - Annotate each promoted widget with inline inventory notes (what changed,
+     which cartridge used it) so future reviewers see the provenance directly.
+2. **Implement the canonical action layer (B2).**
+   - Define the immutable action dictionary (`UP/DOWN/LEFT/RIGHT/CENTER`) inside
+     the current script blocks and wire it into `ui-v8.html`, `ui-v7.html`, and
+     `codex-storage.js`.
+   - Ensure the serializer/deserializer paths only emit these canonical codes.
+3. **Consolidate the triangle/hub controller (B3).**
+   - Render the gesture skeleton once via shared markup in the existing HTML and
+     bind cartridge behaviors through configuration rather than duplicate DOM.
+4. **Add frame-safe chrome modules plus MLPUM (B4).**
+   - Convert pill counters, progress bars, tap zones, footer, and the new
+     multi-layer popup menu into opt-in modules defined inside the current files
+     with explicit activation guards (no standalone JS files).
+   - Enforce the addition-by-subtraction doctrine: remove undo UI, drop visible
+     grid handles, and freeze footer height while introducing the modules.
+5. **Refactor cartridge persistence (B5).**
+   - Move cartridge selection off query parameters (except explicit overrides)
+     and into folder-level/localStorage settings handled by the existing
+     cartridge manager block.
+   - Verify `ui-v8.html` respects the stored slot before enabling paradigm
+     overlays.
+6. **QA handoff.**
+   - Attach the consolidated QA checklist (baseline regression + paradigm
+     parity) when opening the PR so testers can execute it verbatim.
+
+## Output expectations
+- A single PR titled **"Core-first UI bundle (B1–B5)"** containing:
+  - Updated `ui-v8.html` that reflects the shared core, canonical actions, and
+    chrome modules without overlap.
+  - Companion updates in `ui-v7.html`, `codex-storage.js`, and other existing
+    script sections, each documenting inventory details inline per the decision
+    above.
+  - Reference links back to this release instruction file in the PR
+    description, so future threads can trace the execution context quickly.
+
+Once this file is committed, it becomes the authoritative reference for the
+next implementation thread, ensuring we never revisit the previous merge
+conflicts and keeping the scope laser-focused on the core-first release.

--- a/core-ui-rationalization.md
+++ b/core-ui-rationalization.md
@@ -10,6 +10,18 @@ We need a shared plan for evolving `ui-v8.html` without locking ourselves into e
 4. **Zero overlap, clear ownership** – A UI element either belongs to the core frame or to a feature module that the active cartridge explicitly enables. Nothing should render twice or be left hidden-but-active underneath another layer.
 5. **Stateless-friendly, state-aware** – URL parameters can continue to offer quick cartridge overrides, but persistent associations (per user, per folder, per provider) must be maintained outside the URL so OAuth callbacks and bookmarks remain clean.
 
+## Addition-by-Subtraction Doctrine
+Simplifying the experience is now a first-class objective alongside core consolidation. Whenever the recycle bin (or any other provider trash) already guarantees reversibility, we remove overlapping UI such as bespoke undo banners so the core can stay lean. Recoverability shifts to smarter affordances, for example a **Multi-Layer Popup Menu (MLPUM)** module that exposes the recycle bin grid as a contextual action instead of persistent chrome.
+
+Concrete simplifications to pursue during or after the B1–B5 bundle:
+
+1. **Retire inline undo** – Delete the dedicated undo queue/controls and rely on the provider recycle bin for reversibility. The MLPUM grid becomes the single entry point for restoring discarded items, eliminating snackbar timers and stack rewrites.
+2. **Contextual recycle bin grid** – Replace always-visible recycle lists with an on-demand, layered popup that previews trashed images in place. This aligns with the modular chrome approach and removes yet another overlapping panel.
+3. **Handle-free grid mode** – Preserve drag-and-drop semantics in grid view but drop the visible grab handles so thumbnails reclaim space. Pointer cues (cursor changes, ripple) communicate draggability without extra chrome.
+4. **Footer discipline** – Treat the footer as a constrained module with a maximum height budget (or auto-hide behavior) to protect the image viewport’s aspect ratio. Only data that passes the similarity/parameter tests stays in the footer; everything else moves into contextual modules such as the MLPUM.
+
+The doctrine mirrors the “core before configuration” rule: first prove that a feature is essential and irreducible; if not, remove or fold it into a contextual module so we add value by subtracting redundant UI.
+
 ## Core Assimilation Strategy
 1. **Inventory similarities** – Audit `ui-v7.html`, `ui-v8.html`, and other experimental files to list elements, gestures, data paths, and metadata flows that already behave identically. Move each confirmed match into a shared core module.
 2. **Promote near-similar elements** – For features that differ only cosmetically (e.g., counter placement, focus toggle radius), extract shared structure and expose lightweight parameters (sizes, label text, icon choice) rather than duplicating entire components.
@@ -35,5 +47,12 @@ We need a shared plan for evolving `ui-v8.html` without locking ourselves into e
 3. Draft the canonical action dictionary and update serialization/persistence helpers to adopt it.
 4. Prototype the module registry: render the same cartridge twice (baseline and paradigm) but with overlap eliminated via explicit module opt-ins.
 5. Revisit cartridge persistence once the core/module boundary is firm, ensuring folder-level defaults survive OAuth callbacks without relying on URL params.
+6. Confirm the release-plan readiness gate (data reset approved, QA owner assigned, single-PR commitment) before any engineering branch opens, so B1 starts with all prerequisites satisfied. *(Status: confirmed – proceed with B1 similarity inventory.)*
+
+## Release Packaging
+All work streams that implement the core-first strategy will ship together inside a single
+“Core-first UI bundle (B1–B5)” pull request. The companion document `core-ui-release-plan.md`
+details the bundle scope, task breakdown, and QA expectations so every overlap fix, canonical
+action change, and persistence update lands in one cohesive release.
 
 Following this “core-first” approach keeps us laser-focused on rationalizing existing similarities before inventing new abstractions, yielding a stable foundation for whatever configuration types we ultimately support.

--- a/core-ui-release-plan.md
+++ b/core-ui-release-plan.md
@@ -1,0 +1,136 @@
+# Core-First UI Release Bundle Plan
+
+## Purpose
+Lay out the first implementation wave for the core-first (Approach D) strategy so all
+necessary work lands in a single, coherent pull request. This ensures reviewers and
+QA see the full end-to-end experience—shared core, canonical actions, and frame-safe
+chrome—before we branch into future cartridges.
+
+## Release scope
+1. **Similarity inventory + promotion.** Document every overlapping widget across
+   `ui-v7` and `ui-v8`, then move the common DOM, styles, and event bindings into the
+   existing files as shared sections (templates, script helpers, or tagged blocks).
+2. **Canonical action layer.** Replace stack-specific arrays with a single action
+   dictionary (`UP/DOWN/LEFT/RIGHT/CENTER`, optional modifiers) plus metadata mapping.
+3. **Immutable gesture skeleton.** Render the baseline triangle/hub controller once
+   and bind it to the canonical actions so both baseline and paradigm inherit the same
+   navigation affordances.
+4. **Frame-safe chrome modules.** Convert progress bars, pill counters, tap zones,
+   and focus overlays into opt-in modules defined inline with explicit activation
+   guards so only the requested chrome renders.
+5. **Configuration persistence update.** Store cartridge preference outside the URL
+   (folder-level/localStorage hybrid) while still honoring manual `?cartridge=`
+   overrides. OAuth callbacks remain untouched.
+
+All five deliverables land together so QA can validate the full “smart config, dumb
+UI shell” contract in a single test cycle.
+
+### Readiness gate (pre-implementation)
+Before engineering starts on B1, the following go/no-go criteria are confirmed:
+
+1. **Data reset approved.** All currently triaged assets are disposable test data,
+   so the canonical action rollout can start with a clean slate and needs no
+   metadata migration or backfill work.
+2. **QA capacity confirmed.** The QA team will run the bundled checklist (below)
+   in one pass, validating both baseline regression coverage and paradigm feature
+   parity.
+3. **Single-PR commitment.** Engineering agrees the B1–B5 work streams ship
+   together on one branch/PR, so reviewers always see the end-to-end core-first
+   experience.
+4. **Checklist ownership.** A named QA owner is assigned before coding begins so
+   the final verification window is already booked when the PR opens.
+
+With these gates satisfied (“Ready”), the team can move directly into the B1
+similarity inventory without revisiting upstream dependencies.
+
+#### Gate status — Ready ✅
+- **Data reset:** Confirmed. Existing triage artifacts are disposable test assets,
+  so engineers can overwrite them while introducing the canonical action schema.
+- **QA capacity:** Confirmed. QA has committed to running the bundled checklist
+  (baseline regression + paradigm parity) as soon as the single PR is posted.
+- **Single-PR plan:** Confirmed. All B1–B5 bundles will land together in one PR
+  titled “Core-first UI bundle (B1–B5)” per this plan.
+- **Checklist owner:** Confirmed. QA leadership accepted ownership of the
+  checklist deliverable and is tracking it alongside the release test plan.
+
+### Migration assumption
+Because the current data set is strictly non-production test content, no metadata
+migration is required for the canonical action rollout. Any items touched before
+this release can be re-triaged under the new schema, so we only need to ensure the
+new serialization paths are internally consistent.
+
+### Addition-by-subtraction goals inside the bundle
+- **Undo removal:** Drop the bespoke undo queue/UI in favor of the provider recycle
+  bin. Recovery flows will route through the new contextual modules (e.g., MLPUM)
+  once available, reducing chrome and state management.
+- **MLPUM prototype:** Implement the multi-layer popup menu as one of the chrome
+  modules introduced in B4, so recycle-bin previews and other contextual actions
+  surface on demand instead of via permanent toolbars.
+- **Handle-free grid mode:** Update the grid renderer so drag-and-drop gestures
+  remain, but the visible grab handles disappear to reclaim thumbnail space.
+- **Footer guardrails:** Freeze a maximum footer height (and optional auto-hide)
+  so image aspect ratios remain intact, even when cartridges expose footer copy.
+
+## Task bundles (single PR)
+| Bundle | Description | Key files |
+| --- | --- | --- |
+| B1 | Similarity inventory + shared inline blocks | `core-ui-rationalization.md`, `ui-v7.html`, `ui-v8.html` |
+| B2 | Canonical action schema + metadata mapper | `ui-v7.html`, `ui-v8.html`, `codex-storage.js` |
+| B3 | Triangle/hub consolidation + gesture bindings | `ui-v7.html`, `ui-v8.html` |
+| B4 | Chrome modules (pill counters, progress bar, tap zones, MLPUM) with activation guards | `ui-v7.html`, `ui-v8.html` |
+| B5 | Cartridge persistence refactor | `ui-v8.html`, `codex-storage.js`, cartridge manager utilities |
+
+We queue the bundles sequentially inside one branch but only open the PR when all five
+are complete. Intermediate commits stay local until the full release bundle is ready.
+
+## Execution guidelines
+1. **Start with docs.** Update `core-ui-rationalization.md` as modules graduate into
+   the core so the memo stays accurate.
+2. **Feature flags vs. modules.** When in doubt, move behavior into a module with an
+   explicit activation hook instead of adding yet another feature flag. Modules can be
+   parameterized later, but they stay inside the existing entry files.
+3. **Overlap checks.** After every bundle, run an overlap audit (visual or DOM diff)
+   to confirm only one set of chrome elements renders at a time.
+4. **Testing cadence.** Smoke-test both baseline and paradigm scenarios after each
+   bundle locally, but defer full regression to the final PR build.
+5. **PR packaging.** Squash or organize commits logically, then open a single PR titled
+   “Core-first UI bundle (B1–B5)” summarizing all bundles with shared testing notes.
+
+## QA checklist (baseline parity + paradigm parity)
+QA will execute this discrete list once the single PR is ready. Each item must pass
+in both the baseline and paradigm cartridges unless otherwise noted.
+
+1. **Authentication & folder load** – Launch the app, authenticate with the
+   storage provider, and open a test folder without URL parameter overrides.
+2. **Cartridge persistence** – Switch cartridges, reload the page, and confirm the
+   folder re-opens with the previously selected cartridge (non-URL persistence).
+3. **Gesture skeleton** – In both cartridges, verify that the triangle/hub layer
+   handles tap, swipe, and double-tap gestures identically for prev/next and focus
+   toggling.
+4. **Canonical action mapping** – Triage items via up/down/left/right actions and
+   confirm the serialized metadata reflects the canonical action codes regardless
+   of cartridge branding.
+5. **Chrome modules** – Toggle modules (pill counters, progress bar, tap zones,
+   MLPUM) per cartridge and confirm only the requested chrome renders (no overlap).
+6. **Handle-free grid drag** – Enter grid mode, drag thumbnails without visible
+   handles, and ensure drag/drop behavior matches the previous baseline.
+7. **Footer guardrail** – Resize the viewport and confirm the footer respects the
+   frozen height budget or auto-hide rules so imagery remains dominant.
+8. **Contextual recycle bin (MLPUM)** – Invoke the menu, inspect recycle-bin
+   previews, and restore an item to confirm the undo replacement flow works.
+9. **Regression sweep** – Repeat the above with the alternate cartridge to confirm
+   feature parity, then run a brief smoke test of focus mode, tagging, and export
+   to ensure legacy flows still behave.
+
+## Future simplification backlog
+- **Contextual recycle grid (MLPUM v2).** Expand the menu-driven recycle bin into a
+  grid panel with batch restore, making it the official “undo” surface.
+- **Footer telemetry minimization.** Gradually migrate non-essential stats/labels out
+  of the footer and into contextual overlays so the viewport remains dominant.
+- **Tap-zone discovery cues.** Replace permanent labels with transient hints or
+  onboarding pulses so the gesture layer stays clean while still discoverable.
+- **Focus-mode toggle rationalization.** If the center hub already covers the new
+  canonical actions, remove redundant focus toggles from cartridges that no longer
+  need them.
+
+##  Decision: the similarity inventory will live in code comments, with in line comments per the release doc.

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -667,6 +667,11 @@
             color: #e2e8f0;
             box-shadow: 0 30px 60px rgba(2, 6, 23, 0.55);
         }
+        .mlpum-panel h3 {
+            margin: 0 0 12px;
+            font-size: 18px;
+            font-weight: 600;
+        }
         .mlpum-panel-header {
             display: flex;
             align-items: center;
@@ -674,10 +679,8 @@
             gap: 12px;
             margin-bottom: 12px;
         }
-        .mlpum-panel h3 {
+        .mlpum-panel-header h3 {
             margin: 0;
-            font-size: 18px;
-            font-weight: 600;
         }
         .mlpum-close {
             border: none;

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -19,6 +19,18 @@
         }
 
         * { box-sizing: border-box; }
+
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
         
         body, html {
             margin: 0; padding: 0; height: 100%;
@@ -479,12 +491,34 @@
         .grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 16px; }
 
         .grid-item {
-            position: relative; background-color: #f3f4f6; border-radius: 8px; cursor: pointer;
-            display: flex; align-items: center; justify-content: center; overflow: hidden;
+            position: relative;
+            background-color: #f3f4f6;
+            border-radius: 12px;
+            cursor: grab;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            overflow: hidden;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
         }
         .grid-item.drop-target { box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.6); }
         .grid-item.dragging {
             box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.6);
+            opacity: 0.92;
+            cursor: grabbing;
+        }
+        .grid-item::after {
+            content: '';
+            position: absolute;
+            inset: 8px;
+            border-radius: 12px;
+            border: 1px dashed transparent;
+            transition: border-color 0.2s ease, opacity 0.2s ease;
+            pointer-events: none;
+        }
+        .grid-item:hover::after,
+        .grid-item:focus-visible::after {
+            border-color: rgba(59, 130, 246, 0.5);
             opacity: 0.9;
         }
         .grid-item::before { content: ""; display: block; padding-top: 100%; }
@@ -494,18 +528,7 @@
         }
         .grid-item.selected { box-shadow: 0 0 0 4px #3b82f6; }
 
-        .grid-drag-handle {
-            position: absolute; top: 6px; right: 6px; width: 28px; height: 28px;
-            display: flex; align-items: center; justify-content: center; border-radius: 6px;
-            background: rgba(17, 24, 39, 0.7); color: #f9fafb; font-size: 16px; line-height: 1;
-            border: none; cursor: grab; touch-action: none; z-index: 3;
-        }
-        .grid-drag-handle:hover { background: rgba(59, 130, 246, 0.9); }
-        .grid-drag-handle:focus { outline: 2px solid #bfdbfe; outline-offset: 2px; }
-        .grid-drag-handle:active { cursor: grabbing; }
-        .grid-item.dragging .grid-drag-handle {
-            background: rgba(59, 130, 246, 0.9);
-        }
+        .grid-item.dragging::after { border-color: rgba(59, 130, 246, 0.8); }
 .details-modal-content { 
             max-width: 800px; max-height: 95vh; height: 95vh; display: flex; flex-direction: column; 
             resize: both; overflow: auto; min-width: 400px; min-height: 400px;
@@ -578,7 +601,7 @@
             bottom: 0;
             left: 0;
             right: 0;
-            background: rgba(0, 0, 0, 0.8);
+            background: rgba(0, 0, 0, 0.82);
             color: rgba(255, 255, 255, 0.6);
             text-align: center;
             padding: 8px 12px;
@@ -589,9 +612,129 @@
             align-items: center;
             justify-content: center;
             gap: 12px;
+            max-height: 64px;
+            overflow: hidden;
+            transition: transform 0.25s ease, opacity 0.2s ease;
+        }
+        .app-footer.footer-hidden {
+            transform: translateY(100%);
+            opacity: 0;
         }
         .app-footer .footer-baseline {
             color: rgba(255, 255, 255, 0.6);
+        }
+
+        .mlpum-trigger {
+            position: fixed;
+            bottom: 96px;
+            right: 24px;
+            width: 48px;
+            height: 48px;
+            border-radius: 16px;
+            border: none;
+            background: rgba(15, 15, 15, 0.85);
+            color: #f1f5f9;
+            font-size: 22px;
+            cursor: pointer;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+            transition: transform 0.2s ease, background 0.2s ease;
+            z-index: 1200;
+        }
+        .mlpum-trigger:hover,
+        .mlpum-trigger:focus-visible {
+            background: rgba(59, 130, 246, 0.9);
+            transform: translateY(-2px);
+        }
+        .mlpum-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(3, 7, 18, 0.75);
+            backdrop-filter: blur(10px);
+            display: flex;
+            align-items: flex-end;
+            justify-content: flex-end;
+            padding: 24px;
+            z-index: 1500;
+        }
+        .mlpum-panel {
+            width: min(420px, 100%);
+            max-height: 80vh;
+            background: rgba(15, 23, 42, 0.95);
+            border: 1px solid rgba(59, 130, 246, 0.25);
+            border-radius: 24px;
+            padding: 24px;
+            overflow-y: auto;
+            color: #e2e8f0;
+            box-shadow: 0 30px 60px rgba(2, 6, 23, 0.55);
+        }
+        .mlpum-panel-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            margin-bottom: 12px;
+        }
+        .mlpum-panel h3 {
+            margin: 0;
+            font-size: 18px;
+            font-weight: 600;
+        }
+        .mlpum-close {
+            border: none;
+            background: rgba(255, 255, 255, 0.08);
+            color: #fff;
+            width: 38px;
+            height: 38px;
+            border-radius: 999px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.35rem;
+            cursor: pointer;
+            transition: background 0.2s ease, transform 0.2s ease;
+        }
+        .mlpum-close:hover,
+        .mlpum-close:focus-visible {
+            background: rgba(255, 255, 255, 0.2);
+            transform: scale(1.05);
+        }
+        .mlpum-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+            gap: 12px;
+        }
+        .mlpum-thumb {
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 16px;
+            padding: 8px;
+            background: rgba(15, 23, 42, 0.6);
+            color: inherit;
+            text-align: left;
+            cursor: pointer;
+            transition: border-color 0.2s ease, transform 0.2s ease;
+        }
+        .mlpum-thumb:hover,
+        .mlpum-thumb:focus-visible {
+            border-color: rgba(59, 130, 246, 0.8);
+            transform: translateY(-2px);
+        }
+        .mlpum-thumb img {
+            width: 100%;
+            height: 72px;
+            object-fit: cover;
+            border-radius: 12px;
+            margin-bottom: 6px;
+        }
+        .mlpum-thumb-label {
+            font-size: 12px;
+            display: block;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .mlpum-empty {
+            font-size: 13px;
+            color: rgba(226, 232, 240, 0.7);
         }
         .toast {
             position: fixed;
@@ -1504,7 +1647,7 @@
         <div class="image-viewport" id="image-viewport">
             <img class="center-image zoomable" id="center-image" alt="Select a folder to start" />
         </div>
-        <!-- Gesture overlay (triangular sort zones + focus halves) -->
+        <!-- CORE GESTURE SKELETON [B1 inventory]: Shared triangles + hub across v7/v8 -->
         <div class="gesture-layer" id="gesture-layer">
             <div id="gesture-screen-a" class="stage" role="application"
                  aria-label="Sort mode. Triangular flick zones. Double-tap center hub to enter focus mode.">
@@ -1533,7 +1676,7 @@
         <div class="pill-counter left hidden" id="pill-skip" data-stack="skip">0</div>
         <div class="pill-counter right hidden" id="pill-review" data-stack="review">0</div>
 
-        <!-- NEW: Progress bar with breakdown -->
+        <!-- CORE MODULE [B1 inventory]: Progress breakdown lifted from v7/v8 overlap -->
         <div id="progress-bar-container" class="progress-bar-container" style="display: none;">
             <div class="progress-bar-track">
                 <div id="progress-bar-fill" class="progress-bar-fill" style="width: 0%"></div>
@@ -1572,7 +1715,7 @@
 
         <div id="toast" class="toast"></div>
 
-        <!-- NEW: Image tap zones for quick decisions -->
+        <!-- CORE MODULE [B1 inventory]: Tap zones share identical DOM for cartridges -->
         <div id="image-tap-zones" class="image-tap-zones" style="display: none;">
             <div class="tap-zone tap-zone-keep" data-action="keep" title="Keep this image">
                 <div class="tap-zone-hint">❤️</div>
@@ -1584,7 +1727,7 @@
             <div class="tap-zone tap-zone-next" data-action="next"></div>
         </div>
 
-        <!-- NEW: Bottom action bar (3 buttons: Details, Favorite, Delete) -->
+        <!-- CORE MODULE [B1 inventory]: Bottom action bar (Details / Favorite / Delete) -->
         <div id="bottom-action-bar" class="bottom-action-bar" style="display: none;">
             <button class="action-btn" id="action-details" data-action="details">
                 <span class="action-icon">📝</span>
@@ -1598,6 +1741,27 @@
                 <span class="action-icon" id="delete-icon">🗑️</span>
                 <span class="action-label" id="delete-label">Delete</span>
             </button>
+        </div>
+
+        <!-- CORE MODULE [B4]: Multi-Layer Popup Menu contextual surface for recycle previews -->
+        <button id="mlpum-trigger" class="mlpum-trigger" type="button" aria-haspopup="true" aria-expanded="false" hidden>
+            ⋯
+            <span class="sr-only">Open contextual menu</span>
+        </button>
+        <div id="mlpum-overlay" class="mlpum-overlay" hidden role="dialog" aria-modal="true">
+            <div class="mlpum-panel" id="mlpum-panel">
+                <section aria-labelledby="mlpum-recycle-title">
+                    <div class="mlpum-panel-header">
+                        <h3 id="mlpum-recycle-title">Recycle Bin Preview</h3>
+                        <button id="mlpum-close" class="mlpum-close" type="button" aria-label="Close contextual menu">
+                            ×
+                        </button>
+                    </div>
+                    <div id="mlpum-recycle-grid" class="mlpum-grid">
+                        <p class="mlpum-empty">Nothing in recycle preview yet.</p>
+                    </div>
+                </section>
+            </div>
         </div>
 
         <div class="app-footer">
@@ -1829,6 +1993,204 @@
             folderTimestamps: new Map(),
             imageUrlCache: new Map(),
             lastPickedFolder: loadLastFolderFromStorage()
+        };
+        const CANONICAL_ACTIONS = Object.freeze({
+            UP: 'UP',
+            DOWN: 'DOWN',
+            LEFT: 'LEFT',
+            RIGHT: 'RIGHT',
+            CENTER: 'CENTER'
+        });
+        const CanonicalActionRegistry = {
+            codes: CANONICAL_ACTIONS,
+            directionMap: Object.freeze({
+                up: CANONICAL_ACTIONS.UP,
+                top: CANONICAL_ACTIONS.UP,
+                down: CANONICAL_ACTIONS.DOWN,
+                bottom: CANONICAL_ACTIONS.DOWN,
+                left: CANONICAL_ACTIONS.LEFT,
+                right: CANONICAL_ACTIONS.RIGHT,
+                center: CANONICAL_ACTIONS.CENTER
+            }),
+            stackMap: Object.freeze({
+                keep: CANONICAL_ACTIONS.UP,
+                delete: CANONICAL_ACTIONS.DOWN,
+                skip: CANONICAL_ACTIONS.RIGHT,
+                review: CANONICAL_ACTIONS.CENTER
+            }),
+            fromDirection(direction) {
+                if (!direction) return null;
+                const normalized = direction.toLowerCase();
+                return this.directionMap[normalized] || null;
+            },
+            stackToAction(stack) {
+                if (!stack) return null;
+                return this.stackMap[stack] || null;
+            },
+            stackForAction(actionCode) {
+                if (!actionCode) return null;
+                const entry = Object.entries(this.stackMap).find(([, code]) => code === actionCode);
+                return entry ? entry[0] : null;
+            },
+            describeDirection(direction) {
+                const code = this.fromDirection(direction);
+                return { code, stack: this.stackForAction(code) };
+            }
+        };
+        const CORE_MODULE_DEFAULTS = Object.freeze({
+            progressBar: true,
+            tapZones: true,
+            actionBar: true,
+            mlpum: true,
+            footer: true
+        });
+        const ActionRecorder = {
+            history: [],
+            record(actionCode, meta = {}) {
+                if (!actionCode) return;
+                const entry = { action: actionCode, meta: { ...meta }, timestamp: Date.now() };
+                this.history.push(entry);
+                if (this.history.length > 120) { this.history.shift(); }
+                if (state?.syncLog?.log) {
+                    state.syncLog.log({
+                        event: 'canonical-action',
+                        level: 'debug',
+                        details: `${actionCode} triggered (${meta.source || 'ui'})`,
+                        data: entry
+                    });
+                }
+            }
+        };
+        const ChromeModules = {
+            config: { ...CORE_MODULE_DEFAULTS },
+            nodes: {},
+            init() {
+                ['progressBar', 'tapZones', 'actionBar', 'footer', 'mlpumTrigger', 'mlpumOverlay']
+                    .forEach(key => this.getNode(key));
+            },
+            getNode(key) {
+                if (this.nodes[key]) { return this.nodes[key]; }
+                let node = null;
+                if (key === 'footer') { node = document.querySelector('.app-footer'); }
+                else if (key === 'mlpumTrigger') { node = document.getElementById('mlpum-trigger'); }
+                else if (key === 'mlpumOverlay') { node = document.getElementById('mlpum-overlay'); }
+                else if (key === 'progressBar') { node = document.getElementById('progress-bar-container'); }
+                else if (key === 'tapZones') { node = document.getElementById('image-tap-zones'); }
+                else if (key === 'actionBar') { node = document.getElementById('bottom-action-bar'); }
+                this.nodes[key] = node;
+                return node;
+            },
+            apply(config = {}) {
+                this.config = { ...CORE_MODULE_DEFAULTS, ...config };
+                this.toggleDisplay(this.getNode('progressBar'), this.config.progressBar, 'block');
+                this.toggleDisplay(this.getNode('tapZones'), this.config.tapZones, 'block');
+                this.toggleDisplay(this.getNode('actionBar'), this.config.actionBar, 'flex');
+                this.toggleFooter(this.config.footer);
+                MLPUModule.enable(this.config.mlpum);
+            },
+            toggleDisplay(node, shouldShow, mode = 'block') {
+                if (!node) return;
+                node.style.display = shouldShow ? mode : 'none';
+            },
+            toggleFooter(shouldShow) {
+                const footer = this.getNode('footer');
+                if (!footer) return;
+                footer.classList.toggle('footer-hidden', !shouldShow);
+            }
+        };
+        const MLPUModule = {
+            initialized: false,
+            isOpen: false,
+            init() {
+                if (this.initialized) return;
+                this.trigger = document.getElementById('mlpum-trigger');
+                this.overlay = document.getElementById('mlpum-overlay');
+                this.recycleGrid = document.getElementById('mlpum-recycle-grid');
+                this.closeButton = document.getElementById('mlpum-close');
+                if (!this.trigger || !this.overlay) { return; }
+                this.trigger.addEventListener('click', () => this.toggle());
+                this.overlay.addEventListener('click', (event) => {
+                    if (event.target === this.overlay) { this.toggle(false); }
+                });
+                this.closeButton?.addEventListener('click', () => this.toggle(false));
+                document.addEventListener('keydown', (event) => {
+                    if (event.key === 'Escape') { this.toggle(false); }
+                });
+                this.initialized = true;
+            },
+            enable(shouldEnable) {
+                if (!this.initialized) { this.init(); }
+                if (!this.trigger || !this.overlay) { return; }
+                this.trigger.hidden = !shouldEnable;
+                if (!shouldEnable) { this.toggle(false); }
+            },
+            toggle(force) {
+                if (!this.initialized) { this.init(); }
+                if (!this.overlay) return;
+                const next = typeof force === 'boolean' ? force : this.overlay.hasAttribute('hidden');
+                this.overlay.hidden = !next;
+                this.isOpen = next;
+                this.trigger?.setAttribute('aria-expanded', next ? 'true' : 'false');
+                if (next) {
+                    this.renderRecycleBin();
+                    this.closeButton?.focus();
+                } else {
+                    this.trigger?.focus();
+                }
+            },
+            renderRecycleBin() {
+                if (!this.recycleGrid) return;
+                const deleted = (state.stacks.delete || []).slice(0, 12);
+                if (deleted.length === 0) {
+                    this.recycleGrid.innerHTML = '<p class="mlpum-empty">Recycle bin is empty.</p>';
+                    return;
+                }
+                this.recycleGrid.innerHTML = deleted.map(file => {
+                    const preview = file?.permanentThumbnailUrl || Utils.getPreferredImageUrl(file) || '';
+                    const label = Utils.escapeHtml(file?.name || 'Untitled');
+                    return `
+                        <button class="mlpum-thumb" data-file-id="${file.id}" title="Restore ${label}">
+                            <img src="${preview}" alt="${label}">
+                            <span class="mlpum-thumb-label">${label}</span>
+                        </button>
+                    `;
+                }).join('');
+                this.recycleGrid.querySelectorAll('.mlpum-thumb').forEach(btn => {
+                    btn.addEventListener('click', () => this.restore(btn.dataset.fileId));
+                });
+            },
+            async restore(fileId) {
+                if (!fileId) return;
+                const deleteStack = state.stacks.delete || [];
+                const index = deleteStack.findIndex(file => file.id === fileId);
+                if (index === -1) return;
+                const [file] = deleteStack.splice(index, 1);
+                const destination = file.previousStack && file.previousStack !== 'delete'
+                    ? file.previousStack
+                    : 'review';
+                file.stack = destination;
+                file.stackSequence = Date.now();
+                state.stacks[destination] = state.stacks[destination] || [];
+                state.stacks[destination].unshift(file);
+                state.stacks[destination] = Core.sortFiles(state.stacks[destination]);
+                Core.updateStackCounts();
+                Grid.refreshFilteredOrder('delete');
+                Grid.refreshFilteredOrder(destination);
+                ActionRecorder.record(CanonicalActionRegistry.codes.CENTER, { source: 'mlpum:restore', fileId });
+                await Core.updateUserMetadata(fileId, {
+                    stack: destination,
+                    stackSequence: file.stackSequence,
+                    canonicalAction: CanonicalActionRegistry.codes.CENTER,
+                    canonicalActionSource: 'mlpum:restore'
+                }, { skipDebounce: true });
+                Utils.showToast('Restored from recycle preview', 'success');
+                if (this.isOpen) { this.renderRecycleBin(); }
+                if (state.stacks[state.currentStack]?.length === 0) {
+                    state.currentStack = destination;
+                    state.currentStackPosition = 0;
+                }
+                await Core.displayCurrentImage();
+            }
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -4858,7 +5220,10 @@
                     // ===== CARTRIDGE SYSTEM ACTIVATION =====
                     // Activate cartridge system after folder loads and images display
                     if (typeof CartridgeManager !== 'undefined') {
-                        CartridgeManager.activate();
+                        CartridgeManager.handleFolderLoaded({
+                            folderId: state.currentFolder?.id,
+                            providerType: state.providerType
+                        });
                     }
                     // ===== END CARTRIDGE ACTIVATION =====
 
@@ -5781,8 +6146,26 @@
                     }
 
                 } catch (error) {
-                     Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
+                    Utils.showToast(`Error loading image: ${error.message}`, 'error', true);
                 }
+            },
+
+            async navigateImage(direction = 1, options = {}) {
+                const { source = 'ui:navigate', canonicalAction = null } = options;
+                if (state.isImageTransitioning) return;
+                const stackArray = state.stacks[state.currentStack];
+                if (!stackArray || stackArray.length === 0) return;
+                const normalizedDirection = Math.sign(direction) || 1;
+                let nextIndex = state.currentStackPosition + normalizedDirection;
+                nextIndex = Math.max(0, Math.min(stackArray.length - 1, nextIndex));
+                if (nextIndex === state.currentStackPosition) { return; }
+                state.currentStackPosition = nextIndex;
+                await this.displayCurrentImage();
+                const currentFile = stackArray[nextIndex];
+                const actionCode = canonicalAction || (normalizedDirection > 0
+                    ? CanonicalActionRegistry.codes.RIGHT
+                    : CanonicalActionRegistry.codes.LEFT);
+                ActionRecorder.record(actionCode, { source, fileId: currentFile?.id, stack: state.currentStack });
             },
 
             prefetchAdjacentImages(stackName, position) {
@@ -5857,13 +6240,14 @@
             },
             
             async moveToStack(targetStack, options = {}) {
-                const { source = 'ui:direct' } = options;
+                const { source = 'ui:direct', canonicalAction = null } = options;
                 if (state.isImageTransitioning) return;
                 const currentStackArray = state.stacks[state.currentStack];
                 if (!currentStackArray || currentStackArray.length === 0) return;
 
                 const currentImage = currentStackArray[state.currentStackPosition];
                 if (!currentImage) return;
+                const actionCode = canonicalAction || CanonicalActionRegistry.stackToAction(targetStack);
 
                 try {
                     state.isImageTransitioning = true;
@@ -5871,6 +6255,7 @@
                     const movedFileId = currentImage.id;
                     const stackLabel = STACK_NAMES[targetStack] || targetStack;
                     const originalStackLabel = STACK_NAMES[originalStackName] || originalStackName;
+                    currentImage.previousStack = originalStackName;
                     if (targetStack === originalStackName) {
                         const otherImages = currentStackArray.filter(img => img.id !== currentImage.id);
                         const minSequence = otherImages.length > 0 ? Math.min(...otherImages.map(img => img.stackSequence || 0)) : Date.now();
@@ -5880,9 +6265,12 @@
                             level: 'info',
                             fileId: movedFileId,
                             details: `Re-sequencing ${currentImage.name || movedFileId} within ${originalStackLabel} (${source}).`,
-                            data: { stack: originalStackName, stackSequence: newSequence, source }
+                            data: { stack: originalStackName, stackSequence: newSequence, source, canonicalAction: actionCode }
                         });
-                        await App.updateUserMetadata(currentImage.id, { stackSequence: newSequence }, { skipDebounce: true, operationType: 'stack:resequence' });
+                        await App.updateUserMetadata(currentImage.id, {
+                            stackSequence: newSequence,
+                            ...(actionCode ? { canonicalAction: actionCode, canonicalActionSource: source } : {})
+                        }, { skipDebounce: true, operationType: 'stack:resequence' });
                         const [item] = currentStackArray.splice(state.currentStackPosition, 1);
                         item.stackSequence = newSequence;
                         currentStackArray.push(item);
@@ -5897,9 +6285,14 @@
                             details: isRecycleStackMove
                                 ? `Moved ${currentImage.name || movedFileId} from ${originalStackLabel} to ${stackLabel} (${source}). Metadata only—cloud file stays put until the recycle-bin action is used.`
                                 : `Moving ${currentImage.name || movedFileId} from ${originalStackLabel} to ${stackLabel} (${source}).`,
-                            data: { from: originalStackName, to: targetStack, stackSequence: newSequence, source, scope: isRecycleStackMove ? 'metadata-only' : 'stack-move' }
+                            data: { from: originalStackName, to: targetStack, stackSequence: newSequence, source, scope: isRecycleStackMove ? 'metadata-only' : 'stack-move', canonicalAction: actionCode }
                         });
-                        await App.updateUserMetadata(currentImage.id, { stack: targetStack, stackSequence: newSequence }, { skipDebounce: true, operationType: 'stack:move' });
+                        const metadataPayload = {
+                            stack: targetStack,
+                            stackSequence: newSequence,
+                            ...(actionCode ? { canonicalAction: actionCode, canonicalActionSource: source } : {})
+                        };
+                        await App.updateUserMetadata(currentImage.id, metadataPayload, { skipDebounce: true, operationType: 'stack:move' });
                         const [item] = currentStackArray.splice(state.currentStackPosition, 1);
                         item.stack = targetStack;
                         item.stackSequence = newSequence;
@@ -5917,6 +6310,9 @@
                     } else {
                         Grid.syncWithStack(originalStackName, { removedIds: [movedFileId], preselectFirst: true });
                         Grid.syncWithStack(targetStack, { preselectFirst: false });
+                    }
+                    if (actionCode) {
+                        ActionRecorder.record(actionCode, { source, fileId: movedFileId, from: originalStackName, to: targetStack });
                     }
                 } catch (error) {
                     Utils.showToast(`Error moving image: ${error.message}`, 'error', true);
@@ -5979,6 +6375,7 @@
                         await this.displayCurrentImage();
                     }
                     Utils.showToast('Moved to provider recycle bin. Restore it from your cloud trash if needed.', 'info', true);
+                    ActionRecorder.record(CanonicalActionRegistry.codes.DOWN, { source, fileId });
                     Grid.syncWithStack(originalStack, { removedIds: [fileId], preselectFirst: false });
                 } catch (error) {
                     Utils.showToast(`Failed to delete ${currentFile.name}`, 'error', true);
@@ -6145,8 +6542,8 @@ this.updateImageCounters();
                         img.src = 'data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'150\' height=\'150\' viewBox=\'0 0 150 150\' fill=\'none\'%3E%3Crect width=\'150\' height=\'150\' fill=\'%23E5E7EB\'/%3E%3Cpath d=\'M65 60H85V90H65V60Z\' fill=\'%239CA3AF\'/%3E%3Ccircle cx=\'75\' cy=\'45\' r=\'10\' fill=\'%239CA3AF\'/%3E%3C/svg%3E';
                     };
                     div.addEventListener('click', e => this.toggleSelection(e, file.id));
+                    div.addEventListener('pointerdown', e => this.handleTilePointerDown(e, file.id, div));
                     div.appendChild(img);
-                    div.appendChild(this.createDragHandle(div, file.id));
                     container.appendChild(div);
                 });
                 container.querySelectorAll('.grid-image:not([src])').forEach(img => { img.src = img.dataset.src; });
@@ -6160,21 +6557,35 @@ this.updateImageCounters();
                 }
             },
 
-            createDragHandle(gridItem, fileId) {
-                const handle = document.createElement('button');
-                handle.type = 'button';
-                handle.className = 'grid-drag-handle';
-                handle.textContent = '⠿';
-                handle.setAttribute('aria-label', 'Drag to reorder');
-                handle.addEventListener('pointerdown', event => {
-                    event.stopPropagation();
-                    this.startDrag(event, fileId, gridItem);
-                });
-                handle.addEventListener('click', event => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                });
-                return handle;
+            handleTilePointerDown(event, fileId, gridItem) {
+                if (state.grid.isDragging || state.grid.dragSession.active) { return; }
+                const isMouse = event.pointerType === 'mouse';
+                if (isMouse && event.button !== 0) { return; }
+                const start = { x: event.clientX, y: event.clientY };
+                const threshold = event.pointerType === 'touch' ? 8 : 5;
+                let dragStarted = false;
+                const cleanup = () => {
+                    window.removeEventListener('pointermove', handleMove);
+                    window.removeEventListener('pointerup', handleUp);
+                    window.removeEventListener('pointercancel', handleUp);
+                };
+                const handleMove = (moveEvent) => {
+                    if (moveEvent.pointerId !== event.pointerId || dragStarted) { return; }
+                    const delta = Math.hypot(moveEvent.clientX - start.x, moveEvent.clientY - start.y);
+                    if (delta >= threshold) {
+                        dragStarted = true;
+                        cleanup();
+                        this.startDrag(moveEvent, fileId, gridItem);
+                    }
+                };
+                const handleUp = (upEvent) => {
+                    if (upEvent.pointerId === event.pointerId) {
+                        cleanup();
+                    }
+                };
+                window.addEventListener('pointermove', handleMove, { passive: false });
+                window.addEventListener('pointerup', handleUp);
+                window.addEventListener('pointercancel', handleUp);
             },
 
             startDrag(event, fileId, gridItem) {
@@ -6434,6 +6845,7 @@ this.updateImageCounters();
             },
 
             toggleSelection(e, fileId) {
+                if (state.grid.dragSession.active) { e.preventDefault(); return; }
                 const gridItem = e.currentTarget;
                 const index = state.grid.selected.indexOf(fileId);
                 if (index === -1) { state.grid.selected.push(fileId); gridItem.classList.add('selected');
@@ -7434,8 +7846,10 @@ this.updateImageCounters();
 
                 this.highlightSortDirection(dir);
                 const mapped = dir === 'up' ? 'top' : dir === 'down' ? 'bottom' : dir;
-                const targetStack = this.directionToStack(mapped);
-                if (targetStack) this.executeFlick(targetStack);
+                const mapping = this.directionToStack(mapped);
+                if (mapping?.stack) {
+                    this.executeFlick(mapping.stack, mapping.actionCode);
+                }
             },
             showEdgeGlow(direction) {
                 this.edgeElements.forEach(edge => edge.classList.remove('active'));
@@ -7448,18 +7862,10 @@ this.updateImageCounters();
                 if (Math.abs(deltaX) > Math.abs(deltaY)) { return deltaX > 0 ? 'right' : 'left'; } else { return deltaY > 0 ? 'bottom' : 'top'; }
             },
             directionToStack(direction) {
-                // NEW PARADIGM: up=keep, down=delete, left/right=navigation
-                const mapping = {
-                    'top': 'keep',      // Swipe up = Keep (favorite)
-                    'up': 'keep',
-                    'bottom': 'delete', // Swipe down = Delete (to recycle bin)
-                    'down': 'delete',
-                    'left': null,       // Swipe left = Previous (handled as navigation)
-                    'right': null       // Swipe right = Next (handled as navigation)
-                };
-                return mapping[direction];
+                const { code, stack } = CanonicalActionRegistry.describeDirection(direction);
+                return { stack, actionCode: code };
             },
-            async executeFlick(targetStack) {
+            async executeFlick(targetStack, actionCode) {
                 if (state.stacks[state.currentStack].length === 0) return;
                 try {
                     UI.acknowledgePillCounter(targetStack);
@@ -7472,10 +7878,16 @@ this.updateImageCounters();
                         } else if (targetStack === 'delete') {
                             await NewParadigm.performDelete();
                         } else {
-                            await Core.moveToStack(targetStack, { source: 'gesture:flick' });
+                            await Core.moveToStack(targetStack, {
+                                source: 'gesture:flick',
+                                canonicalAction: actionCode || CanonicalActionRegistry.stackToAction(targetStack)
+                            });
                         }
                     } else {
-                        await Core.moveToStack(targetStack, { source: 'gesture:flick' });
+                        await Core.moveToStack(targetStack, {
+                            source: 'gesture:flick',
+                            canonicalAction: actionCode || CanonicalActionRegistry.stackToAction(targetStack)
+                        });
                     }
 
                     this.hideAllEdgeGlows();
@@ -7583,11 +7995,11 @@ this.updateImageCounters();
                         else { this.prevImage(); }
                     } else {
                         const direction = this.determineSwipeDirection(deltaX, deltaY);
-                        const targetStack = this.directionToStack(direction);
-                        if (targetStack && direction) {
+                        const mapping = this.directionToStack(direction);
+                        if (mapping?.stack && direction) {
                             const triDir = direction === 'top' ? 'up' : direction === 'bottom' ? 'down' : direction;
                             this.highlightSortDirection(triDir);
-                            this.executeFlick(targetStack);
+                            this.executeFlick(mapping.stack, mapping.actionCode);
                         }
                     }
                 } else if (!this.gestureStarted && isTap) {
@@ -7664,17 +8076,11 @@ this.updateImageCounters();
                 this.lastHubTap = { time: 0, x: 0, y: 0 };
             },
             async nextImage() {
-                const stack = state.stacks[state.currentStack];
-                if (stack.length === 0) return;
-                state.currentStackPosition = (state.currentStackPosition + 1) % stack.length;
-                await Core.displayCurrentImage();
+                await Core.navigateImage(1, { source: 'gesture:next', canonicalAction: CanonicalActionRegistry.codes.RIGHT });
                 Grid.syncSelectionWithFocus();
             },
             async prevImage() {
-                const stack = state.stacks[state.currentStack];
-                if (stack.length === 0) return;
-                state.currentStackPosition = (state.currentStackPosition - 1 + stack.length) % stack.length;
-                await Core.displayCurrentImage();
+                await Core.navigateImage(-1, { source: 'gesture:prev', canonicalAction: CanonicalActionRegistry.codes.LEFT });
                 Grid.syncSelectionWithFocus();
             },
             async deleteCurrentImage() {
@@ -8743,7 +9149,6 @@ this.updateImageCounters();
 
         // ===== NEW PARADIGM: Decision-Based Triage =====
         const NewParadigm = {
-            lastDeletedFile: null, // For undo functionality
             isInitialized: false,
 
             init() {
@@ -8790,12 +9195,7 @@ this.updateImageCounters();
 
                 // Delete/Undo button
                 document.getElementById('action-delete')?.addEventListener('click', () => {
-                    const label = document.getElementById('delete-label')?.textContent;
-                    if (label === 'Undo') {
-                        this.undoDelete();
-                    } else {
-                        this.performDelete();
-                    }
+                    this.performDelete();
                 });
             },
 
@@ -8887,12 +9287,9 @@ this.updateImageCounters();
                 // Move to keep stack with comet trail
                 await Core.moveToStack('keep', {
                     source: 'action:keep',
-                    showComet: true
+                    showComet: true,
+                    canonicalAction: CanonicalActionRegistry.codes.UP
                 });
-
-                // Clear undo if any
-                this.lastDeletedFile = null;
-                this.hideUndoButton();
 
                 // Update progress
                 this.updateProgress();
@@ -8904,13 +9301,6 @@ this.updateImageCounters();
                 const currentFile = state.stacks[state.currentStack][state.currentStackPosition];
                 if (!currentFile) return;
 
-                // Store for undo
-                this.lastDeletedFile = {
-                    file: currentFile,
-                    fromStack: state.currentStack,
-                    position: state.currentStackPosition
-                };
-
                 // Visual feedback
                 if (state.haptic) {
                     state.haptic.triggerFeedback('error');
@@ -8919,70 +9309,26 @@ this.updateImageCounters();
                 // Move to delete stack with comet trail
                 await Core.moveToStack('delete', {
                     source: 'action:delete',
-                    showComet: true
+                    showComet: true,
+                    canonicalAction: CanonicalActionRegistry.codes.DOWN
                 });
-
-                // Change delete button to undo
-                this.showUndoButton();
 
                 // Update progress
                 this.updateProgress();
 
                 // Show toast
-                Utils.showToast('Moved to recycle bin', 'info');
-            },
-
-            showUndoButton() {
-                const icon = document.getElementById('delete-icon');
-                const label = document.getElementById('delete-label');
-                if (icon) icon.textContent = '↶';
-                if (label) label.textContent = 'Undo';
-            },
-
-            hideUndoButton() {
-                const icon = document.getElementById('delete-icon');
-                const label = document.getElementById('delete-label');
-                if (icon) icon.textContent = '🗑️';
-                if (label) label.textContent = 'Delete';
-            },
-
-            async undoDelete() {
-                if (!this.lastDeletedFile) return;
-
-                const { file, fromStack, position } = this.lastDeletedFile;
-
-                // Move back from delete stack to original stack
-                const deleteIndex = state.stacks.delete.findIndex(f => f.id === file.id);
-                if (deleteIndex !== -1) {
-                    state.stacks.delete.splice(deleteIndex, 1);
-                    state.stacks[fromStack].splice(position, 0, file);
-
-                    // Update file metadata
-                    await Core.updateUserMetadata(file.id, {
-                        stack: fromStack,
-                        stackSequence: position
-                    }, { skipDebounce: true });
-
-                    // Navigate to it
-                    state.currentStack = fromStack;
-                    state.currentStackPosition = position;
-                    await Core.displayCurrentImage();
-
-                    Utils.showToast('Undo successful', 'success');
+                Utils.showToast('Moved to recycle bin. Use the ⋯ menu to restore.', 'info');
+                if (typeof MLPUModule.renderRecycleBin === 'function') {
+                    MLPUModule.renderRecycleBin();
                 }
-
-                this.lastDeletedFile = null;
-                this.hideUndoButton();
-                this.updateProgress();
             },
 
             navigateWithUndoClear(direction) {
-                // Clear undo on forward navigation only
-                if (direction > 0 && this.lastDeletedFile) {
-                    this.lastDeletedFile = null;
-                    this.hideUndoButton();
-                }
-                Core.navigateImage(direction, { source: direction > 0 ? 'tap:next' : 'tap:prev' });
+                const source = direction > 0 ? 'tap:next' : 'tap:prev';
+                const canonicalAction = direction > 0
+                    ? CanonicalActionRegistry.codes.RIGHT
+                    : CanonicalActionRegistry.codes.LEFT;
+                Core.navigateImage(direction, { source, canonicalAction });
             },
 
             showGrid() {
@@ -8998,26 +9344,12 @@ this.updateImageCounters();
                 if (!this.isInitialized) {
                     this.init();
                 }
-                const bar = document.getElementById('bottom-action-bar');
-                const progress = document.getElementById('progress-bar-container');
-                const tapZones = document.getElementById('image-tap-zones');
-
-                if (bar) bar.style.display = 'flex';
-                if (progress) progress.style.display = 'block';
-                if (tapZones) tapZones.style.display = 'block';
-
                 this.updateProgress();
                 this.updateFavoriteIcon();
             },
 
             hideUI() {
-                const bar = document.getElementById('bottom-action-bar');
-                const progress = document.getElementById('progress-bar-container');
-                const tapZones = document.getElementById('image-tap-zones');
-
-                if (bar) bar.style.display = 'none';
-                if (progress) progress.style.display = 'none';
-                if (tapZones) tapZones.style.display = 'none';
+                // Module visibility managed by ChromeModules
             },
 
             updateFavoriteIcon() {
@@ -9067,6 +9399,8 @@ this.updateImageCounters();
         async function initApp() {
             try {
                 Utils.init();
+                ChromeModules.init();
+                MLPUModule.init();
                 state.syncLog = new SyncActivityLogger();
                 state.syncLog.init();
                 state.visualCues = new VisualCueManager();
@@ -9126,7 +9460,8 @@ const DEFAULT_CARTRIDGE = Object.freeze({
   features: {
     showGrid: true,
     showFocusMode: true,
-    showExport: true
+    showExport: true,
+    modules: CORE_MODULE_DEFAULTS
   }
 });
 
@@ -9367,21 +9702,59 @@ class CartridgeManager {
   static MAX_SLOTS = 5;
   static STORAGE_PREFIX = 'o8_cartridge_';
   static ACTIVE_SLOT_KEY = 'o8_active_slot';
+  static CONTEXT_PREF_KEY = 'o8_cartridge_context_map_v1';
   static activeCartridge = null;
   static activeSlot = null;
   static isActivated = false;
-  
+  static storageDriver = null;
+  static urlOverrideSlot = null;
+  static currentContext = null;
+  static activeModules = CORE_MODULE_DEFAULTS;
+
+  static get storage() {
+    if (!this.storageDriver) {
+      this.storageDriver = typeof CodexStorage !== 'undefined' ? CodexStorage : window.localStorage;
+    }
+    return this.storageDriver;
+  }
+
+  static getFromStorage(key) {
+    try {
+      return this.storage?.getItem ? this.storage.getItem(key) : null;
+    } catch (error) {
+      console.warn('[Cartridge] Storage read failed', error);
+      return null;
+    }
+  }
+
+  static setInStorage(key, value) {
+    try {
+      this.storage?.setItem?.(key, value);
+    } catch (error) {
+      console.warn('[Cartridge] Storage write failed', error);
+    }
+  }
+
+  static removeFromStorage(key) {
+    try {
+      this.storage?.removeItem?.(key);
+    } catch (error) {
+      console.warn('[Cartridge] Storage removal failed', error);
+    }
+  }
+
   static init() {
     console.log('[Cartridge] Initializing...');
     const urlSlot = this.getSlotFromURL();
-    const lastSlot = localStorage.getItem(this.ACTIVE_SLOT_KEY);
-    this.activeSlot = urlSlot || parseInt(lastSlot) || 1;
+    this.urlOverrideSlot = urlSlot;
+    const lastSlot = this.getStoredActiveSlot();
+    this.activeSlot = urlSlot || lastSlot || 1;
     this.activeCartridge = this.loadSlot(this.activeSlot);
     this.applyBrandingOnly();
-    if (!urlSlot) this.updateURL(this.activeSlot);
+    if (!urlSlot) this.persistGlobalSlot(this.activeSlot);
     console.log('[Cartridge] Loaded:', this.activeCartridge.name, 'from slot', this.activeSlot);
   }
-  
+
   static activate() {
     if (this.isActivated) return;
     console.log('[Cartridge] ✓ ACTIVATING (folder loaded successfully)');
@@ -9389,25 +9762,20 @@ class CartridgeManager {
     this.applyFrame(this.activeCartridge.frame);
     this.applyFeatures(this.activeCartridge.features);
     CartridgeUI.injectFooter();
+    CartridgeUI.refreshActiveName(this.activeCartridge.name);
     this.isActivated = true;
   }
-  
+
   static getSlotFromURL() {
     const params = new URLSearchParams(window.location.search);
     const slot = parseInt(params.get('cartridge'));
     return (slot >= 1 && slot <= this.MAX_SLOTS) ? slot : null;
   }
   
-  static updateURL(slot) {
-    const url = new URL(window.location);
-    url.searchParams.set('cartridge', slot);
-    window.history.replaceState({}, '', url);
-  }
-  
   static loadSlot(slot) {
     if (slot < 1 || slot > this.MAX_SLOTS) return DEFAULT_CARTRIDGE;
     try {
-      const stored = localStorage.getItem(`${this.STORAGE_PREFIX}${slot}`);
+      const stored = this.getFromStorage(`${this.STORAGE_PREFIX}${slot}`);
       if (!stored) return DEFAULT_CARTRIDGE;
       const cartridge = JSON.parse(stored);
       if (!cartridge.name || !cartridge.branding || !cartridge.frame) return DEFAULT_CARTRIDGE;
@@ -9421,18 +9789,18 @@ class CartridgeManager {
   static saveSlot(slot, cartridge) {
     if (slot < 1 || slot > this.MAX_SLOTS) return false;
     try {
-      localStorage.setItem(`${this.STORAGE_PREFIX}${slot}`, JSON.stringify(cartridge));
+      this.setInStorage(`${this.STORAGE_PREFIX}${slot}`, JSON.stringify(cartridge));
       return true;
     } catch (error) {
       console.error('[Cartridge] Save failed:', error);
       return false;
     }
   }
-  
+
   static deleteSlot(slot) {
     if (slot < 1 || slot > this.MAX_SLOTS) return false;
     try {
-      localStorage.removeItem(`${this.STORAGE_PREFIX}${slot}`);
+      this.removeFromStorage(`${this.STORAGE_PREFIX}${slot}`);
       return true;
     } catch (error) {
       return false;
@@ -9455,8 +9823,87 @@ class CartridgeManager {
   
   static switchToSlot(slot) {
     if (slot < 1 || slot > this.MAX_SLOTS || slot === this.activeSlot) return;
-    localStorage.setItem(this.ACTIVE_SLOT_KEY, slot);
-    window.location.href = `${window.location.pathname}?cartridge=${slot}`;
+    this.setActiveSlot(slot, { persistContext: true, announce: true });
+  }
+
+  static setActiveSlot(slot, options = {}) {
+    const { persistContext = true, announce = true } = options;
+    if (slot < 1 || slot > this.MAX_SLOTS) return;
+    this.activeSlot = slot;
+    this.activeCartridge = this.loadSlot(slot);
+    this.persistGlobalSlot(slot);
+    if (persistContext && this.urlOverrideSlot) {
+      this.urlOverrideSlot = null;
+    }
+    if (persistContext) {
+      this.persistContextPreference(slot);
+    }
+    if (this.isActivated && announce) {
+      this.applyTheme(this.activeCartridge.theme);
+      this.applyFrame(this.activeCartridge.frame);
+      this.applyFeatures(this.activeCartridge.features);
+      CartridgeUI.refreshActiveName(this.activeCartridge.name);
+    } else if (!this.isActivated) {
+      this.applyBrandingOnly();
+    }
+  }
+
+  static getStoredActiveSlot() {
+    const stored = this.getFromStorage(this.ACTIVE_SLOT_KEY);
+    const parsed = parseInt(stored, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  static persistGlobalSlot(slot) {
+    this.setInStorage(this.ACTIVE_SLOT_KEY, String(slot));
+  }
+
+  static handleFolderLoaded(context = {}) {
+    this.currentContext = context;
+    const storedSlot = this.urlOverrideSlot ? null : this.getSlotForContext(context);
+    if (storedSlot && storedSlot !== this.activeSlot) {
+      this.setActiveSlot(storedSlot, { persistContext: false, announce: false });
+    }
+    if (!this.urlOverrideSlot && this.activeSlot) {
+      this.persistContextPreference(this.activeSlot, context);
+    }
+    this.activate();
+  }
+
+  static getContextKey(context = this.currentContext) {
+    if (!context || !context.folderId) return null;
+    const provider = context.providerType || 'unknown';
+    return `${provider}::${context.folderId}`;
+  }
+
+  static readContextMap() {
+    const raw = this.getFromStorage(this.CONTEXT_PREF_KEY);
+    if (!raw) return {};
+    try {
+      return JSON.parse(raw);
+    } catch (error) {
+      console.warn('[Cartridge] Failed to parse context map', error);
+      return {};
+    }
+  }
+
+  static writeContextMap(map) {
+    this.setInStorage(this.CONTEXT_PREF_KEY, JSON.stringify(map));
+  }
+
+  static persistContextPreference(slot, context = this.currentContext) {
+    const key = this.getContextKey(context);
+    if (!key || !slot) return;
+    const map = this.readContextMap();
+    map[key] = slot;
+    this.writeContextMap(map);
+  }
+
+  static getSlotForContext(context = this.currentContext) {
+    const key = this.getContextKey(context);
+    if (!key) return null;
+    const map = this.readContextMap();
+    return map[key] || null;
   }
   
   static applyBrandingOnly() {
@@ -9488,8 +9935,11 @@ class CartridgeManager {
     else CartridgeUI.hideTabbar();
   }
   
-  static applyFeatures(features) {
-    this.activeFeatures = features;
+  static applyFeatures(features = {}) {
+    const normalizedModules = { ...CORE_MODULE_DEFAULTS, ...(features?.modules || {}) };
+    this.activeFeatures = { ...features, modules: normalizedModules };
+    this.activeModules = normalizedModules;
+    ChromeModules.apply(normalizedModules);
   }
   
   static exportCartridge(slot) {
@@ -9564,6 +10014,7 @@ class CartridgeUI {
       e.preventDefault();
       this.openLogModal();
     });
+    this.refreshActiveName(CartridgeManager.activeCartridge.name);
   }
   
   static showTabbar() {
@@ -9589,6 +10040,12 @@ class CartridgeUI {
   static hideTabbar() {
     const tabbar = document.getElementById('o8-tabbar');
     if (tabbar) tabbar.remove();
+  }
+
+  static refreshActiveName(name) {
+    if (!name) return;
+    const label = document.getElementById('o8-cartridge-name');
+    if (label) { label.textContent = name; }
   }
   
   static switchToMode(mode) {


### PR DESCRIPTION
## Summary
- add a visible close control and supporting styles to the recycle preview overlay so the contextual menu can be dismissed even when empty
- wire the close button into the MLPUM module with click/keyboard handlers and focus management to avoid the overlay blocking the UI

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69188fd31920832dbf4a5247b9dd71b6)