### PR TITLE
Use permanent Google Drive links in image flows

### DIFF
--- a/ui-v3.html
+++ b/ui-v3.html
@@ -1696,14 +1696,13 @@
             },
             getPreferredImageUrl(file) {
                 if (state.providerType === 'googledrive') {
-                    const effectiveId = file?.targetFileId || file?.id;
-                    const resourceKey = file?.resourceKey || file?.shortcutDetails?.targetResourceKey || null;
                     return file?.permanentImageUrl
                         || file?.permanentThumbnailUrl
-                        || DriveLinkHelper.normalizeToAssetUrl(file?.thumbnailLink, effectiveId, resourceKey)
-                        || DriveLinkHelper.buildThumbnailUrl(effectiveId, 1000, resourceKey)
+                        || file?.thumbnailLink
                         || file?.downloadUrl
-                        || DriveLinkHelper.buildUcDownloadUrl(effectiveId, resourceKey);
+                        || file?.viewUrl
+                        || file?.permanentViewUrl
+                        || '';
                 } else { // OneDrive
                     if (file.thumbnails && file.thumbnails.large) {
                         return file.thumbnails.large.url;
@@ -1714,14 +1713,14 @@
 
             getFallbackImageUrl(file) {
                 if (state.providerType === 'googledrive') {
-                    const effectiveId = file?.targetFileId || file?.id;
-                    const resourceKey = file?.resourceKey || file?.shortcutDetails?.targetResourceKey || null;
                     return file?.permanentThumbnailUrlSmall
                         || file?.permanentThumbnailUrl
-                        || DriveLinkHelper.normalizeToAssetUrl(file?.thumbnailLink || file?.thumbnail?.url, effectiveId, resourceKey)
-                        || DriveLinkHelper.buildThumbnailUrl(effectiveId, 800, resourceKey)
+                        || file?.thumbnailLink
+                        || file?.thumbnail?.url
                         || file?.downloadUrl
-                        || DriveLinkHelper.buildUcDownloadUrl(effectiveId, resourceKey);
+                        || file?.viewUrl
+                        || file?.permanentViewUrl
+                        || '';
                 } else { // OneDrive
                     return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`;
                 }
@@ -3719,10 +3718,10 @@
                 const effectiveId = options.useShortcutId ? file.id : fallbackId;
                 const resourceKey = target?.resourceKey || file?.resourceKey || target?.shortcutDetails?.targetResourceKey || file?.shortcutDetails?.targetResourceKey || null;
                 const viewUrl = target?.webViewLink || DriveLinkHelper.buildShareUrl(fallbackId, resourceKey) || '';
-                const apiDownloadUrl = target?.webContentLink || (fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId, resourceKey) : null);
-                const downloadUrl = (fallbackId ? DriveLinkHelper.buildUcDownloadUrl(fallbackId, resourceKey) : null) || apiDownloadUrl;
-                const permanentThumbnailUrl = fallbackId ? DriveLinkHelper.buildThumbnailUrl(fallbackId, 1000, resourceKey) : null;
-                const permanentThumbnailUrlSmall = fallbackId ? DriveLinkHelper.buildThumbnailUrl(fallbackId, 800, resourceKey) : null;
+                const apiDownloadUrl = fallbackId ? DriveLinkHelper.buildApiDownloadUrl(fallbackId, resourceKey) : null;
+                const downloadUrl = target?.webContentLink || apiDownloadUrl;
+                const permanentThumbnailUrl = target?.thumbnailLink || file?.thumbnailLink || null;
+                const permanentThumbnailUrlSmall = target?.thumbnailLink || file?.thumbnailLink || null;
                 const sizeValue = target?.size != null ? Number(target.size) : null;
 
                 const normalized = {
@@ -3733,7 +3732,7 @@
                     size: Number.isFinite(sizeValue) ? sizeValue : 0,
                     createdTime: target?.createdTime || file?.createdTime,
                     modifiedTime: target?.modifiedTime || file?.modifiedTime,
-                    thumbnailLink: DriveLinkHelper.normalizeToAssetUrl(target?.thumbnailLink || file?.thumbnailLink, fallbackId, resourceKey) || target?.thumbnailLink || file?.thumbnailLink,
+                    thumbnailLink: target?.thumbnailLink || file?.thumbnailLink || null,
                     downloadUrl,
                     permanentImageUrl: downloadUrl,
                     viewUrl,


### PR DESCRIPTION
### Motivation
- Avoid constructing temporary `drive.google.com/uc`/thumbnail URLs and consistently prefer permanent metadata-provided links for images used in normal browsing, grid view, and favorites workflows.
- Ensure thumbnails, direct image URLs, and view links come from stable Drive metadata fields to improve link durability and simplify caching logic.

### Description
- Updated `getPreferredImageUrl` to prefer `file.permanentImageUrl`, `file.permanentThumbnailUrl`, `file.thumbnailLink`, `file.downloadUrl`, `file.viewUrl`, and `file.permanentViewUrl` for Google Drive files instead of building `uc`/thumbnail URLs.
- Updated `getFallbackImageUrl` to prefer `file.permanentThumbnailUrlSmall`, `file.permanentThumbnailUrl`, `file.thumbnailLink`, and `file.thumbnail?.url` before falling back to other download/view URLs for Google Drive files.
- Modified `normalizeDriveFileMetadata` to use `target.webContentLink` and existing `thumbnailLink` values (when present) for `downloadUrl`, `permanentThumbnailUrl`, and `permanentThumbnailUrlSmall` instead of constructing `api`/`uc`/thumbnail URLs programmatically.
- Replaced `DriveLinkHelper.normalizeToAssetUrl` and explicit `DriveLinkHelper.build*` calls in metadata normalization and image selection paths with direct usage of stored metadata fields.

### Testing
- Ran repository inspections using `rg`/`sed`/`nl` to locate and verify updated code paths and confirm the replacements applied; these checks completed successfully.
- Verified the produced diff with `git diff` and committed the change with `git commit`, and both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0a012cb30832d8ce60ff9f799e758)