### PR TITLE
Preserve stored PAT when URL token param is blank in view.html

### DIFF
--- a/view.html
+++ b/view.html
@@ -1344,8 +1344,11 @@
       state.branch = params.get('branch');
     }
     if (params.has('token')) {
-      tokenInput.value = params.get('token');
-      saveTokenBtn.click();
+      const tokenFromQuery = (params.get('token') || '').trim();
+      if (tokenFromQuery) {
+        tokenInput.value = tokenFromQuery;
+        persistToken(tokenFromQuery);
+      }
     }
 
     if (state.owner && state.repo) {


### PR DESCRIPTION
### Motivation
- Prevent an empty `token` URL query parameter from clearing a previously persisted personal access token (PAT) in the UI.
- Ensure a PAT, once persisted, remains available for API calls until it is explicitly replaced or expires.

### Description
- Change token hydration logic in `view.html` to trim and validate the `token` query parameter before applying it.
- Replace the previous simulated save-button click with a direct call to `persistToken(tokenFromQuery)` when the trimmed token is non-empty.
- This avoids overwriting `state.token` and the saved input value when `?token=` is present but empty.

### Testing
- Verified the change by running `git diff -- view.html` to confirm the token hydration path was updated (success).
- Inspected the updated lines with `nl -ba view.html | sed -n '1338,1362p'` to validate the conditional `tokenFromQuery` check and `persistToken(...)` call (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6227c5fd8832da106e86933ff8c6c)