### PR TITLE
Persist folder and image view context on tab visibility/focus changes

### DIFF
--- a/ui-open.html
+++ b/ui-open.html
@@ -1227,6 +1227,7 @@
         const SHARE_URL_TEMPLATE = "https://drive.google.com/file/d/${fileId}/view?usp=sharing";
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const LAST_FOLDER_STORAGE_KEY = 'orbital8_last_folder';
+        const VIEW_CONTEXT_STORAGE_KEY = 'orbital8_view_context';
         const loadLastFolderFromStorage = () => {
             if (typeof localStorage === 'undefined') {
                 return null;
@@ -1250,6 +1251,19 @@
             selectedIds: [],
             dragElements: []
         });
+        const loadViewContextFromStorage = () => {
+            try {
+                const raw = localStorage.getItem(VIEW_CONTEXT_STORAGE_KEY);
+                if (!raw) return null;
+                const parsed = JSON.parse(raw);
+                if (parsed && parsed.folderId && parsed.providerType) {
+                    return parsed;
+                }
+            } catch (error) {
+                console.warn('Failed to load view context from storage:', error);
+            }
+            return null;
+        };
         const OMNI_SEARCH_RESULT_LIMIT = 8;
         const IMAGE_CACHE_LIMIT = 40;
         const state = {
@@ -1278,7 +1292,8 @@
             folderTimestamps: new Map(),
             imageUrlCache: new Map(),
             imageFetchPromises: new Map(),
-            lastPickedFolder: loadLastFolderFromStorage()
+            lastPickedFolder: loadLastFolderFromStorage(),
+            lastViewContext: loadViewContextFromStorage()
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -5082,6 +5097,8 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
+                this.persistViewContext();
+                this.restoreViewContext({ force: true });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -5148,6 +5165,92 @@
                 }
 
                 Folders.updateLastFolderBanner();
+            },
+            persistViewContext() {
+                if (!state.currentFolder?.id || !state.providerType) {
+                    return;
+                }
+                const currentStackArray = state.stacks[state.currentStack] || [];
+                const currentFile = currentStackArray[state.currentStackPosition] || null;
+                const payload = {
+                    providerType: state.providerType,
+                    folderId: state.currentFolder.id,
+                    folderName: state.currentFolder.name || '',
+                    stack: state.currentStack || 'in',
+                    position: Number.isFinite(state.currentStackPosition) ? state.currentStackPosition : 0,
+                    fileId: currentFile?.id || null,
+                    isFocusMode: Boolean(state.isFocusMode),
+                    savedAt: new Date().toISOString()
+                };
+                state.lastViewContext = payload;
+                try {
+                    localStorage.setItem(VIEW_CONTEXT_STORAGE_KEY, JSON.stringify(payload));
+                } catch (error) {
+                    console.warn('Failed to persist view context:', error);
+                }
+            },
+            async restoreViewContext(options = {}) {
+                const { force = false } = options;
+                const persisted = state.lastViewContext || loadViewContextFromStorage();
+                if (!persisted) return false;
+                if (!state.currentFolder?.id || !state.providerType) return false;
+                if (persisted.providerType !== state.providerType || persisted.folderId !== state.currentFolder.id) return false;
+
+                const targetStack = STACKS.includes(persisted.stack) ? persisted.stack : state.currentStack;
+                const stackArray = state.stacks[targetStack] || [];
+                if (!Array.isArray(stackArray) || stackArray.length === 0) return false;
+
+                let targetIndex = -1;
+                if (persisted.fileId) {
+                    targetIndex = stackArray.findIndex(file => file.id === persisted.fileId);
+                }
+                if (targetIndex === -1) {
+                    const fallback = Number.isFinite(persisted.position) ? persisted.position : 0;
+                    targetIndex = Math.max(0, Math.min(fallback, stackArray.length - 1));
+                }
+
+                const stackChanged = state.currentStack !== targetStack;
+                const indexChanged = state.currentStackPosition !== targetIndex;
+                if (!force && !stackChanged && !indexChanged) {
+                    return true;
+                }
+
+                state.currentStack = targetStack;
+                state.currentStackPosition = targetIndex;
+
+                try {
+                    await Core.displayCurrentImage();
+                    Core.updateImageCounters();
+                    Core.updateStackCounts();
+                } catch (error) {
+                    console.warn('Failed to restore persisted view context:', error);
+                    return false;
+                }
+                return true;
+            },
+            registerViewPersistenceLifecycle() {
+                if (this._viewPersistenceLifecycleRegistered) {
+                    return;
+                }
+                const persist = () => this.persistViewContext();
+                const restore = () => {
+                    if (document.visibilityState === 'visible') {
+                        this.restoreViewContext({ force: true });
+                    }
+                };
+
+                document.addEventListener('visibilitychange', () => {
+                    if (document.visibilityState === 'hidden') {
+                        persist();
+                        return;
+                    }
+                    restore();
+                });
+                window.addEventListener('focus', restore);
+                window.addEventListener('blur', persist);
+                window.addEventListener('pagehide', persist);
+                window.addEventListener('beforeunload', persist);
+                this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {
                 if (state.isReturningToFolders) {
@@ -9183,6 +9286,7 @@
                 Events.init();
                 Gestures.init();
                 Core.updateActiveProxTab();
+                App.registerViewPersistenceLifecycle();
             } catch (error) {
                 console.error("Fatal initialization error:", error);
                 const body = document.body;

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -1288,6 +1288,7 @@
             googleRefreshToken: `${APP_IDENTITY.storagePrefix}:google_refresh_token`,
             googleClientSecret: `${APP_IDENTITY.storagePrefix}:google_client_secret`
         };
+        const VIEW_CONTEXT_STORAGE_KEY = `${APP_IDENTITY.storagePrefix}:view_context`;
         const GOOGLE_DRIVE_FOLDER_CACHE_SCHEMA_VERSION = 1;
         const createGoogleDriveFolderCacheEntry = () => ({
             folderImageCountCache: new Map(),
@@ -1305,6 +1306,19 @@
                 }
             } catch (error) {
                 console.warn('Failed to load last folder from storage:', error);
+            }
+            return null;
+        };
+        const loadViewContextFromStorage = () => {
+            try {
+                const raw = localStorage.getItem(VIEW_CONTEXT_STORAGE_KEY);
+                if (!raw) return null;
+                const parsed = JSON.parse(raw);
+                if (parsed && parsed.folderId && parsed.providerType) {
+                    return parsed;
+                }
+            } catch (error) {
+                console.warn('Failed to load view context from storage:', error);
             }
             return null;
         };
@@ -1337,6 +1351,7 @@
             isImageTransitioning: false,
             showDebugToasts: true,
             lastPickedFolder: loadLastFolderFromStorage(),
+            lastViewContext: loadViewContextFromStorage(),
             folderSearchDataset: [],
             folderSearchTerm: '',
             folderSort: { field: 'date', direction: 'desc' },
@@ -5881,6 +5896,8 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
+                this.persistViewContext();
+                this.restoreViewContext({ force: true });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -5936,6 +5953,92 @@
                     }).catch(error => console.warn('Failed to persist folder stats:', error));
                 }
                 Folders.updateLastFolderBanner();
+            },
+            persistViewContext() {
+                if (!state.currentFolder?.id || !state.providerType) {
+                    return;
+                }
+                const currentStackArray = state.stacks[state.currentStack] || [];
+                const currentFile = currentStackArray[state.currentStackPosition] || null;
+                const payload = {
+                    providerType: state.providerType,
+                    folderId: state.currentFolder.id,
+                    folderName: state.currentFolder.name || '',
+                    stack: state.currentStack || 'in',
+                    position: Number.isFinite(state.currentStackPosition) ? state.currentStackPosition : 0,
+                    fileId: currentFile?.id || null,
+                    isFocusMode: Boolean(state.isFocusMode),
+                    savedAt: new Date().toISOString()
+                };
+                state.lastViewContext = payload;
+                try {
+                    localStorage.setItem(VIEW_CONTEXT_STORAGE_KEY, JSON.stringify(payload));
+                } catch (error) {
+                    console.warn('Failed to persist view context:', error);
+                }
+            },
+            async restoreViewContext(options = {}) {
+                const { force = false } = options;
+                const persisted = state.lastViewContext || loadViewContextFromStorage();
+                if (!persisted) return false;
+                if (!state.currentFolder?.id || !state.providerType) return false;
+                if (persisted.providerType !== state.providerType || persisted.folderId !== state.currentFolder.id) return false;
+
+                const targetStack = STACKS.includes(persisted.stack) ? persisted.stack : state.currentStack;
+                const stackArray = state.stacks[targetStack] || [];
+                if (!Array.isArray(stackArray) || stackArray.length === 0) return false;
+
+                let targetIndex = -1;
+                if (persisted.fileId) {
+                    targetIndex = stackArray.findIndex(file => file.id === persisted.fileId);
+                }
+                if (targetIndex === -1) {
+                    const fallback = Number.isFinite(persisted.position) ? persisted.position : 0;
+                    targetIndex = Math.max(0, Math.min(fallback, stackArray.length - 1));
+                }
+
+                const stackChanged = state.currentStack !== targetStack;
+                const indexChanged = state.currentStackPosition !== targetIndex;
+                if (!force && !stackChanged && !indexChanged) {
+                    return true;
+                }
+
+                state.currentStack = targetStack;
+                state.currentStackPosition = targetIndex;
+
+                try {
+                    await Core.displayCurrentImage();
+                    Core.updateImageCounters();
+                    Core.updateStackCounts();
+                } catch (error) {
+                    console.warn('Failed to restore persisted view context:', error);
+                    return false;
+                }
+                return true;
+            },
+            registerViewPersistenceLifecycle() {
+                if (this._viewPersistenceLifecycleRegistered) {
+                    return;
+                }
+                const persist = () => this.persistViewContext();
+                const restore = () => {
+                    if (document.visibilityState === 'visible') {
+                        this.restoreViewContext({ force: true });
+                    }
+                };
+
+                document.addEventListener('visibilitychange', () => {
+                    if (document.visibilityState === 'hidden') {
+                        persist();
+                        return;
+                    }
+                    restore();
+                });
+                window.addEventListener('focus', restore);
+                window.addEventListener('blur', persist);
+                window.addEventListener('pagehide', persist);
+                window.addEventListener('beforeunload', persist);
+                this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {
                 if (state.isReturningToFolders) {
@@ -9366,6 +9469,7 @@ this.updateImageCounters();
                 Events.init();
                 Gestures.init();
                 Core.updateActiveProxTab();
+                App.registerViewPersistenceLifecycle();
             } catch (error) {
                 console.error("Fatal initialization error:", error);
                 const body = document.body;

--- a/ui-v10.html
+++ b/ui-v10.html
@@ -1141,6 +1141,7 @@
         const SHARE_URL_TEMPLATE = "https://drive.google.com/file/d/${fileId}/view?usp=sharing";
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const LAST_FOLDER_STORAGE_KEY = 'orbital8_last_folder';
+        const VIEW_CONTEXT_STORAGE_KEY = 'orbital8_view_context';
         const loadLastFolderFromStorage = () => {
             try {
                 const raw = localStorage.getItem(LAST_FOLDER_STORAGE_KEY);
@@ -1151,6 +1152,19 @@
                 }
             } catch (error) {
                 console.warn('Failed to load last folder from storage:', error);
+            }
+            return null;
+        };
+        const loadViewContextFromStorage = () => {
+            try {
+                const raw = localStorage.getItem(VIEW_CONTEXT_STORAGE_KEY);
+                if (!raw) return null;
+                const parsed = JSON.parse(raw);
+                if (parsed && parsed.folderId && parsed.providerType) {
+                    return parsed;
+                }
+            } catch (error) {
+                console.warn('Failed to load view context from storage:', error);
             }
             return null;
         };
@@ -1174,6 +1188,7 @@
             isImageTransitioning: false,
             showDebugToasts: true,
             lastPickedFolder: loadLastFolderFromStorage(),
+            lastViewContext: loadViewContextFromStorage(),
             folderSearchDataset: [],
             folderSearchTerm: ''
         };
@@ -4729,6 +4744,8 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
+                this.persistViewContext();
+                this.restoreViewContext({ force: true });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -4763,6 +4780,92 @@
                     console.warn('Failed to persist last folder:', error);
                 }
                 Folders.updateLastFolderBanner();
+            },
+            persistViewContext() {
+                if (!state.currentFolder?.id || !state.providerType) {
+                    return;
+                }
+                const currentStackArray = state.stacks[state.currentStack] || [];
+                const currentFile = currentStackArray[state.currentStackPosition] || null;
+                const payload = {
+                    providerType: state.providerType,
+                    folderId: state.currentFolder.id,
+                    folderName: state.currentFolder.name || '',
+                    stack: state.currentStack || 'in',
+                    position: Number.isFinite(state.currentStackPosition) ? state.currentStackPosition : 0,
+                    fileId: currentFile?.id || null,
+                    isFocusMode: Boolean(state.isFocusMode),
+                    savedAt: new Date().toISOString()
+                };
+                state.lastViewContext = payload;
+                try {
+                    localStorage.setItem(VIEW_CONTEXT_STORAGE_KEY, JSON.stringify(payload));
+                } catch (error) {
+                    console.warn('Failed to persist view context:', error);
+                }
+            },
+            async restoreViewContext(options = {}) {
+                const { force = false } = options;
+                const persisted = state.lastViewContext || loadViewContextFromStorage();
+                if (!persisted) return false;
+                if (!state.currentFolder?.id || !state.providerType) return false;
+                if (persisted.providerType !== state.providerType || persisted.folderId !== state.currentFolder.id) return false;
+
+                const targetStack = STACKS.includes(persisted.stack) ? persisted.stack : state.currentStack;
+                const stackArray = state.stacks[targetStack] || [];
+                if (!Array.isArray(stackArray) || stackArray.length === 0) return false;
+
+                let targetIndex = -1;
+                if (persisted.fileId) {
+                    targetIndex = stackArray.findIndex(file => file.id === persisted.fileId);
+                }
+                if (targetIndex === -1) {
+                    const fallback = Number.isFinite(persisted.position) ? persisted.position : 0;
+                    targetIndex = Math.max(0, Math.min(fallback, stackArray.length - 1));
+                }
+
+                const stackChanged = state.currentStack !== targetStack;
+                const indexChanged = state.currentStackPosition !== targetIndex;
+                if (!force && !stackChanged && !indexChanged) {
+                    return true;
+                }
+
+                state.currentStack = targetStack;
+                state.currentStackPosition = targetIndex;
+
+                try {
+                    await Core.displayCurrentImage();
+                    Core.updateImageCounters();
+                    Core.updateStackCounts();
+                } catch (error) {
+                    console.warn('Failed to restore persisted view context:', error);
+                    return false;
+                }
+                return true;
+            },
+            registerViewPersistenceLifecycle() {
+                if (this._viewPersistenceLifecycleRegistered) {
+                    return;
+                }
+                const persist = () => this.persistViewContext();
+                const restore = () => {
+                    if (document.visibilityState === 'visible') {
+                        this.restoreViewContext({ force: true });
+                    }
+                };
+
+                document.addEventListener('visibilitychange', () => {
+                    if (document.visibilityState === 'hidden') {
+                        persist();
+                        return;
+                    }
+                    restore();
+                });
+                window.addEventListener('focus', restore);
+                window.addEventListener('blur', persist);
+                window.addEventListener('pagehide', persist);
+                window.addEventListener('beforeunload', persist);
+                this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {
                 if (state.isReturningToFolders) {
@@ -7420,6 +7523,7 @@ this.updateImageCounters();
                 Events.init();
                 Gestures.init();
                 Core.updateActiveProxTab();
+                App.registerViewPersistenceLifecycle();
             } catch (error) {
                 console.error("Fatal initialization error:", error);
                 const body = document.body;

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -1178,6 +1178,7 @@
         const SHARE_URL_TEMPLATE = "https://drive.google.com/file/d/${fileId}/view?usp=sharing";
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const LAST_FOLDER_STORAGE_KEY = 'orbital8_last_folder';
+        const VIEW_CONTEXT_STORAGE_KEY = 'orbital8_view_context';
         const loadLastFolderFromStorage = () => {
             if (typeof localStorage === 'undefined') {
                 return null;
@@ -1201,6 +1202,19 @@
             selectedIds: [],
             dragElements: []
         });
+        const loadViewContextFromStorage = () => {
+            try {
+                const raw = localStorage.getItem(VIEW_CONTEXT_STORAGE_KEY);
+                if (!raw) return null;
+                const parsed = JSON.parse(raw);
+                if (parsed && parsed.folderId && parsed.providerType) {
+                    return parsed;
+                }
+            } catch (error) {
+                console.warn('Failed to load view context from storage:', error);
+            }
+            return null;
+        };
         const OMNI_SEARCH_RESULT_LIMIT = 8;
         const IMAGE_CACHE_LIMIT = 40;
         const state = {
@@ -1226,7 +1240,8 @@
             folderSearchTerm: '',
             folderTimestamps: new Map(),
             imageUrlCache: new Map(),
-            lastPickedFolder: loadLastFolderFromStorage()
+            lastPickedFolder: loadLastFolderFromStorage(),
+            lastViewContext: loadViewContextFromStorage()
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -4734,6 +4749,8 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
+                this.persistViewContext();
+                this.restoreViewContext({ force: true });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -4800,6 +4817,92 @@
                 }
 
                 Folders.updateLastFolderBanner();
+            },
+            persistViewContext() {
+                if (!state.currentFolder?.id || !state.providerType) {
+                    return;
+                }
+                const currentStackArray = state.stacks[state.currentStack] || [];
+                const currentFile = currentStackArray[state.currentStackPosition] || null;
+                const payload = {
+                    providerType: state.providerType,
+                    folderId: state.currentFolder.id,
+                    folderName: state.currentFolder.name || '',
+                    stack: state.currentStack || 'in',
+                    position: Number.isFinite(state.currentStackPosition) ? state.currentStackPosition : 0,
+                    fileId: currentFile?.id || null,
+                    isFocusMode: Boolean(state.isFocusMode),
+                    savedAt: new Date().toISOString()
+                };
+                state.lastViewContext = payload;
+                try {
+                    localStorage.setItem(VIEW_CONTEXT_STORAGE_KEY, JSON.stringify(payload));
+                } catch (error) {
+                    console.warn('Failed to persist view context:', error);
+                }
+            },
+            async restoreViewContext(options = {}) {
+                const { force = false } = options;
+                const persisted = state.lastViewContext || loadViewContextFromStorage();
+                if (!persisted) return false;
+                if (!state.currentFolder?.id || !state.providerType) return false;
+                if (persisted.providerType !== state.providerType || persisted.folderId !== state.currentFolder.id) return false;
+
+                const targetStack = STACKS.includes(persisted.stack) ? persisted.stack : state.currentStack;
+                const stackArray = state.stacks[targetStack] || [];
+                if (!Array.isArray(stackArray) || stackArray.length === 0) return false;
+
+                let targetIndex = -1;
+                if (persisted.fileId) {
+                    targetIndex = stackArray.findIndex(file => file.id === persisted.fileId);
+                }
+                if (targetIndex === -1) {
+                    const fallback = Number.isFinite(persisted.position) ? persisted.position : 0;
+                    targetIndex = Math.max(0, Math.min(fallback, stackArray.length - 1));
+                }
+
+                const stackChanged = state.currentStack !== targetStack;
+                const indexChanged = state.currentStackPosition !== targetIndex;
+                if (!force && !stackChanged && !indexChanged) {
+                    return true;
+                }
+
+                state.currentStack = targetStack;
+                state.currentStackPosition = targetIndex;
+
+                try {
+                    await Core.displayCurrentImage();
+                    Core.updateImageCounters();
+                    Core.updateStackCounts();
+                } catch (error) {
+                    console.warn('Failed to restore persisted view context:', error);
+                    return false;
+                }
+                return true;
+            },
+            registerViewPersistenceLifecycle() {
+                if (this._viewPersistenceLifecycleRegistered) {
+                    return;
+                }
+                const persist = () => this.persistViewContext();
+                const restore = () => {
+                    if (document.visibilityState === 'visible') {
+                        this.restoreViewContext({ force: true });
+                    }
+                };
+
+                document.addEventListener('visibilitychange', () => {
+                    if (document.visibilityState === 'hidden') {
+                        persist();
+                        return;
+                    }
+                    restore();
+                });
+                window.addEventListener('focus', restore);
+                window.addEventListener('blur', persist);
+                window.addEventListener('pagehide', persist);
+                window.addEventListener('beforeunload', persist);
+                this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {
                 if (state.isReturningToFolders) {
@@ -8233,6 +8336,7 @@ this.updateImageCounters();
                 Events.init();
                 Gestures.init();
                 Core.updateActiveProxTab();
+                App.registerViewPersistenceLifecycle();
             } catch (error) {
                 console.error("Fatal initialization error:", error);
                 const body = document.body;

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -1181,6 +1181,7 @@
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const LAST_FOLDER_STORAGE_KEY = 'orbital8_last_folder';
+        const VIEW_CONTEXT_STORAGE_KEY = 'orbital8_view_context';
         const loadLastFolderFromStorage = () => {
             try {
                 const raw = localStorage.getItem(LAST_FOLDER_STORAGE_KEY);
@@ -1191,6 +1192,19 @@
                 }
             } catch (error) {
                 console.warn('Failed to load last folder from storage:', error);
+            }
+            return null;
+        };
+        const loadViewContextFromStorage = () => {
+            try {
+                const raw = localStorage.getItem(VIEW_CONTEXT_STORAGE_KEY);
+                if (!raw) return null;
+                const parsed = JSON.parse(raw);
+                if (parsed && parsed.folderId && parsed.providerType) {
+                    return parsed;
+                }
+            } catch (error) {
+                console.warn('Failed to load view context from storage:', error);
             }
             return null;
         };
@@ -1223,6 +1237,7 @@
             isImageTransitioning: false,
             showDebugToasts: true,
             lastPickedFolder: loadLastFolderFromStorage(),
+            lastViewContext: loadViewContextFromStorage(),
             folderSearchDataset: [],
             folderSearchTerm: ''
         };
@@ -5144,6 +5159,8 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
+                this.persistViewContext();
+                this.restoreViewContext({ force: true });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -5182,6 +5199,92 @@
                     console.warn('Failed to persist last folder:', error);
                 }
                 Folders.updateLastFolderBanner();
+            },
+            persistViewContext() {
+                if (!state.currentFolder?.id || !state.providerType) {
+                    return;
+                }
+                const currentStackArray = state.stacks[state.currentStack] || [];
+                const currentFile = currentStackArray[state.currentStackPosition] || null;
+                const payload = {
+                    providerType: state.providerType,
+                    folderId: state.currentFolder.id,
+                    folderName: state.currentFolder.name || '',
+                    stack: state.currentStack || 'in',
+                    position: Number.isFinite(state.currentStackPosition) ? state.currentStackPosition : 0,
+                    fileId: currentFile?.id || null,
+                    isFocusMode: Boolean(state.isFocusMode),
+                    savedAt: new Date().toISOString()
+                };
+                state.lastViewContext = payload;
+                try {
+                    localStorage.setItem(VIEW_CONTEXT_STORAGE_KEY, JSON.stringify(payload));
+                } catch (error) {
+                    console.warn('Failed to persist view context:', error);
+                }
+            },
+            async restoreViewContext(options = {}) {
+                const { force = false } = options;
+                const persisted = state.lastViewContext || loadViewContextFromStorage();
+                if (!persisted) return false;
+                if (!state.currentFolder?.id || !state.providerType) return false;
+                if (persisted.providerType !== state.providerType || persisted.folderId !== state.currentFolder.id) return false;
+
+                const targetStack = STACKS.includes(persisted.stack) ? persisted.stack : state.currentStack;
+                const stackArray = state.stacks[targetStack] || [];
+                if (!Array.isArray(stackArray) || stackArray.length === 0) return false;
+
+                let targetIndex = -1;
+                if (persisted.fileId) {
+                    targetIndex = stackArray.findIndex(file => file.id === persisted.fileId);
+                }
+                if (targetIndex === -1) {
+                    const fallback = Number.isFinite(persisted.position) ? persisted.position : 0;
+                    targetIndex = Math.max(0, Math.min(fallback, stackArray.length - 1));
+                }
+
+                const stackChanged = state.currentStack !== targetStack;
+                const indexChanged = state.currentStackPosition !== targetIndex;
+                if (!force && !stackChanged && !indexChanged) {
+                    return true;
+                }
+
+                state.currentStack = targetStack;
+                state.currentStackPosition = targetIndex;
+
+                try {
+                    await Core.displayCurrentImage();
+                    Core.updateImageCounters();
+                    Core.updateStackCounts();
+                } catch (error) {
+                    console.warn('Failed to restore persisted view context:', error);
+                    return false;
+                }
+                return true;
+            },
+            registerViewPersistenceLifecycle() {
+                if (this._viewPersistenceLifecycleRegistered) {
+                    return;
+                }
+                const persist = () => this.persistViewContext();
+                const restore = () => {
+                    if (document.visibilityState === 'visible') {
+                        this.restoreViewContext({ force: true });
+                    }
+                };
+
+                document.addEventListener('visibilitychange', () => {
+                    if (document.visibilityState === 'hidden') {
+                        persist();
+                        return;
+                    }
+                    restore();
+                });
+                window.addEventListener('focus', restore);
+                window.addEventListener('blur', persist);
+                window.addEventListener('pagehide', persist);
+                window.addEventListener('beforeunload', persist);
+                this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {
                 if (state.isReturningToFolders) {
@@ -8257,6 +8360,7 @@ this.updateImageCounters();
                 Events.init();
                 Gestures.init();
                 Core.updateActiveProxTab();
+                App.registerViewPersistenceLifecycle();
             } catch (error) {
                 console.error("Fatal initialization error:", error);
                 const body = document.body;

--- a/ui-v5.html
+++ b/ui-v5.html
@@ -1186,6 +1186,7 @@
             dragElements: []
         });
         const LAST_FOLDER_STORAGE_KEY = 'orbital8_last_folder';
+        const VIEW_CONTEXT_STORAGE_KEY = 'orbital8_view_context';
         const loadLastFolderFromStorage = () => {
             try {
                 const raw = localStorage.getItem(LAST_FOLDER_STORAGE_KEY);
@@ -1196,6 +1197,19 @@
                 }
             } catch (error) {
                 console.warn('Failed to load last folder from storage:', error);
+            }
+            return null;
+        };
+        const loadViewContextFromStorage = () => {
+            try {
+                const raw = localStorage.getItem(VIEW_CONTEXT_STORAGE_KEY);
+                if (!raw) return null;
+                const parsed = JSON.parse(raw);
+                if (parsed && parsed.folderId && parsed.providerType) {
+                    return parsed;
+                }
+            } catch (error) {
+                console.warn('Failed to load view context from storage:', error);
             }
             return null;
         };
@@ -1393,6 +1407,7 @@
             isImageTransitioning: false,
             showDebugToasts: true,
             lastPickedFolder: loadLastFolderFromStorage(),
+            lastViewContext: loadViewContextFromStorage(),
             folderSearchDataset: [],
             folderSearchTerm: ''
         };
@@ -4956,6 +4971,8 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
+                this.persistViewContext();
+                this.restoreViewContext({ force: true });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -4990,6 +5007,92 @@
                     console.warn('Failed to persist last folder:', error);
                 }
                 Folders.updateLastFolderBanner();
+            },
+            persistViewContext() {
+                if (!state.currentFolder?.id || !state.providerType) {
+                    return;
+                }
+                const currentStackArray = state.stacks[state.currentStack] || [];
+                const currentFile = currentStackArray[state.currentStackPosition] || null;
+                const payload = {
+                    providerType: state.providerType,
+                    folderId: state.currentFolder.id,
+                    folderName: state.currentFolder.name || '',
+                    stack: state.currentStack || 'in',
+                    position: Number.isFinite(state.currentStackPosition) ? state.currentStackPosition : 0,
+                    fileId: currentFile?.id || null,
+                    isFocusMode: Boolean(state.isFocusMode),
+                    savedAt: new Date().toISOString()
+                };
+                state.lastViewContext = payload;
+                try {
+                    localStorage.setItem(VIEW_CONTEXT_STORAGE_KEY, JSON.stringify(payload));
+                } catch (error) {
+                    console.warn('Failed to persist view context:', error);
+                }
+            },
+            async restoreViewContext(options = {}) {
+                const { force = false } = options;
+                const persisted = state.lastViewContext || loadViewContextFromStorage();
+                if (!persisted) return false;
+                if (!state.currentFolder?.id || !state.providerType) return false;
+                if (persisted.providerType !== state.providerType || persisted.folderId !== state.currentFolder.id) return false;
+
+                const targetStack = STACKS.includes(persisted.stack) ? persisted.stack : state.currentStack;
+                const stackArray = state.stacks[targetStack] || [];
+                if (!Array.isArray(stackArray) || stackArray.length === 0) return false;
+
+                let targetIndex = -1;
+                if (persisted.fileId) {
+                    targetIndex = stackArray.findIndex(file => file.id === persisted.fileId);
+                }
+                if (targetIndex === -1) {
+                    const fallback = Number.isFinite(persisted.position) ? persisted.position : 0;
+                    targetIndex = Math.max(0, Math.min(fallback, stackArray.length - 1));
+                }
+
+                const stackChanged = state.currentStack !== targetStack;
+                const indexChanged = state.currentStackPosition !== targetIndex;
+                if (!force && !stackChanged && !indexChanged) {
+                    return true;
+                }
+
+                state.currentStack = targetStack;
+                state.currentStackPosition = targetIndex;
+
+                try {
+                    await Core.displayCurrentImage();
+                    Core.updateImageCounters();
+                    Core.updateStackCounts();
+                } catch (error) {
+                    console.warn('Failed to restore persisted view context:', error);
+                    return false;
+                }
+                return true;
+            },
+            registerViewPersistenceLifecycle() {
+                if (this._viewPersistenceLifecycleRegistered) {
+                    return;
+                }
+                const persist = () => this.persistViewContext();
+                const restore = () => {
+                    if (document.visibilityState === 'visible') {
+                        this.restoreViewContext({ force: true });
+                    }
+                };
+
+                document.addEventListener('visibilitychange', () => {
+                    if (document.visibilityState === 'hidden') {
+                        persist();
+                        return;
+                    }
+                    restore();
+                });
+                window.addEventListener('focus', restore);
+                window.addEventListener('blur', persist);
+                window.addEventListener('pagehide', persist);
+                window.addEventListener('beforeunload', persist);
+                this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {
                 if (state.isReturningToFolders) {
@@ -8545,6 +8648,7 @@ this.updateImageCounters();
                 Events.init();
                 Gestures.init();
                 Core.updateActiveProxTab();
+                App.registerViewPersistenceLifecycle();
             } catch (error) {
                 console.error("Fatal initialization error:", error);
                 const body = document.body;

--- a/ui-v6.html
+++ b/ui-v6.html
@@ -1141,6 +1141,7 @@
         const SHARE_URL_TEMPLATE = "https://drive.google.com/file/d/${fileId}/view?usp=sharing";
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const LAST_FOLDER_STORAGE_KEY = 'orbital8_last_folder';
+        const VIEW_CONTEXT_STORAGE_KEY = 'orbital8_view_context';
         const loadLastFolderFromStorage = () => {
             try {
                 const raw = localStorage.getItem(LAST_FOLDER_STORAGE_KEY);
@@ -1151,6 +1152,19 @@
                 }
             } catch (error) {
                 console.warn('Failed to load last folder from storage:', error);
+            }
+            return null;
+        };
+        const loadViewContextFromStorage = () => {
+            try {
+                const raw = localStorage.getItem(VIEW_CONTEXT_STORAGE_KEY);
+                if (!raw) return null;
+                const parsed = JSON.parse(raw);
+                if (parsed && parsed.folderId && parsed.providerType) {
+                    return parsed;
+                }
+            } catch (error) {
+                console.warn('Failed to load view context from storage:', error);
             }
             return null;
         };
@@ -1174,6 +1188,7 @@
             isImageTransitioning: false,
             showDebugToasts: true,
             lastPickedFolder: loadLastFolderFromStorage(),
+            lastViewContext: loadViewContextFromStorage(),
             folderSearchDataset: [],
             folderSearchTerm: ''
         };
@@ -4729,6 +4744,8 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
+                this.persistViewContext();
+                this.restoreViewContext({ force: true });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -4763,6 +4780,92 @@
                     console.warn('Failed to persist last folder:', error);
                 }
                 Folders.updateLastFolderBanner();
+            },
+            persistViewContext() {
+                if (!state.currentFolder?.id || !state.providerType) {
+                    return;
+                }
+                const currentStackArray = state.stacks[state.currentStack] || [];
+                const currentFile = currentStackArray[state.currentStackPosition] || null;
+                const payload = {
+                    providerType: state.providerType,
+                    folderId: state.currentFolder.id,
+                    folderName: state.currentFolder.name || '',
+                    stack: state.currentStack || 'in',
+                    position: Number.isFinite(state.currentStackPosition) ? state.currentStackPosition : 0,
+                    fileId: currentFile?.id || null,
+                    isFocusMode: Boolean(state.isFocusMode),
+                    savedAt: new Date().toISOString()
+                };
+                state.lastViewContext = payload;
+                try {
+                    localStorage.setItem(VIEW_CONTEXT_STORAGE_KEY, JSON.stringify(payload));
+                } catch (error) {
+                    console.warn('Failed to persist view context:', error);
+                }
+            },
+            async restoreViewContext(options = {}) {
+                const { force = false } = options;
+                const persisted = state.lastViewContext || loadViewContextFromStorage();
+                if (!persisted) return false;
+                if (!state.currentFolder?.id || !state.providerType) return false;
+                if (persisted.providerType !== state.providerType || persisted.folderId !== state.currentFolder.id) return false;
+
+                const targetStack = STACKS.includes(persisted.stack) ? persisted.stack : state.currentStack;
+                const stackArray = state.stacks[targetStack] || [];
+                if (!Array.isArray(stackArray) || stackArray.length === 0) return false;
+
+                let targetIndex = -1;
+                if (persisted.fileId) {
+                    targetIndex = stackArray.findIndex(file => file.id === persisted.fileId);
+                }
+                if (targetIndex === -1) {
+                    const fallback = Number.isFinite(persisted.position) ? persisted.position : 0;
+                    targetIndex = Math.max(0, Math.min(fallback, stackArray.length - 1));
+                }
+
+                const stackChanged = state.currentStack !== targetStack;
+                const indexChanged = state.currentStackPosition !== targetIndex;
+                if (!force && !stackChanged && !indexChanged) {
+                    return true;
+                }
+
+                state.currentStack = targetStack;
+                state.currentStackPosition = targetIndex;
+
+                try {
+                    await Core.displayCurrentImage();
+                    Core.updateImageCounters();
+                    Core.updateStackCounts();
+                } catch (error) {
+                    console.warn('Failed to restore persisted view context:', error);
+                    return false;
+                }
+                return true;
+            },
+            registerViewPersistenceLifecycle() {
+                if (this._viewPersistenceLifecycleRegistered) {
+                    return;
+                }
+                const persist = () => this.persistViewContext();
+                const restore = () => {
+                    if (document.visibilityState === 'visible') {
+                        this.restoreViewContext({ force: true });
+                    }
+                };
+
+                document.addEventListener('visibilitychange', () => {
+                    if (document.visibilityState === 'hidden') {
+                        persist();
+                        return;
+                    }
+                    restore();
+                });
+                window.addEventListener('focus', restore);
+                window.addEventListener('blur', persist);
+                window.addEventListener('pagehide', persist);
+                window.addEventListener('beforeunload', persist);
+                this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {
                 if (state.isReturningToFolders) {
@@ -7420,6 +7523,7 @@ this.updateImageCounters();
                 Events.init();
                 Gestures.init();
                 Core.updateActiveProxTab();
+                App.registerViewPersistenceLifecycle();
             } catch (error) {
                 console.error("Fatal initialization error:", error);
                 const body = document.body;

--- a/ui-v7.html
+++ b/ui-v7.html
@@ -1589,6 +1589,7 @@
         const SHARE_URL_TEMPLATE = "https://drive.google.com/file/d/${fileId}/view?usp=sharing";
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const LAST_FOLDER_STORAGE_KEY = 'orbital8_last_folder';
+        const VIEW_CONTEXT_STORAGE_KEY = 'orbital8_view_context';
         const loadLastFolderFromStorage = () => {
             if (typeof localStorage === 'undefined') {
                 return null;
@@ -1612,6 +1613,19 @@
             selectedIds: [],
             dragElements: []
         });
+        const loadViewContextFromStorage = () => {
+            try {
+                const raw = localStorage.getItem(VIEW_CONTEXT_STORAGE_KEY);
+                if (!raw) return null;
+                const parsed = JSON.parse(raw);
+                if (parsed && parsed.folderId && parsed.providerType) {
+                    return parsed;
+                }
+            } catch (error) {
+                console.warn('Failed to load view context from storage:', error);
+            }
+            return null;
+        };
         const OMNI_SEARCH_RESULT_LIMIT = 8;
         const IMAGE_CACHE_LIMIT = 40;
         const state = {
@@ -1637,7 +1651,8 @@
             folderSearchTerm: '',
             folderTimestamps: new Map(),
             imageUrlCache: new Map(),
-            lastPickedFolder: loadLastFolderFromStorage()
+            lastPickedFolder: loadLastFolderFromStorage(),
+            lastViewContext: loadViewContextFromStorage()
         };
         const DriveLinkHelper = {
             extractFileId(input) {
@@ -5017,6 +5032,8 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
+                this.persistViewContext();
+                this.restoreViewContext({ force: true });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -5083,6 +5100,92 @@
                 }
 
                 Folders.updateLastFolderBanner();
+            },
+            persistViewContext() {
+                if (!state.currentFolder?.id || !state.providerType) {
+                    return;
+                }
+                const currentStackArray = state.stacks[state.currentStack] || [];
+                const currentFile = currentStackArray[state.currentStackPosition] || null;
+                const payload = {
+                    providerType: state.providerType,
+                    folderId: state.currentFolder.id,
+                    folderName: state.currentFolder.name || '',
+                    stack: state.currentStack || 'in',
+                    position: Number.isFinite(state.currentStackPosition) ? state.currentStackPosition : 0,
+                    fileId: currentFile?.id || null,
+                    isFocusMode: Boolean(state.isFocusMode),
+                    savedAt: new Date().toISOString()
+                };
+                state.lastViewContext = payload;
+                try {
+                    localStorage.setItem(VIEW_CONTEXT_STORAGE_KEY, JSON.stringify(payload));
+                } catch (error) {
+                    console.warn('Failed to persist view context:', error);
+                }
+            },
+            async restoreViewContext(options = {}) {
+                const { force = false } = options;
+                const persisted = state.lastViewContext || loadViewContextFromStorage();
+                if (!persisted) return false;
+                if (!state.currentFolder?.id || !state.providerType) return false;
+                if (persisted.providerType !== state.providerType || persisted.folderId !== state.currentFolder.id) return false;
+
+                const targetStack = STACKS.includes(persisted.stack) ? persisted.stack : state.currentStack;
+                const stackArray = state.stacks[targetStack] || [];
+                if (!Array.isArray(stackArray) || stackArray.length === 0) return false;
+
+                let targetIndex = -1;
+                if (persisted.fileId) {
+                    targetIndex = stackArray.findIndex(file => file.id === persisted.fileId);
+                }
+                if (targetIndex === -1) {
+                    const fallback = Number.isFinite(persisted.position) ? persisted.position : 0;
+                    targetIndex = Math.max(0, Math.min(fallback, stackArray.length - 1));
+                }
+
+                const stackChanged = state.currentStack !== targetStack;
+                const indexChanged = state.currentStackPosition !== targetIndex;
+                if (!force && !stackChanged && !indexChanged) {
+                    return true;
+                }
+
+                state.currentStack = targetStack;
+                state.currentStackPosition = targetIndex;
+
+                try {
+                    await Core.displayCurrentImage();
+                    Core.updateImageCounters();
+                    Core.updateStackCounts();
+                } catch (error) {
+                    console.warn('Failed to restore persisted view context:', error);
+                    return false;
+                }
+                return true;
+            },
+            registerViewPersistenceLifecycle() {
+                if (this._viewPersistenceLifecycleRegistered) {
+                    return;
+                }
+                const persist = () => this.persistViewContext();
+                const restore = () => {
+                    if (document.visibilityState === 'visible') {
+                        this.restoreViewContext({ force: true });
+                    }
+                };
+
+                document.addEventListener('visibilitychange', () => {
+                    if (document.visibilityState === 'hidden') {
+                        persist();
+                        return;
+                    }
+                    restore();
+                });
+                window.addEventListener('focus', restore);
+                window.addEventListener('blur', persist);
+                window.addEventListener('pagehide', persist);
+                window.addEventListener('beforeunload', persist);
+                this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {
                 if (state.isReturningToFolders) {
@@ -8516,6 +8619,7 @@ this.updateImageCounters();
                 Events.init();
                 Gestures.init();
                 Core.updateActiveProxTab();
+                App.registerViewPersistenceLifecycle();
             } catch (error) {
                 console.error("Fatal initialization error:", error);
                 const body = document.body;

--- a/ui-v8.html
+++ b/ui-v8.html
@@ -2096,6 +2096,7 @@
         const SHARE_URL_TEMPLATE = "https://drive.google.com/file/d/${fileId}/view?usp=sharing";
         const STACK_NAMES = { 'review': 'To Review', 'keep': 'Keep', 'delete': 'Delete', 'skip': 'Skip' };
         const LAST_FOLDER_STORAGE_KEY = 'orbital8_last_folder';
+        const VIEW_CONTEXT_STORAGE_KEY = 'orbital8_view_context';
         const loadLastFolderFromStorage = () => {
             if (typeof localStorage === 'undefined') {
                 return null;
@@ -2119,6 +2120,19 @@
             selectedIds: [],
             dragElements: []
         });
+        const loadViewContextFromStorage = () => {
+            try {
+                const raw = localStorage.getItem(VIEW_CONTEXT_STORAGE_KEY);
+                if (!raw) return null;
+                const parsed = JSON.parse(raw);
+                if (parsed && parsed.folderId && parsed.providerType) {
+                    return parsed;
+                }
+            } catch (error) {
+                console.warn('Failed to load view context from storage:', error);
+            }
+            return null;
+        };
         const OMNI_SEARCH_RESULT_LIMIT = 8;
         const IMAGE_CACHE_LIMIT = 40;
         const state = {
@@ -2144,7 +2158,8 @@
             folderSearchTerm: '',
             folderTimestamps: new Map(),
             imageUrlCache: new Map(),
-            lastPickedFolder: loadLastFolderFromStorage()
+            lastPickedFolder: loadLastFolderFromStorage(),
+            lastViewContext: loadViewContextFromStorage()
         };
         const CANONICAL_ACTIONS = Object.freeze({
             UP: 'UP',
@@ -5934,6 +5949,8 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
+                this.persistViewContext();
+                this.restoreViewContext({ force: true });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -6000,6 +6017,92 @@
                 }
 
                 Folders.updateLastFolderBanner();
+            },
+            persistViewContext() {
+                if (!state.currentFolder?.id || !state.providerType) {
+                    return;
+                }
+                const currentStackArray = state.stacks[state.currentStack] || [];
+                const currentFile = currentStackArray[state.currentStackPosition] || null;
+                const payload = {
+                    providerType: state.providerType,
+                    folderId: state.currentFolder.id,
+                    folderName: state.currentFolder.name || '',
+                    stack: state.currentStack || 'in',
+                    position: Number.isFinite(state.currentStackPosition) ? state.currentStackPosition : 0,
+                    fileId: currentFile?.id || null,
+                    isFocusMode: Boolean(state.isFocusMode),
+                    savedAt: new Date().toISOString()
+                };
+                state.lastViewContext = payload;
+                try {
+                    localStorage.setItem(VIEW_CONTEXT_STORAGE_KEY, JSON.stringify(payload));
+                } catch (error) {
+                    console.warn('Failed to persist view context:', error);
+                }
+            },
+            async restoreViewContext(options = {}) {
+                const { force = false } = options;
+                const persisted = state.lastViewContext || loadViewContextFromStorage();
+                if (!persisted) return false;
+                if (!state.currentFolder?.id || !state.providerType) return false;
+                if (persisted.providerType !== state.providerType || persisted.folderId !== state.currentFolder.id) return false;
+
+                const targetStack = STACKS.includes(persisted.stack) ? persisted.stack : state.currentStack;
+                const stackArray = state.stacks[targetStack] || [];
+                if (!Array.isArray(stackArray) || stackArray.length === 0) return false;
+
+                let targetIndex = -1;
+                if (persisted.fileId) {
+                    targetIndex = stackArray.findIndex(file => file.id === persisted.fileId);
+                }
+                if (targetIndex === -1) {
+                    const fallback = Number.isFinite(persisted.position) ? persisted.position : 0;
+                    targetIndex = Math.max(0, Math.min(fallback, stackArray.length - 1));
+                }
+
+                const stackChanged = state.currentStack !== targetStack;
+                const indexChanged = state.currentStackPosition !== targetIndex;
+                if (!force && !stackChanged && !indexChanged) {
+                    return true;
+                }
+
+                state.currentStack = targetStack;
+                state.currentStackPosition = targetIndex;
+
+                try {
+                    await Core.displayCurrentImage();
+                    Core.updateImageCounters();
+                    Core.updateStackCounts();
+                } catch (error) {
+                    console.warn('Failed to restore persisted view context:', error);
+                    return false;
+                }
+                return true;
+            },
+            registerViewPersistenceLifecycle() {
+                if (this._viewPersistenceLifecycleRegistered) {
+                    return;
+                }
+                const persist = () => this.persistViewContext();
+                const restore = () => {
+                    if (document.visibilityState === 'visible') {
+                        this.restoreViewContext({ force: true });
+                    }
+                };
+
+                document.addEventListener('visibilitychange', () => {
+                    if (document.visibilityState === 'hidden') {
+                        persist();
+                        return;
+                    }
+                    restore();
+                });
+                window.addEventListener('focus', restore);
+                window.addEventListener('blur', persist);
+                window.addEventListener('pagehide', persist);
+                window.addEventListener('beforeunload', persist);
+                this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {
                 if (state.isReturningToFolders) {
@@ -9774,6 +9877,7 @@ this.updateImageCounters();
                 Events.init();
                 Gestures.init();
                 Core.updateActiveProxTab();
+                App.registerViewPersistenceLifecycle();
             } catch (error) {
                 console.error("Fatal initialization error:", error);
                 const body = document.body;

--- a/ui-v9.html
+++ b/ui-v9.html
@@ -1104,6 +1104,7 @@
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const LAST_FOLDER_STORAGE_KEY = 'orbital8_last_folder';
+        const VIEW_CONTEXT_STORAGE_KEY = 'orbital8_view_context';
         const loadLastFolderFromStorage = () => {
             try {
                 const raw = localStorage.getItem(LAST_FOLDER_STORAGE_KEY);
@@ -1114,6 +1115,19 @@
                 }
             } catch (error) {
                 console.warn('Failed to load last folder from storage:', error);
+            }
+            return null;
+        };
+        const loadViewContextFromStorage = () => {
+            try {
+                const raw = localStorage.getItem(VIEW_CONTEXT_STORAGE_KEY);
+                if (!raw) return null;
+                const parsed = JSON.parse(raw);
+                if (parsed && parsed.folderId && parsed.providerType) {
+                    return parsed;
+                }
+            } catch (error) {
+                console.warn('Failed to load view context from storage:', error);
             }
             return null;
         };
@@ -1137,6 +1151,7 @@
             pendingBackgroundProbe: null,
             showDebugToasts: true,
             lastPickedFolder: loadLastFolderFromStorage(),
+            lastViewContext: loadViewContextFromStorage(),
             folderSearchDataset: [],
             folderSearchTerm: ''
         };
@@ -4765,6 +4780,8 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
+                this.persistViewContext();
+                this.restoreViewContext({ force: true });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -4799,6 +4816,92 @@
                     console.warn('Failed to persist last folder:', error);
                 }
                 Folders.updateLastFolderBanner();
+            },
+            persistViewContext() {
+                if (!state.currentFolder?.id || !state.providerType) {
+                    return;
+                }
+                const currentStackArray = state.stacks[state.currentStack] || [];
+                const currentFile = currentStackArray[state.currentStackPosition] || null;
+                const payload = {
+                    providerType: state.providerType,
+                    folderId: state.currentFolder.id,
+                    folderName: state.currentFolder.name || '',
+                    stack: state.currentStack || 'in',
+                    position: Number.isFinite(state.currentStackPosition) ? state.currentStackPosition : 0,
+                    fileId: currentFile?.id || null,
+                    isFocusMode: Boolean(state.isFocusMode),
+                    savedAt: new Date().toISOString()
+                };
+                state.lastViewContext = payload;
+                try {
+                    localStorage.setItem(VIEW_CONTEXT_STORAGE_KEY, JSON.stringify(payload));
+                } catch (error) {
+                    console.warn('Failed to persist view context:', error);
+                }
+            },
+            async restoreViewContext(options = {}) {
+                const { force = false } = options;
+                const persisted = state.lastViewContext || loadViewContextFromStorage();
+                if (!persisted) return false;
+                if (!state.currentFolder?.id || !state.providerType) return false;
+                if (persisted.providerType !== state.providerType || persisted.folderId !== state.currentFolder.id) return false;
+
+                const targetStack = STACKS.includes(persisted.stack) ? persisted.stack : state.currentStack;
+                const stackArray = state.stacks[targetStack] || [];
+                if (!Array.isArray(stackArray) || stackArray.length === 0) return false;
+
+                let targetIndex = -1;
+                if (persisted.fileId) {
+                    targetIndex = stackArray.findIndex(file => file.id === persisted.fileId);
+                }
+                if (targetIndex === -1) {
+                    const fallback = Number.isFinite(persisted.position) ? persisted.position : 0;
+                    targetIndex = Math.max(0, Math.min(fallback, stackArray.length - 1));
+                }
+
+                const stackChanged = state.currentStack !== targetStack;
+                const indexChanged = state.currentStackPosition !== targetIndex;
+                if (!force && !stackChanged && !indexChanged) {
+                    return true;
+                }
+
+                state.currentStack = targetStack;
+                state.currentStackPosition = targetIndex;
+
+                try {
+                    await Core.displayCurrentImage();
+                    Core.updateImageCounters();
+                    Core.updateStackCounts();
+                } catch (error) {
+                    console.warn('Failed to restore persisted view context:', error);
+                    return false;
+                }
+                return true;
+            },
+            registerViewPersistenceLifecycle() {
+                if (this._viewPersistenceLifecycleRegistered) {
+                    return;
+                }
+                const persist = () => this.persistViewContext();
+                const restore = () => {
+                    if (document.visibilityState === 'visible') {
+                        this.restoreViewContext({ force: true });
+                    }
+                };
+
+                document.addEventListener('visibilitychange', () => {
+                    if (document.visibilityState === 'hidden') {
+                        persist();
+                        return;
+                    }
+                    restore();
+                });
+                window.addEventListener('focus', restore);
+                window.addEventListener('blur', persist);
+                window.addEventListener('pagehide', persist);
+                window.addEventListener('beforeunload', persist);
+                this._viewPersistenceLifecycleRegistered = true;
             },
             async returnToFolderSelection() {
                 if (state.isReturningToFolders) return;
@@ -7455,6 +7558,7 @@ this.updateImageCounters();
                 Events.init();
                 Gestures.init();
                 Core.updateActiveProxTab();
+                App.registerViewPersistenceLifecycle();
             } catch (error) {
                 console.error("Fatal initialization error:", error);
                 const body = document.body;

--- a/ui-v9a.html
+++ b/ui-v9a.html
@@ -1104,6 +1104,7 @@
         const STACKS = ['in', 'out', 'priority', 'trash'];
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const LAST_FOLDER_STORAGE_KEY = 'orbital8_last_folder';
+        const VIEW_CONTEXT_STORAGE_KEY = 'orbital8_view_context';
         const loadLastFolderFromStorage = () => {
             try {
                 const raw = localStorage.getItem(LAST_FOLDER_STORAGE_KEY);
@@ -1114,6 +1115,19 @@
                 }
             } catch (error) {
                 console.warn('Failed to load last folder from storage:', error);
+            }
+            return null;
+        };
+        const loadViewContextFromStorage = () => {
+            try {
+                const raw = localStorage.getItem(VIEW_CONTEXT_STORAGE_KEY);
+                if (!raw) return null;
+                const parsed = JSON.parse(raw);
+                if (parsed && parsed.folderId && parsed.providerType) {
+                    return parsed;
+                }
+            } catch (error) {
+                console.warn('Failed to load view context from storage:', error);
             }
             return null;
         };
@@ -1137,6 +1151,7 @@
             pendingBackgroundProbe: null,
             showDebugToasts: true,
             lastPickedFolder: loadLastFolderFromStorage(),
+            lastViewContext: loadViewContextFromStorage(),
             folderSearchDataset: [],
             folderSearchTerm: ''
         };
@@ -4765,6 +4780,8 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
+                this.persistViewContext();
+                this.restoreViewContext({ force: true });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -4799,6 +4816,92 @@
                     console.warn('Failed to persist last folder:', error);
                 }
                 Folders.updateLastFolderBanner();
+            },
+            persistViewContext() {
+                if (!state.currentFolder?.id || !state.providerType) {
+                    return;
+                }
+                const currentStackArray = state.stacks[state.currentStack] || [];
+                const currentFile = currentStackArray[state.currentStackPosition] || null;
+                const payload = {
+                    providerType: state.providerType,
+                    folderId: state.currentFolder.id,
+                    folderName: state.currentFolder.name || '',
+                    stack: state.currentStack || 'in',
+                    position: Number.isFinite(state.currentStackPosition) ? state.currentStackPosition : 0,
+                    fileId: currentFile?.id || null,
+                    isFocusMode: Boolean(state.isFocusMode),
+                    savedAt: new Date().toISOString()
+                };
+                state.lastViewContext = payload;
+                try {
+                    localStorage.setItem(VIEW_CONTEXT_STORAGE_KEY, JSON.stringify(payload));
+                } catch (error) {
+                    console.warn('Failed to persist view context:', error);
+                }
+            },
+            async restoreViewContext(options = {}) {
+                const { force = false } = options;
+                const persisted = state.lastViewContext || loadViewContextFromStorage();
+                if (!persisted) return false;
+                if (!state.currentFolder?.id || !state.providerType) return false;
+                if (persisted.providerType !== state.providerType || persisted.folderId !== state.currentFolder.id) return false;
+
+                const targetStack = STACKS.includes(persisted.stack) ? persisted.stack : state.currentStack;
+                const stackArray = state.stacks[targetStack] || [];
+                if (!Array.isArray(stackArray) || stackArray.length === 0) return false;
+
+                let targetIndex = -1;
+                if (persisted.fileId) {
+                    targetIndex = stackArray.findIndex(file => file.id === persisted.fileId);
+                }
+                if (targetIndex === -1) {
+                    const fallback = Number.isFinite(persisted.position) ? persisted.position : 0;
+                    targetIndex = Math.max(0, Math.min(fallback, stackArray.length - 1));
+                }
+
+                const stackChanged = state.currentStack !== targetStack;
+                const indexChanged = state.currentStackPosition !== targetIndex;
+                if (!force && !stackChanged && !indexChanged) {
+                    return true;
+                }
+
+                state.currentStack = targetStack;
+                state.currentStackPosition = targetIndex;
+
+                try {
+                    await Core.displayCurrentImage();
+                    Core.updateImageCounters();
+                    Core.updateStackCounts();
+                } catch (error) {
+                    console.warn('Failed to restore persisted view context:', error);
+                    return false;
+                }
+                return true;
+            },
+            registerViewPersistenceLifecycle() {
+                if (this._viewPersistenceLifecycleRegistered) {
+                    return;
+                }
+                const persist = () => this.persistViewContext();
+                const restore = () => {
+                    if (document.visibilityState === 'visible') {
+                        this.restoreViewContext({ force: true });
+                    }
+                };
+
+                document.addEventListener('visibilitychange', () => {
+                    if (document.visibilityState === 'hidden') {
+                        persist();
+                        return;
+                    }
+                    restore();
+                });
+                window.addEventListener('focus', restore);
+                window.addEventListener('blur', persist);
+                window.addEventListener('pagehide', persist);
+                window.addEventListener('beforeunload', persist);
+                this._viewPersistenceLifecycleRegistered = true;
             },
             async returnToFolderSelection() {
                 if (state.isReturningToFolders) return;
@@ -7444,6 +7547,7 @@ this.updateImageCounters();
                 Events.init();
                 Gestures.init();
                 Core.updateActiveProxTab();
+                App.registerViewPersistenceLifecycle();
             } catch (error) {
                 console.error("Fatal initialization error:", error);
                 const body = document.body;

--- a/ui-v9b.html
+++ b/ui-v9b.html
@@ -1141,6 +1141,7 @@
         const SHARE_URL_TEMPLATE = "https://drive.google.com/file/d/${fileId}/view?usp=sharing";
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const LAST_FOLDER_STORAGE_KEY = 'orbital8_last_folder';
+        const VIEW_CONTEXT_STORAGE_KEY = 'orbital8_view_context';
         const loadLastFolderFromStorage = () => {
             try {
                 const raw = localStorage.getItem(LAST_FOLDER_STORAGE_KEY);
@@ -1151,6 +1152,19 @@
                 }
             } catch (error) {
                 console.warn('Failed to load last folder from storage:', error);
+            }
+            return null;
+        };
+        const loadViewContextFromStorage = () => {
+            try {
+                const raw = localStorage.getItem(VIEW_CONTEXT_STORAGE_KEY);
+                if (!raw) return null;
+                const parsed = JSON.parse(raw);
+                if (parsed && parsed.folderId && parsed.providerType) {
+                    return parsed;
+                }
+            } catch (error) {
+                console.warn('Failed to load view context from storage:', error);
             }
             return null;
         };
@@ -1174,6 +1188,7 @@
             isImageTransitioning: false,
             showDebugToasts: true,
             lastPickedFolder: loadLastFolderFromStorage(),
+            lastViewContext: loadViewContextFromStorage(),
             folderSearchDataset: [],
             folderSearchTerm: ''
         };
@@ -4744,6 +4759,8 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
+                this.persistViewContext();
+                this.restoreViewContext({ force: true });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -4778,6 +4795,92 @@
                     console.warn('Failed to persist last folder:', error);
                 }
                 Folders.updateLastFolderBanner();
+            },
+            persistViewContext() {
+                if (!state.currentFolder?.id || !state.providerType) {
+                    return;
+                }
+                const currentStackArray = state.stacks[state.currentStack] || [];
+                const currentFile = currentStackArray[state.currentStackPosition] || null;
+                const payload = {
+                    providerType: state.providerType,
+                    folderId: state.currentFolder.id,
+                    folderName: state.currentFolder.name || '',
+                    stack: state.currentStack || 'in',
+                    position: Number.isFinite(state.currentStackPosition) ? state.currentStackPosition : 0,
+                    fileId: currentFile?.id || null,
+                    isFocusMode: Boolean(state.isFocusMode),
+                    savedAt: new Date().toISOString()
+                };
+                state.lastViewContext = payload;
+                try {
+                    localStorage.setItem(VIEW_CONTEXT_STORAGE_KEY, JSON.stringify(payload));
+                } catch (error) {
+                    console.warn('Failed to persist view context:', error);
+                }
+            },
+            async restoreViewContext(options = {}) {
+                const { force = false } = options;
+                const persisted = state.lastViewContext || loadViewContextFromStorage();
+                if (!persisted) return false;
+                if (!state.currentFolder?.id || !state.providerType) return false;
+                if (persisted.providerType !== state.providerType || persisted.folderId !== state.currentFolder.id) return false;
+
+                const targetStack = STACKS.includes(persisted.stack) ? persisted.stack : state.currentStack;
+                const stackArray = state.stacks[targetStack] || [];
+                if (!Array.isArray(stackArray) || stackArray.length === 0) return false;
+
+                let targetIndex = -1;
+                if (persisted.fileId) {
+                    targetIndex = stackArray.findIndex(file => file.id === persisted.fileId);
+                }
+                if (targetIndex === -1) {
+                    const fallback = Number.isFinite(persisted.position) ? persisted.position : 0;
+                    targetIndex = Math.max(0, Math.min(fallback, stackArray.length - 1));
+                }
+
+                const stackChanged = state.currentStack !== targetStack;
+                const indexChanged = state.currentStackPosition !== targetIndex;
+                if (!force && !stackChanged && !indexChanged) {
+                    return true;
+                }
+
+                state.currentStack = targetStack;
+                state.currentStackPosition = targetIndex;
+
+                try {
+                    await Core.displayCurrentImage();
+                    Core.updateImageCounters();
+                    Core.updateStackCounts();
+                } catch (error) {
+                    console.warn('Failed to restore persisted view context:', error);
+                    return false;
+                }
+                return true;
+            },
+            registerViewPersistenceLifecycle() {
+                if (this._viewPersistenceLifecycleRegistered) {
+                    return;
+                }
+                const persist = () => this.persistViewContext();
+                const restore = () => {
+                    if (document.visibilityState === 'visible') {
+                        this.restoreViewContext({ force: true });
+                    }
+                };
+
+                document.addEventListener('visibilitychange', () => {
+                    if (document.visibilityState === 'hidden') {
+                        persist();
+                        return;
+                    }
+                    restore();
+                });
+                window.addEventListener('focus', restore);
+                window.addEventListener('blur', persist);
+                window.addEventListener('pagehide', persist);
+                window.addEventListener('beforeunload', persist);
+                this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {
                 if (state.isReturningToFolders) {
@@ -7450,6 +7553,7 @@ this.updateImageCounters();
                 Events.init();
                 Gestures.init();
                 Core.updateActiveProxTab();
+                App.registerViewPersistenceLifecycle();
             } catch (error) {
                 console.error("Fatal initialization error:", error);
                 const body = document.body;

--- a/ui.html
+++ b/ui.html
@@ -1157,6 +1157,7 @@
         const SHARE_URL_TEMPLATE = "https://drive.google.com/file/d/${fileId}/view?usp=sharing";
         const STACK_NAMES = { 'in': 'Inbox', 'out': 'Maybe', 'priority': 'Keep', 'trash': 'Recycle' };
         const LAST_FOLDER_STORAGE_KEY = 'orbital8_last_folder';
+        const VIEW_CONTEXT_STORAGE_KEY = 'orbital8_view_context';
         const loadLastFolderFromStorage = () => {
             try {
                 const raw = localStorage.getItem(LAST_FOLDER_STORAGE_KEY);
@@ -1167,6 +1168,19 @@
                 }
             } catch (error) {
                 console.warn('Failed to load last folder from storage:', error);
+            }
+            return null;
+        };
+        const loadViewContextFromStorage = () => {
+            try {
+                const raw = localStorage.getItem(VIEW_CONTEXT_STORAGE_KEY);
+                if (!raw) return null;
+                const parsed = JSON.parse(raw);
+                if (parsed && parsed.folderId && parsed.providerType) {
+                    return parsed;
+                }
+            } catch (error) {
+                console.warn('Failed to load view context from storage:', error);
             }
             return null;
         };
@@ -1198,6 +1212,7 @@
             isImageTransitioning: false,
             showDebugToasts: true,
             lastPickedFolder: loadLastFolderFromStorage(),
+            lastViewContext: loadViewContextFromStorage(),
             folderSearchDataset: [],
             folderSearchTerm: '',
             storageStatus: { available: true, reason: null }
@@ -5005,6 +5020,8 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
+                this.persistViewContext();
+                this.restoreViewContext({ force: true });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -5039,6 +5056,92 @@
                     console.warn('Failed to persist last folder:', error);
                 }
                 Folders.updateLastFolderBanner();
+            },
+            persistViewContext() {
+                if (!state.currentFolder?.id || !state.providerType) {
+                    return;
+                }
+                const currentStackArray = state.stacks[state.currentStack] || [];
+                const currentFile = currentStackArray[state.currentStackPosition] || null;
+                const payload = {
+                    providerType: state.providerType,
+                    folderId: state.currentFolder.id,
+                    folderName: state.currentFolder.name || '',
+                    stack: state.currentStack || 'in',
+                    position: Number.isFinite(state.currentStackPosition) ? state.currentStackPosition : 0,
+                    fileId: currentFile?.id || null,
+                    isFocusMode: Boolean(state.isFocusMode),
+                    savedAt: new Date().toISOString()
+                };
+                state.lastViewContext = payload;
+                try {
+                    localStorage.setItem(VIEW_CONTEXT_STORAGE_KEY, JSON.stringify(payload));
+                } catch (error) {
+                    console.warn('Failed to persist view context:', error);
+                }
+            },
+            async restoreViewContext(options = {}) {
+                const { force = false } = options;
+                const persisted = state.lastViewContext || loadViewContextFromStorage();
+                if (!persisted) return false;
+                if (!state.currentFolder?.id || !state.providerType) return false;
+                if (persisted.providerType !== state.providerType || persisted.folderId !== state.currentFolder.id) return false;
+
+                const targetStack = STACKS.includes(persisted.stack) ? persisted.stack : state.currentStack;
+                const stackArray = state.stacks[targetStack] || [];
+                if (!Array.isArray(stackArray) || stackArray.length === 0) return false;
+
+                let targetIndex = -1;
+                if (persisted.fileId) {
+                    targetIndex = stackArray.findIndex(file => file.id === persisted.fileId);
+                }
+                if (targetIndex === -1) {
+                    const fallback = Number.isFinite(persisted.position) ? persisted.position : 0;
+                    targetIndex = Math.max(0, Math.min(fallback, stackArray.length - 1));
+                }
+
+                const stackChanged = state.currentStack !== targetStack;
+                const indexChanged = state.currentStackPosition !== targetIndex;
+                if (!force && !stackChanged && !indexChanged) {
+                    return true;
+                }
+
+                state.currentStack = targetStack;
+                state.currentStackPosition = targetIndex;
+
+                try {
+                    await Core.displayCurrentImage();
+                    Core.updateImageCounters();
+                    Core.updateStackCounts();
+                } catch (error) {
+                    console.warn('Failed to restore persisted view context:', error);
+                    return false;
+                }
+                return true;
+            },
+            registerViewPersistenceLifecycle() {
+                if (this._viewPersistenceLifecycleRegistered) {
+                    return;
+                }
+                const persist = () => this.persistViewContext();
+                const restore = () => {
+                    if (document.visibilityState === 'visible') {
+                        this.restoreViewContext({ force: true });
+                    }
+                };
+
+                document.addEventListener('visibilitychange', () => {
+                    if (document.visibilityState === 'hidden') {
+                        persist();
+                        return;
+                    }
+                    restore();
+                });
+                window.addEventListener('focus', restore);
+                window.addEventListener('blur', persist);
+                window.addEventListener('pagehide', persist);
+                window.addEventListener('beforeunload', persist);
+                this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {
                 if (state.isReturningToFolders) {
@@ -8050,6 +8153,7 @@ this.updateImageCounters();
                 Events.init();
                 Gestures.init();
                 Core.updateActiveProxTab();
+                App.registerViewPersistenceLifecycle();
             } catch (error) {
                 console.error("Fatal initialization error:", error);
                 const body = document.body;


### PR DESCRIPTION
### Motivation

- Ensure the UI restores the same folder, stack, selected image and focus state when the user returns to the app tab or refocuses the window. 
- Avoid losing the current view after `visibilitychange` / `focus` / `blur` events so workflows (e.g., reviewing images) are uninterrupted.

### Description

- Added a view-context storage key and loader: `VIEW_CONTEXT_STORAGE_KEY` and `loadViewContextFromStorage` to read persisted view context from `localStorage` across the main `ui*.html` variants. 
- Extended runtime state with `lastViewContext` and new APIs on the app object: `persistViewContext()`, `restoreViewContext(options = {})`, and `registerViewPersistenceLifecycle()` to save and restore `providerType`, `folderId`, `folderName`, active `stack`, `position` (index), `fileId`, and `isFocusMode`. 
- Wire persistence into lifecycle and UI flow by calling `persistViewContext()` from `switchToCommonUI()` (so folder switch persists view) and by registering lifecycle listeners during app startup (`DOMContentLoaded`) to handle `visibilitychange`, `focus`, `blur`, `pagehide`, and `beforeunload`. 
- Applied these changes across the following UI variants: `ui.html`, `ui-open.html`, `ui-v1.html`, `ui-v2.html`, `ui-v3.html`, `ui-v5.html`, `ui-v6.html`, `ui-v7.html`, `ui-v8.html`, `ui-v9.html`, `ui-v9a.html`, `ui-v9b.html`, and `ui-v10.html` (added storage key, loader, state entry, persistence methods, lifecycle registration, and init hook). 

### Testing

- Ran a repository check script using `python` to verify each updated `ui*.html` contains the required tokens (`VIEW_CONTEXT_STORAGE_KEY`, `loadViewContextFromStorage`, `persistViewContext()`, `restoreViewContext(options = {})`, `registerViewPersistenceLifecycle()`, and `App.registerViewPersistenceLifecycle();`) and all files reported `OK`.
- Used `rg` searches to confirm lifecycle listeners and persistence calls are present in each modified file and inspected diffs (`git diff --stat`) to verify changes were limited to the target `ui*.html` files.
- All automated verification checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3b8764d18832d87c3e61f5cd7a11c)