### PR TITLE
Align ui-v3 Google Drive links with ui-v1

### DIFF
--- a/ui-v3.html
+++ b/ui-v3.html
@@ -1179,7 +1179,6 @@
         // ===== ORBITAL8 Goji Version - App Root =====
         
         const STACKS = ['in', 'out', 'priority', 'trash'];
-        const SHARE_URL_TEMPLATE = "https://drive.google.com/file/d/${fileId}/view?usp=sharing";
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const LAST_FOLDER_STORAGE_KEY = 'orbital8_last_folder';
         const loadLastFolderFromStorage = () => {
@@ -1246,55 +1245,60 @@
                 }
                 return null;
             },
-            buildShareUrl(fileId, resourceKey = null) {
-                if (!fileId) return null;
-                const baseUrl = SHARE_URL_TEMPLATE.replace('${fileId}', fileId);
-                if (!resourceKey) return baseUrl;
+            buildDriveUrl(baseUrl, searchParams = {}) {
                 try {
                     const url = new URL(baseUrl);
-                    url.searchParams.set('resourcekey', resourceKey);
+                    Object.entries(searchParams).forEach(([key, value]) => {
+                        if (value != null && value !== '') {
+                            url.searchParams.set(key, value);
+                        }
+                    });
                     return url.toString();
                 } catch (error) {
-                    return `${baseUrl}&resourcekey=${encodeURIComponent(resourceKey)}`;
+                    const query = new URLSearchParams();
+                    Object.entries(searchParams).forEach(([key, value]) => {
+                        if (value != null && value !== '') {
+                            query.set(key, value);
+                        }
+                    });
+                    const suffix = query.toString();
+                    if (!suffix) return baseUrl;
+                    return `${baseUrl}${baseUrl.includes('?') ? '&' : '?'}${suffix}`;
                 }
+            },
+            buildShareUrl(fileId, resourceKey = null) {
+                if (!fileId) return null;
+                return this.buildDriveUrl(`https://drive.google.com/file/d/${fileId}/view`, {
+                    usp: 'sharing',
+                    resourcekey: resourceKey
+                });
             },
             buildUcDownloadUrl(fileId, resourceKey = null) {
                 if (!fileId) return null;
-                try {
-                    const url = new URL(`https://drive.google.com/uc?id=${fileId}&export=view`);
-                    if (resourceKey) url.searchParams.set('resourcekey', resourceKey);
-                    return url.toString();
-                } catch (error) {
-                    const resourcePart = resourceKey ? `&resourcekey=${encodeURIComponent(resourceKey)}` : '';
-                    return `https://drive.google.com/uc?id=${fileId}&export=view${resourcePart}`;
-                }
+                return this.buildDriveUrl('https://drive.google.com/uc', {
+                    id: fileId,
+                    export: 'view',
+                    resourcekey: resourceKey
+                });
             },
             buildApiDownloadUrl(fileId, resourceKey = null) {
                 if (!fileId) return null;
-                try {
-                    const url = new URL(`https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`);
-                    if (resourceKey) url.searchParams.set('resourceKey', resourceKey);
-                    return url.toString();
-                } catch (error) {
-                    const resourcePart = resourceKey ? `&resourceKey=${encodeURIComponent(resourceKey)}` : '';
-                    return `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media${resourcePart}`;
-                }
+                return this.buildDriveUrl(`https://www.googleapis.com/drive/v3/files/${fileId}`, {
+                    alt: 'media',
+                    resourceKey
+                });
             },
             buildThumbnailUrl(fileId, width = 1000, resourceKey = null) {
                 if (!fileId) return null;
-                try {
-                    const url = new URL(`https://drive.google.com/thumbnail?id=${fileId}`);
-                    url.searchParams.set('sz', `w${Math.max(64, Number(width) || 1000)}`);
-                    if (resourceKey) url.searchParams.set('resourcekey', resourceKey);
-                    return url.toString();
-                } catch (error) {
-                    const resourcePart = resourceKey ? `&resourcekey=${encodeURIComponent(resourceKey)}` : '';
-                    return `https://drive.google.com/thumbnail?id=${fileId}&sz=w${Math.max(64, Number(width) || 1000)}${resourcePart}`;
-                }
+                return this.buildDriveUrl('https://drive.google.com/thumbnail', {
+                    id: fileId,
+                    sz: `w${Math.max(64, Number(width) || 1000)}`,
+                    resourcekey: resourceKey
+                });
             },
             normalizeToAssetUrl(rawUrl, fallbackId = null, resourceKey = null) {
                 if (!rawUrl || typeof rawUrl !== 'string') return null;
-                const directHosts = new RegExp('(?:^|\.)googleusercontent\.com$');
+                const directHosts = new RegExp('(?:^|\\.)googleusercontent\\.com$');
                 const fileId = fallbackId || this.extractFileId(rawUrl);
                 try {
                     const parsed = new URL(rawUrl);
@@ -1333,6 +1337,46 @@
                     return this.buildUcDownloadUrl(fileId, resourceKey) || this.buildApiDownloadUrl(fileId, resourceKey);
                 }
                 return null;
+            },
+            resolveFileUrls(file, options = {}) {
+                const targetFile = options.target || file;
+                const fileId = options.fileId || targetFile?.targetFileId || targetFile?.id || file?.targetFileId || file?.id || null;
+                const resourceKey = options.resourceKey || targetFile?.resourceKey || targetFile?.shortcutDetails?.targetResourceKey || file?.resourceKey || file?.shortcutDetails?.targetResourceKey || null;
+                const normalizedWebViewUrl = this.normalizeToAssetUrl(targetFile?.webViewLink || file?.webViewLink, fileId, resourceKey);
+                const normalizedWebContentUrl = this.normalizeToAssetUrl(targetFile?.webContentLink || file?.webContentLink, fileId, resourceKey);
+                const viewUrl = this.buildShareUrl(fileId, resourceKey) || normalizedWebViewUrl || targetFile?.webViewLink || file?.webViewLink || '';
+                const directUrl = normalizedWebContentUrl || this.buildUcDownloadUrl(fileId, resourceKey) || this.buildApiDownloadUrl(fileId, resourceKey) || '';
+                return {
+                    fileId,
+                    resourceKey,
+                    viewUrl,
+                    directUrl,
+                    exportUrl: directUrl,
+                    thumbnailUrl: fileId ? this.buildThumbnailUrl(fileId, 1000, resourceKey) : null,
+                    thumbnailUrlSmall: fileId ? this.buildThumbnailUrl(fileId, 800, resourceKey) : null
+                };
+            },
+            resolveAssetUrls(file, options = {}) {
+                const resolved = this.resolveFileUrls(file, options);
+                const fileId = resolved.fileId;
+                const resourceKey = resolved.resourceKey;
+                return {
+                    ...resolved,
+                    imageUrl: file?.permanentImageUrl
+                        || file?.downloadUrl
+                        || resolved.directUrl
+                        || (fileId ? this.buildApiDownloadUrl(fileId, resourceKey) : ''),
+                    thumbnailUrl: file?.permanentThumbnailUrl
+                        || this.normalizeToAssetUrl(file?.thumbnailLink, fileId, resourceKey)
+                        || resolved.thumbnailUrl
+                        || resolved.directUrl,
+                    thumbnailUrlSmall: file?.permanentThumbnailUrlSmall
+                        || file?.permanentThumbnailUrl
+                        || this.normalizeToAssetUrl(file?.thumbnailLink || file?.thumbnail?.url, fileId, resourceKey)
+                        || resolved.thumbnailUrlSmall
+                        || resolved.thumbnailUrl
+                        || resolved.directUrl
+                };
             }
         };
         const Utils = {
@@ -6428,7 +6472,7 @@ this.updateImageCounters();
             populateInfoTab(file) {
                 const filename = file.name || 'Unknown';
                 Utils.elements.detailFilename.textContent = filename;
-                if (state.providerType === 'googledrive') { Utils.elements.detailFilenameLink.href = `https://drive.google.com/file/d/${file.id}/view`;
+                if (state.providerType === 'googledrive') { Utils.elements.detailFilenameLink.href = DriveLinkHelper.resolveAssetUrls(file).viewUrl || '#';
                 } else { Utils.elements.detailFilenameLink.href = file.downloadUrl || '#'; }
                 Utils.elements.detailFilenameLink.style.display = 'inline';
                 const date = file.modifiedTime ? new Date(file.modifiedTime).toLocaleString() : file.createdTime ? new Date(file.createdTime).toLocaleString() : 'Unknown';


### PR DESCRIPTION
### Motivation
- Ensure `ui-v3.html` produces the exact same Google Drive links and link-resolution behavior as `ui-v1.html` so all parts of the app use identical, word-for-word Drive URLs. 
- Centralize Drive URL construction and asset resolution logic in `DriveLinkHelper` to avoid hard-coded divergences across UI versions.

### Description
- Reworked `DriveLinkHelper` in `ui-v3.html` to match `ui-v1` style URL construction by adding `buildDriveUrl(...)` and converting share/uc/api/thumbnail builders to use the same templates and query-parameter handling. 
- Added `resolveFileUrls(...)` and `resolveAssetUrls(...)` to `DriveLinkHelper` so view/direct/export/thumbnail URLs are resolved the same way as `ui-v1`. 
- Normalized the `googleusercontent` host regex and replaced the hard-coded details link with `DriveLinkHelper.resolveAssetUrls(file).viewUrl` so the details modal uses the same view link generation as `ui-v1`.

### Testing
- Ran `rg`/`ripgrep` searches to find all `drive.google.com` usages and confirm literal URL patterns in `ui-v1.html` and `ui-v3.html` were compared successfully. 
- Executed a Python regex script (`python - <<'PY' ...`) that enumerated unique `https://drive.google.com/...` patterns in both files and verified they match the expected set: `https://drive.google.com/file/d/${fileId}/view`, `https://drive.google.com/thumbnail`, and `https://drive.google.com/uc`.
- Confirmed the modified file (`ui-v3.html`) is the only source file changed by the update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0d376068c832d89a66a671c6b1c30)