### PR TITLE
Fix auth refresh, loading UX, background indicator, and metadata persistence

### DIFF
--- a/pic-v1-curate-engine.js
+++ b/pic-v1-curate-engine.js
@@ -113,7 +113,7 @@ const App = {
                 this.switchToCommonUI(); Core.initializeStacks(); Core.showEmptyState(); Core.updateStackCounts();
                 Utils.showToast('No images found in this folder', 'info', true); return true;
             }
-            for (const uid of updatedIds) { const uf = mergedFiles.find(f => f.id === uid); if (uf) await state.dbManager.saveMetadata(uid, uf, { folderId, providerType: state.providerType }); }
+            for (const uid of updatedIds) { const uf = mergedFiles.find(f => f.id === uid); if (uf) { const existing = await state.dbManager.getMetadata(uid); if (existing) ['extractedMetadata','metadataStatus','prompt','negativePrompt','model','seed','steps','cfgScale','sampler','stack','tags','notes','qualityRating','contentRating','favorite','stackSequence','lastUpdated','localUpdatedAt'].forEach(field => { if (existing[field] !== undefined) uf[field] = existing[field]; }); await state.dbManager.saveMetadata(uid, uf, { folderId, providerType: state.providerType }); } }
             if (removedIds.length > 0) await Promise.all(removedIds.map(id => state.dbManager.deleteMetadata(id)));
             state.imageFiles = mergedFiles;
             const remaining = await this.prepareFolderForFirstPaint(state.imageFiles, { navigationToken });
@@ -126,13 +126,14 @@ const App = {
         } catch(e) { if (e.name !== 'AbortError') Utils.showToast(`Error loading images: ${e.message}`, 'error', true); this.returnToFolderSelection(); }
     },
     async refreshFolderInBackground() {
+        Utils.beginBackgroundActivity('Refreshing folder');
         try {
             const navigationToken = state.navigationToken; const folderId = state.currentFolder.id;
             const cachedFiles = await state.dbManager.getFolderCache(folderId) || [];
             const result = await state.provider.getFilesAndMetadata(folderId);
             const { mergedFiles, updatedIds, removedIds, hasChanges } = this.mergeCloudWithCache(result.files || [], cachedFiles);
             if (!hasChanges) return;
-            for (const uid of updatedIds) { const uf = mergedFiles.find(f => f.id === uid); if (uf) await state.dbManager.saveMetadata(uid, uf, { folderId, providerType: state.providerType }); }
+            for (const uid of updatedIds) { const uf = mergedFiles.find(f => f.id === uid); if (uf) { const existing = await state.dbManager.getMetadata(uid); if (existing) ['extractedMetadata','metadataStatus','prompt','negativePrompt','model','seed','steps','cfgScale','sampler','stack','tags','notes','qualityRating','contentRating','favorite','stackSequence','lastUpdated','localUpdatedAt'].forEach(field => { if (existing[field] !== undefined) uf[field] = existing[field]; }); await state.dbManager.saveMetadata(uid, uf, { folderId, providerType: state.providerType }); } }
             if (removedIds.length > 0) await Promise.all(removedIds.map(id => state.dbManager.deleteMetadata(id)));
             await this.processAllMetadata(mergedFiles, false, { navigationToken });
             if (!this.isNavigationActive(navigationToken)) return;
@@ -141,17 +142,24 @@ const App = {
             if (state.imageFiles.length > 0) Core.displayCurrentImage(); else Core.showEmptyState();
             Utils.showToast('Folder updated in background', 'info');
         } catch(e) { console.warn('Background refresh failed:', e.message); }
+        finally { Utils.endBackgroundActivity('Refreshing folder'); }
     },
     async processAllMetadata(files, isFirstLoad = false, options = {}) {
         const { navigationToken = null } = options;
         if (isFirstLoad) Utils.updateLoadingProgress(0, files.length, 'Processing files...');
-        for (let i = 0; i < files.length; i++) {
-            if (navigationToken && !this.isNavigationActive(navigationToken)) return;
-            const file = files[i];
-            try { const metadata = await state.dbManager.getMetadata(file.id); if (metadata) Object.assign(file, metadata); else { const dm = this.generateDefaultMetadata(file, { index: i, total: files.length }); Object.assign(file, dm); await state.dbManager.saveMetadata(file.id, dm, { folderId: state.currentFolder.id, providerType: state.providerType }); } } catch(e) { console.error(`Failed to process metadata for ${file.name}:`, e); }
-            if (isFirstLoad) Utils.updateLoadingProgress(i + 1, files.length);
+        const showBackgroundIndicator = !isFirstLoad && files.length > 0;
+        if (showBackgroundIndicator) Utils.beginBackgroundActivity('Loading file records');
+        try {
+            for (let i = 0; i < files.length; i++) {
+                if (navigationToken && !this.isNavigationActive(navigationToken)) return;
+                const file = files[i];
+                try { const metadata = await state.dbManager.getMetadata(file.id); if (metadata) Object.assign(file, metadata); else { const dm = this.generateDefaultMetadata(file, { index: i, total: files.length }); Object.assign(file, dm); await state.dbManager.saveMetadata(file.id, dm, { folderId: state.currentFolder.id, providerType: state.providerType }); } } catch(e) { console.error(`Failed to process metadata for ${file.name}:`, e); }
+                if (isFirstLoad) Utils.updateLoadingProgress(i + 1, files.length);
+            }
+            if (!navigationToken || this.isNavigationActive(navigationToken)) this.extractMetadataInBackground(files.filter(f => f.mimeType === 'image/png'));
+        } finally {
+            if (showBackgroundIndicator) Utils.endBackgroundActivity('Loading file records');
         }
-        if (!navigationToken || this.isNavigationActive(navigationToken)) this.extractMetadataInBackground(files.filter(f => f.mimeType === 'image/png'));
     },
     generateDefaultMetadata(file, context = {}) {
         const bm = { stack: 'in', tags: [], qualityRating: 0, contentRating: 0, notes: '', stackSequence: 0, favorite: false, extractedMetadata: {}, metadataStatus: 'pending' };
@@ -223,7 +231,7 @@ const App = {
         try { const cf = await state.dbManager.getFolderCache(folderId) || []; await state.dbManager.clearFolderData({ providerType: state.providerType, folderId }, cf.map(f => f.id)); await state.folderSyncCoordinator?.markRequiresFullResync(folderId, 'user-reset'); state.sessionVisitedFolders.delete(`${state.providerType||'unknown'}::${folderId}`); Utils.showToast('Folder cache cleared. Resyncing...', 'info'); const nt = Symbol('navigation'); state.navigationToken = nt; await this.loadImages({ forceFullResync: true, navigationToken: nt }); }
         catch(e) { Utils.showToast(`Reset failed: ${e.message}`, 'error', true); }
     },
-    async extractMetadataInBackground(pngFiles) { const BS = 5; for (let i = 0; i < pngFiles.length; i += BS) { if (state.activeRequests.signal.aborted) return; await Promise.allSettled(pngFiles.slice(i, i+BS).map(f => (f.metadataStatus === 'pending' || f.metadataStatus === 'queued') ? this.processFileMetadata(f) : Promise.resolve())); } },
+    async extractMetadataInBackground(pngFiles) { const pending = pngFiles.filter(f => f.metadataStatus === 'pending' || f.metadataStatus === 'queued'); if (pending.length === 0) return; const BS = 5; let completed = false; Utils.beginBackgroundActivity('Extracting metadata'); try { for (let i = 0; i < pending.length; i += BS) { if (state.activeRequests.signal.aborted) return; await Promise.allSettled(pending.slice(i, i+BS).map(f => this.processFileMetadata(f))); } completed = true; } finally { if (completed && state.currentFolder?.id && Array.isArray(state.imageFiles)) state.dbManager.scheduleFolderCacheSave(state.currentFolder.id, state.imageFiles, { priority: 'normal' }); Utils.endBackgroundActivity('Extracting metadata'); } },
     async processFileMetadata(file) {
         if (['loaded','loading','error'].includes(file.metadataStatus)) return;
         file.metadataStatus = 'loading';

--- a/pic-v1-curate-foundation.js
+++ b/pic-v1-curate-foundation.js
@@ -37,7 +37,7 @@ const state = {
     grid: { stack: null, selected: [], filtered: [], isDirty: false, isDragging: false,
         dragSession: createDefaultGridDragSession(), skipReorderOnClose: false,
         lazyLoadState: { allFiles: [], renderedCount: 0, observer: null, batchSize: 20 } },
-    tags: new Set(), loadingProgress: { current: 0, total: 0 },
+    tags: new Set(), loadingProgress: { current: 0, total: 0, offset: 0, phase: '' }, backgroundActivityCount: 0,
     folderMoveMode: { active: false, files: [] },
     isReturningToFolders: false, navigationToken: null, activeRequests: new AbortController(),
     sessionVisitedFolders: new Set(), isImageTransitioning: false, showDebugToasts: true,
@@ -129,7 +129,7 @@ const Utils = {
             toast: document.getElementById('toast'), centerTrashBtn: document.getElementById('center-trash-btn'),
             focusStackName: document.getElementById('focus-stack-name'), focusImageCount: document.getElementById('focus-image-count'), normalImageCount: document.getElementById('normal-image-count'),
             focusDeleteBtn: document.getElementById('focus-delete-btn'), focusFavoriteBtn: document.getElementById('focus-favorite-btn'), focusFavoriteIcon: document.getElementById('focus-favorite-icon'),
-            loadingCounter: document.getElementById('loading-counter'), loadingMessage: document.getElementById('loading-message'), loadingProgressBar: document.getElementById('loading-progress-bar'), cancelLoading: document.getElementById('cancel-loading'),
+            loadingCounter: document.getElementById('loading-counter'), loadingPhase: document.getElementById('loading-phase'), loadingMessage: document.getElementById('loading-message'), loadingProgressBar: document.getElementById('loading-progress-bar'), backgroundActivity: document.getElementById('background-activity'), backgroundActivityLabel: document.getElementById('background-activity-label'), cancelLoading: document.getElementById('cancel-loading'),
             edgeTop: document.getElementById('edge-top'), edgeBottom: document.getElementById('edge-bottom'), edgeLeft: document.getElementById('edge-left'), edgeRight: document.getElementById('edge-right'),
             gestureLayer: document.getElementById('gesture-layer'), gestureScreenA: document.getElementById('gesture-screen-a'), gestureScreenB: document.getElementById('gesture-screen-b'),
             gestureTriUp: document.getElementById('gesture-tri-up'), gestureTriRight: document.getElementById('gesture-tri-right'), gestureTriDown: document.getElementById('gesture-tri-down'), gestureTriLeft: document.getElementById('gesture-tri-left'),
@@ -151,7 +151,7 @@ const Utils = {
             qualityRating: document.getElementById('quality-rating'), contentRating: document.getElementById('content-rating'), metadataTable: document.getElementById('metadata-table')
         };
     },
-    showScreen(screenId) { ['provider-screen','auth-screen','folder-screen','loading-screen','app-container'].forEach(id => { const s = document.getElementById(id); if (s) s.classList.toggle('hidden', id !== screenId); }); },
+    showScreen(screenId) { if (screenId === 'loading-screen' && state.currentScreen !== 'loading-screen') state.loadingProgress = { current: 0, total: 0, offset: 0, phase: '', displayCurrent: 0, displayTotal: 0 }; state.currentScreen = screenId; ['provider-screen','auth-screen','folder-screen','loading-screen','app-container'].forEach(id => { const s = document.getElementById(id); if (s) s.classList.toggle('hidden', id !== screenId); }); },
     showModal(id) { document.getElementById(id).classList.remove('hidden'); },
     hideModal(id) { document.getElementById(id).classList.add('hidden'); },
     showToast(message, type = 'success', important = false) {
@@ -177,11 +177,20 @@ const Utils = {
     getFallbackImageUrl(file) { if (state.providerType === 'googledrive') { const u = DriveLinkHelper.resolveAssetUrls(file); return u.thumbnailUrlSmall || u.thumbnailUrl || u.imageUrl; } else { return file.downloadUrl || `https://graph.microsoft.com/v1.0/me/drive/items/${file.id}/content`; } },
     defer(callback, options = {}) { const { priority = 'normal', timeout = 120 } = options; const run = () => { try { const r = callback(); if (r && typeof r.then === 'function') r.catch(e => console.error('Deferred task failed', e)); } catch(e) { console.error('Deferred task failed', e); } }; if (priority === 'animation' && typeof requestAnimationFrame === 'function') { requestAnimationFrame(run); return; } if (typeof requestIdleCallback === 'function') { requestIdleCallback(run, { timeout: priority === 'high' ? Math.min(timeout,48) : timeout }); } else { setTimeout(run, priority === 'high' ? 0 : priority === 'animation' ? 16 : 32); } },
     formatFileSize(bytes) { if (bytes === 0) return '0 Bytes'; const k = 1024; const sizes = ['Bytes','KB','MB','GB']; const i = Math.floor(Math.log(bytes)/Math.log(k)); return parseFloat((bytes/Math.pow(k,i)).toFixed(2)) + ' ' + sizes[i]; },
+    beginBackgroundActivity(label = 'Background processing') { state.backgroundActivityCount = (state.backgroundActivityCount || 0) + 1; this.updateBackgroundActivity(label); },
+    endBackgroundActivity(label = 'Background processing') { state.backgroundActivityCount = Math.max(0, (state.backgroundActivityCount || 0) - 1); this.updateBackgroundActivity(label); },
+    updateBackgroundActivity(label = 'Background processing') { const el = this.elements?.backgroundActivity; if (!el) return; const active = (state.backgroundActivityCount || 0) > 0; el.classList.toggle('hidden', !active); if (this.elements.backgroundActivityLabel) this.elements.backgroundActivityLabel.textContent = active && state.backgroundActivityCount > 1 ? `${label} (${state.backgroundActivityCount})` : label; },
     updateLoadingProgress(current, total, message = '') {
-        state.loadingProgress = { current, total };
-        this.elements.loadingCounter.textContent = current;
-        this.elements.loadingMessage.textContent = message || (total ? `Processing ${current} of ${total} items...` : `Found ${current} items`);
-        if (total > 0) { this.elements.loadingProgressBar.style.width = `${(current/total)*100}%`; }
-        else { this.elements.loadingProgressBar.style.width = `${current > 0 ? Math.min(88, 12+((current%12)*6)) : 8}%`; }
+        const normalizedCurrent = Number(current) || 0; const normalizedTotal = Number(total) || 0;
+        const phase = /process|metadata/i.test(message) ? 'Loading metadata...' : /compar|ready|almost/i.test(message) ? 'Almost ready...' : 'Discovering files...';
+        const previous = state.loadingProgress || { current: 0, total: 0, offset: 0, phase: '', displayCurrent: 0 };
+        let offset = previous.offset || 0;
+        if (previous.phase && phase !== previous.phase && normalizedCurrent < (previous.current || 0)) offset = previous.displayCurrent || previous.current || 0;
+        const displayCurrent = normalizedCurrent + offset; const displayTotal = normalizedTotal > 0 ? Math.max(normalizedTotal + offset, displayCurrent) : 0;
+        state.loadingProgress = { current: normalizedCurrent, total: normalizedTotal, offset, phase, displayCurrent, displayTotal };
+        this.elements.loadingCounter.textContent = displayCurrent; if (this.elements.loadingPhase) this.elements.loadingPhase.textContent = phase;
+        this.elements.loadingMessage.textContent = message || (displayTotal ? `Processing ${displayCurrent} of ${displayTotal} items...` : `Found ${displayCurrent} items`);
+        if (displayTotal > 0) { this.elements.loadingProgressBar.style.width = `${(displayCurrent/displayTotal)*100}%`; }
+        else { this.elements.loadingProgressBar.style.width = `${displayCurrent > 0 ? Math.min(88, 12+((displayCurrent%12)*6)) : 8}%`; }
     }
 };

--- a/pic-v1-providers.js
+++ b/pic-v1-providers.js
@@ -94,13 +94,20 @@ class GoogleDriveProvider extends BaseProvider {
         this.accessToken = tokens.access_token; this.refreshToken = tokens.refresh_token; this.storeCredentials();
         this.bindSharedFolderCaches({ previousKey: prev, clearPrevious: true });
     }
-    async refreshAccessToken() { if (!this.refreshToken || !this.clientSecret) throw new Error('No refresh token'); const r = await fetch('https://oauth2.googleapis.com/token', { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body: new URLSearchParams({ client_id: this.clientId, client_secret: this.clientSecret, refresh_token: this.refreshToken, grant_type: 'refresh_token' }) }); if (!r.ok) throw new Error('Failed to refresh token'); const t = await r.json(); this.accessToken = t.access_token; this.storeCredentials(); return this.accessToken; }
+    async refreshAccessToken() {
+        if (!this.refreshToken || !this.clientSecret) throw new Error('No refresh token');
+        let r;
+        try { r = await fetch('https://oauth2.googleapis.com/token', { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body: new URLSearchParams({ client_id: this.clientId, client_secret: this.clientSecret, refresh_token: this.refreshToken, grant_type: 'refresh_token' }) }); }
+        catch (e) { e.networkError = true; throw e; }
+        if (!r.ok) { const e = new Error('Failed to refresh token'); if (r.status === 400 || r.status === 401) e.tokenRevoked = true; else if (r.status >= 500) e.networkError = true; throw e; }
+        const t = await r.json(); this.accessToken = t.access_token; this.storeCredentials(); return this.accessToken;
+    }
     async makeApiCall(endpoint, options = {}, isJson = true) {
         if (!this.accessToken) throw new Error('Not authenticated');
         let url; if (endpoint.startsWith('https://')) url = endpoint; else if (endpoint.startsWith('/upload/drive/')) url = `https://www.googleapis.com${endpoint}`; else url = `${this.apiBase}${endpoint}`;
         const headers = { 'Authorization': `Bearer ${this.accessToken}`, ...options.headers }; if (isJson) headers['Content-Type'] = 'application/json';
         let response = await fetch(url, { ...options, headers });
-        if (response.status === 401 && this.refreshToken && this.clientSecret) { try { await this.refreshAccessToken(); headers['Authorization'] = `Bearer ${this.accessToken}`; response = await fetch(url, { ...options, headers }); } catch(e) { this.isAuthenticated = false; this.clearStoredCredentials(); throw new Error('Authentication expired.'); } }
+        if (response.status === 401 && this.refreshToken && this.clientSecret) { try { await this.refreshAccessToken(); headers['Authorization'] = `Bearer ${this.accessToken}`; response = await fetch(url, { ...options, headers }); } catch(e) { if (e?.tokenRevoked) { this.isAuthenticated = false; this.clearStoredCredentials(); throw new Error('Authentication expired.'); } const err = new Error('Network error during token refresh. Please try again.'); err.networkError = Boolean(e?.networkError); throw err; } }
         if (!response.ok) { const t = await response.text(); throw new Error(`API call failed: ${response.status} ${response.statusText} - ${t}`); }
         if (isJson) return await response.json(); return response;
     }

--- a/pic-v1.html
+++ b/pic-v1.html
@@ -154,11 +154,16 @@
         @keyframes spin { to { transform: rotate(360deg); } }
 
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0,0,0,0.8); }
+        .loading-phase { color: var(--accent); font-size: 13px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 8px; }
         .loading-message { color: rgba(255,255,255,0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255,255,255,0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
 
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
+        .background-activity { position: fixed; top: 14px; left: 50%; transform: translateX(-50%); z-index: 20; display: flex; align-items: center; gap: 8px; padding: 6px 12px; border-radius: 999px; background: rgba(17,24,39,0.82); color: rgba(255,255,255,0.86); font-size: 12px; border: 1px solid rgba(245,158,11,0.35); pointer-events: none; transition: opacity 0.2s ease; }
+        .background-activity.hidden { display: none; }
+        .background-activity-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); animation: backgroundPulse 1.2s ease-in-out infinite; }
+        @keyframes backgroundPulse { 0%,100% { opacity: 0.35; transform: scale(0.85); } 50% { opacity: 1; transform: scale(1.15); } }
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image { max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain; user-select: none; pointer-events: none; transition: all 0.3s cubic-bezier(0.25,0.46,0.45,0.94), opacity 0.2s ease; transform-origin: center center; cursor: grab; }
         .center-image.dragging { filter: brightness(0.9); cursor: grabbing; }
@@ -406,6 +411,7 @@
         <div class="card">
             <h2 class="title">Loading Images</h2>
             <div class="loading-counter" id="loading-counter">0</div>
+            <div class="loading-phase" id="loading-phase">Discovering files...</div>
             <div class="loading-message" id="loading-message">Processing files...</div>
             <div class="loading-progress"><div class="loading-progress-bar" id="loading-progress-bar"></div></div>
             <button class="button" id="cancel-loading" style="background:rgba(239,68,68,0.8);margin-top:16px">Cancel</button>
@@ -415,6 +421,7 @@
 
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
+        <div class="background-activity hidden" id="background-activity"><span class="background-activity-dot"></span><span id="background-activity-label">Background processing</span></div>
         <button class="ui-button" id="back-button"><span id="back-button-spinner" class="spinner" style="display:none;width:14px;height:14px;margin-right:6px"></span>Folders</button>
         <button class="ui-button" id="details-button">Details</button>
 

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -386,11 +386,16 @@
         @keyframes spin { to { transform: rotate(360deg); } }
 
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
+        .loading-phase { color: var(--accent); font-size: 13px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 8px; }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
 
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
+        .background-activity { position: fixed; top: 14px; left: 50%; transform: translateX(-50%); z-index: 20; display: flex; align-items: center; gap: 8px; padding: 6px 12px; border-radius: 999px; background: rgba(17, 24, 39, 0.82); color: rgba(255, 255, 255, 0.86); font-size: 12px; border: 1px solid rgba(245, 158, 11, 0.35); pointer-events: none; transition: opacity 0.2s ease; }
+        .background-activity.hidden { display: none; }
+        .background-activity-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); animation: backgroundPulse 1.2s ease-in-out infinite; }
+        @keyframes backgroundPulse { 0%, 100% { opacity: 0.35; transform: scale(0.85); } 50% { opacity: 1; transform: scale(1.15); } }
 
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
@@ -1020,6 +1025,7 @@
         <div class="card">
             <h2 class="title">Loading Images</h2>
             <div class="loading-counter" id="loading-counter">0</div>
+            <div class="loading-phase" id="loading-phase">Discovering files...</div>
             <div class="loading-message" id="loading-message">Processing files...</div>
             <div class="loading-progress">
                 <div class="loading-progress-bar" id="loading-progress-bar"></div>
@@ -1033,6 +1039,7 @@
 
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
+        <div class="background-activity hidden" id="background-activity"><span class="background-activity-dot"></span><span id="background-activity-label">Background processing</span></div>
         <button class="ui-button" id="back-button">
             <span id="back-button-spinner" class="spinner" style="display: none; width: 14px; height: 14px; margin-right: 6px;"></span>
             Folders
@@ -1342,7 +1349,7 @@
             grid: { stack: null, selected: [], filtered: [], isDirty: false, isDragging: false,
                 dragSession: createDefaultGridDragSession(), skipReorderOnClose: false,
                 lazyLoadState: { allFiles: [], renderedCount: 0, observer: null, batchSize: 20 } },
-            tags: new Set(), loadingProgress: { current: 0, total: 0 },
+            tags: new Set(), loadingProgress: { current: 0, total: 0, offset: 0, phase: '' }, backgroundActivityCount: 0,
             folderMoveMode: { active: false, files: [] },
             isReturningToFolders: false,
             navigationToken: null,
@@ -1640,8 +1647,11 @@
                     focusFavoriteIcon: document.getElementById('focus-favorite-icon'),
 
                     loadingCounter: document.getElementById('loading-counter'),
+                    loadingPhase: document.getElementById('loading-phase'),
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
+                    backgroundActivity: document.getElementById('background-activity'),
+                    backgroundActivityLabel: document.getElementById('background-activity-label'),
                     cancelLoading: document.getElementById('cancel-loading'),
 
                     edgeTop: document.getElementById('edge-top'),
@@ -1713,6 +1723,10 @@
             },
 
             showScreen(screenId) {
+                if (screenId === 'loading-screen' && state.currentScreen !== 'loading-screen') {
+                    state.loadingProgress = { current: 0, total: 0, offset: 0, phase: '', displayCurrent: 0, displayTotal: 0 };
+                }
+                state.currentScreen = screenId;
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
                     const screen = document.getElementById(id);
@@ -1850,17 +1864,56 @@
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
 
+            beginBackgroundActivity(label = 'Background processing') {
+                state.backgroundActivityCount = (state.backgroundActivityCount || 0) + 1;
+                this.updateBackgroundActivity(label);
+            },
+
+            endBackgroundActivity(label = 'Background processing') {
+                state.backgroundActivityCount = Math.max(0, (state.backgroundActivityCount || 0) - 1);
+                this.updateBackgroundActivity(label);
+            },
+
+            updateBackgroundActivity(label = 'Background processing') {
+                const indicator = this.elements?.backgroundActivity;
+                if (!indicator) return;
+                const active = (state.backgroundActivityCount || 0) > 0;
+                indicator.classList.toggle('hidden', !active);
+                if (this.elements.backgroundActivityLabel) {
+                    this.elements.backgroundActivityLabel.textContent = active && state.backgroundActivityCount > 1
+                        ? `${label} (${state.backgroundActivityCount})`
+                        : label;
+                }
+            },
+
             updateLoadingProgress(current, total, message = '') {
-                state.loadingProgress = { current, total };
-                this.elements.loadingCounter.textContent = current;
-                this.elements.loadingMessage.textContent = message || (total ?
-                    `Processing ${current} of ${total} items...` :
-                    `Found ${current} items`);
-                if (total > 0) {
-                    const percentage = (current / total) * 100;
+                const normalizedCurrent = Number(current) || 0;
+                const normalizedTotal = Number(total) || 0;
+                const phase = /process|metadata/i.test(message)
+                    ? 'Loading metadata...'
+                    : /compar|ready|almost/i.test(message)
+                        ? 'Almost ready...'
+                        : 'Discovering files...';
+                const previous = state.loadingProgress || { current: 0, total: 0, offset: 0, phase: '', displayCurrent: 0 };
+                let offset = previous.offset || 0;
+                if (previous.phase && phase !== previous.phase && normalizedCurrent < (previous.current || 0)) {
+                    offset = previous.displayCurrent || previous.current || 0;
+                }
+                const displayCurrent = normalizedCurrent + offset;
+                const displayTotal = normalizedTotal > 0 ? Math.max(normalizedTotal + offset, displayCurrent) : 0;
+                state.loadingProgress = { current: normalizedCurrent, total: normalizedTotal, offset, phase, displayCurrent, displayTotal };
+                this.elements.loadingCounter.textContent = displayCurrent;
+                if (this.elements.loadingPhase) {
+                    this.elements.loadingPhase.textContent = phase;
+                }
+                this.elements.loadingMessage.textContent = message || (displayTotal ?
+                    `Processing ${displayCurrent} of ${displayTotal} items...` :
+                    `Found ${displayCurrent} items`);
+                if (displayTotal > 0) {
+                    const percentage = (displayCurrent / displayTotal) * 100;
                     this.elements.loadingProgressBar.style.width = `${percentage}%`;
                 } else {
-                    const pulse = current > 0 ? Math.min(88, 12 + ((current % 12) * 6)) : 8;
+                    const pulse = displayCurrent > 0 ? Math.min(88, 12 + ((displayCurrent % 12) * 6)) : 8;
                     this.elements.loadingProgressBar.style.width = `${pulse}%`;
                 }
             }
@@ -4113,11 +4166,25 @@
             }
             async refreshAccessToken() {
                 if (!this.refreshToken || !this.clientSecret) { throw new Error('No refresh token or client secret available'); }
-                const response = await fetch('https://oauth2.googleapis.com/token', {
-                    method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                    body: new URLSearchParams({ client_id: this.clientId, client_secret: this.clientSecret, refresh_token: this.refreshToken, grant_type: 'refresh_token' })
-                });
-                if (!response.ok) { throw new Error('Failed to refresh access token'); }
+                let response;
+                try {
+                    response = await fetch('https://oauth2.googleapis.com/token', {
+                        method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                        body: new URLSearchParams({ client_id: this.clientId, client_secret: this.clientSecret, refresh_token: this.refreshToken, grant_type: 'refresh_token' })
+                    });
+                } catch (fetchError) {
+                    fetchError.networkError = true;
+                    throw fetchError;
+                }
+                if (!response.ok) {
+                    const error = new Error('Failed to refresh access token');
+                    if (response.status === 400 || response.status === 401) {
+                        error.tokenRevoked = true;
+                    } else if (response.status >= 500) {
+                        error.networkError = true;
+                    }
+                    throw error;
+                }
                 const tokens = await response.json(); this.accessToken = tokens.access_token; this.storeCredentials(); return this.accessToken;
             }
             async makeApiCall(endpoint, options = {}, isJson = true) {
@@ -4138,7 +4205,16 @@
                         await this.refreshAccessToken();
                         headers['Authorization'] = `Bearer ${this.accessToken}`;
                         response = await fetch(url, { ...options, headers });
-                    } catch (refreshError) { this.isAuthenticated = false; this.clearStoredCredentials(); throw new Error('Authentication expired. Please reconnect.'); }
+                    } catch (refreshError) {
+                        if (refreshError?.tokenRevoked) {
+                            this.isAuthenticated = false;
+                            this.clearStoredCredentials();
+                            throw new Error('Authentication expired. Please reconnect.');
+                        }
+                        const error = new Error('Network error during token refresh. Please try again.');
+                        error.networkError = Boolean(refreshError?.networkError);
+                        throw error;
+                    }
                 }
                 if (!response.ok) { const errorText = await response.text(); throw new Error(`API call failed: ${response.status} ${response.statusText} - ${errorText}`); }
                 if (isJson) { return await response.json(); }
@@ -5450,7 +5526,7 @@
                         options.forceFullResync
                     );
 
-                    const mustRefreshFromCloud = true; // Always refresh to capture latest cloud changes per folder load.
+                    const mustRefreshFromCloud = isFirstSessionVisit || Boolean(options.forceFullResync);
                     const canUseCache = !mustRefreshFromCloud && !shouldFullSync && (preparation?.mode === 'cache' || !coordinator);
 
                     if (!canUseCache) {
@@ -5679,6 +5755,20 @@
                     for (const updatedId of updatedIds) {
                         const updatedFile = mergedFiles.find(file => file.id === updatedId);
                         if (updatedFile) {
+                            const existingMetadata = await state.dbManager.getMetadata(updatedId);
+                            if (existingMetadata) {
+                                const preservedFields = [
+                                    'extractedMetadata', 'metadataStatus', 'prompt', 'negativePrompt',
+                                    'model', 'seed', 'steps', 'cfgScale', 'sampler', 'stack', 'tags',
+                                    'notes', 'qualityRating', 'contentRating', 'favorite', 'stackSequence',
+                                    'lastUpdated', 'localUpdatedAt'
+                                ];
+                                for (const field of preservedFields) {
+                                    if (existingMetadata[field] !== undefined) {
+                                        updatedFile[field] = existingMetadata[field];
+                                    }
+                                }
+                            }
                             await state.dbManager.saveMetadata(updatedId, updatedFile, { folderId, providerType: state.providerType });
                         }
                     }
@@ -5791,6 +5881,7 @@
                 }
             },
             async refreshFolderInBackground() {
+                Utils.beginBackgroundActivity('Refreshing folder');
                 try {
                     const navigationToken = state.navigationToken;
                     const folderId = state.currentFolder.id;
@@ -5806,7 +5897,21 @@
                     for (const updatedId of updatedIds) {
                         const updatedFile = mergedFiles.find(file => file.id === updatedId);
                         if (updatedFile) {
-                        await state.dbManager.saveMetadata(updatedId, updatedFile, { folderId, providerType: state.providerType });
+                            const existingMetadata = await state.dbManager.getMetadata(updatedId);
+                            if (existingMetadata) {
+                                const preservedFields = [
+                                    'extractedMetadata', 'metadataStatus', 'prompt', 'negativePrompt',
+                                    'model', 'seed', 'steps', 'cfgScale', 'sampler', 'stack', 'tags',
+                                    'notes', 'qualityRating', 'contentRating', 'favorite', 'stackSequence',
+                                    'lastUpdated', 'localUpdatedAt'
+                                ];
+                                for (const field of preservedFields) {
+                                    if (existingMetadata[field] !== undefined) {
+                                        updatedFile[field] = existingMetadata[field];
+                                    }
+                                }
+                            }
+                            await state.dbManager.saveMetadata(updatedId, updatedFile, { folderId, providerType: state.providerType });
                         }
                     }
                     if (removedIds.length > 0) {
@@ -5826,11 +5931,16 @@
                     Utils.showToast('Folder updated in background', 'info');
                 } catch (error) {
                     console.warn("Background refresh failed:", error.message);
+                } finally {
+                    Utils.endBackgroundActivity('Refreshing folder');
                 }
             },
             async processAllMetadata(files, isFirstLoad = false, options = {}) {
                  const { navigationToken = null } = options;
                  if (isFirstLoad) Utils.updateLoadingProgress(0, files.length, 'Processing files...');
+                 const showBackgroundIndicator = !isFirstLoad && files.length > 0;
+                 if (showBackgroundIndicator) Utils.beginBackgroundActivity('Loading file records');
+                 try {
                  for (let i = 0; i < files.length; i++) {
                     if (navigationToken && !this.isNavigationActive(navigationToken)) {
                         return;
@@ -5856,6 +5966,9 @@
                 if (!navigationToken || this.isNavigationActive(navigationToken)) {
                     this.extractMetadataInBackground(files.filter(f => f.mimeType === 'image/png'));
                 }
+                 } finally {
+                    if (showBackgroundIndicator) Utils.endBackgroundActivity('Loading file records');
+                 }
             },
             generateDefaultMetadata(file, context = {}) {
                  const baseMetadata = {
@@ -6304,17 +6417,24 @@
                 }
             },
             async extractMetadataInBackground(pngFiles) {
+                const pendingFiles = pngFiles.filter(file => file.metadataStatus === 'pending' || file.metadataStatus === 'queued');
+                if (pendingFiles.length === 0) return;
                 const BATCH_SIZE = 5;
-                for (let i = 0; i < pngFiles.length; i += BATCH_SIZE) {
-                    if (state.activeRequests.signal.aborted) return;
-                    const batch = pngFiles.slice(i, i + BATCH_SIZE);
-                    const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
-                            return this.processFileMetadata(file);
-                        }
-                        return Promise.resolve();
-                    });
-                    await Promise.allSettled(promises);
+                let completed = false;
+                Utils.beginBackgroundActivity('Extracting metadata');
+                try {
+                    for (let i = 0; i < pendingFiles.length; i += BATCH_SIZE) {
+                        if (state.activeRequests.signal.aborted) return;
+                        const batch = pendingFiles.slice(i, i + BATCH_SIZE);
+                        const promises = batch.map(file => this.processFileMetadata(file));
+                        await Promise.allSettled(promises);
+                    }
+                    completed = true;
+                } finally {
+                    if (completed && state.currentFolder?.id && Array.isArray(state.imageFiles)) {
+                        state.dbManager.scheduleFolderCacheSave(state.currentFolder.id, state.imageFiles, { priority: 'normal' });
+                    }
+                    Utils.endBackgroundActivity('Extracting metadata');
                 }
             },
             async processFileMetadata(file) {

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -281,11 +281,16 @@
         @keyframes spin { to { transform: rotate(360deg); } }
         
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
+        .loading-phase { color: var(--accent); font-size: 13px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 8px; }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
         
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
+        .background-activity { position: fixed; top: 14px; left: 50%; transform: translateX(-50%); z-index: 20; display: flex; align-items: center; gap: 8px; padding: 6px 12px; border-radius: 999px; background: rgba(17, 24, 39, 0.82); color: rgba(255, 255, 255, 0.86); font-size: 12px; border: 1px solid rgba(245, 158, 11, 0.35); pointer-events: none; transition: opacity 0.2s ease; }
+        .background-activity.hidden { display: none; }
+        .background-activity-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); animation: backgroundPulse 1.2s ease-in-out infinite; }
+        @keyframes backgroundPulse { 0%, 100% { opacity: 0.35; transform: scale(0.85); } 50% { opacity: 1; transform: scale(1.15); } }
         
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
@@ -922,6 +927,7 @@
         <div class="card">
             <h2 class="title">Loading Images</h2>
             <div class="loading-counter" id="loading-counter">0</div>
+            <div class="loading-phase" id="loading-phase">Discovering files...</div>
             <div class="loading-message" id="loading-message">Processing files...</div>
             <div class="loading-progress">
                 <div class="loading-progress-bar" id="loading-progress-bar"></div>
@@ -935,6 +941,7 @@
     
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
+        <div class="background-activity hidden" id="background-activity"><span class="background-activity-dot"></span><span id="background-activity-label">Background processing</span></div>
         <button class="ui-button" id="back-button">
             <span id="back-button-spinner" class="spinner" style="display: none; width: 14px; height: 14px; margin-right: 6px;"></span>
             Folders
@@ -1228,7 +1235,7 @@
             grid: { stack: null, selected: [], filtered: [], isDirty: false, isDragging: false,
                 dragSession: createDefaultGridDragSession(), skipReorderOnClose: false,
                 lazyLoadState: { allFiles: [], renderedCount: 0, observer: null, batchSize: 20 } },
-            tags: new Set(), loadingProgress: { current: 0, total: 0 },
+            tags: new Set(), loadingProgress: { current: 0, total: 0, offset: 0, phase: '' }, backgroundActivityCount: 0,
             folderMoveMode: { active: false, files: [] },
             isReturningToFolders: false,
             navigationToken: null,
@@ -1457,8 +1464,11 @@
                     focusFavoriteIcon: document.getElementById('focus-favorite-icon'),
 
                     loadingCounter: document.getElementById('loading-counter'),
+                    loadingPhase: document.getElementById('loading-phase'),
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
+                    backgroundActivity: document.getElementById('background-activity'),
+                    backgroundActivityLabel: document.getElementById('background-activity-label'),
                     cancelLoading: document.getElementById('cancel-loading'),
                     
                     edgeTop: document.getElementById('edge-top'),
@@ -1530,6 +1540,10 @@
             },
             
             showScreen(screenId) {
+                if (screenId === 'loading-screen' && state.currentScreen !== 'loading-screen') {
+                    state.loadingProgress = { current: 0, total: 0, offset: 0, phase: '', displayCurrent: 0, displayTotal: 0 };
+                }
+                state.currentScreen = screenId;
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
                     const screen = document.getElementById(id);
@@ -1906,15 +1920,57 @@
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
             
+            beginBackgroundActivity(label = 'Background processing') {
+                state.backgroundActivityCount = (state.backgroundActivityCount || 0) + 1;
+                this.updateBackgroundActivity(label);
+            },
+
+            endBackgroundActivity(label = 'Background processing') {
+                state.backgroundActivityCount = Math.max(0, (state.backgroundActivityCount || 0) - 1);
+                this.updateBackgroundActivity(label);
+            },
+
+            updateBackgroundActivity(label = 'Background processing') {
+                const indicator = this.elements?.backgroundActivity;
+                if (!indicator) return;
+                const active = (state.backgroundActivityCount || 0) > 0;
+                indicator.classList.toggle('hidden', !active);
+                if (this.elements.backgroundActivityLabel) {
+                    this.elements.backgroundActivityLabel.textContent = active && state.backgroundActivityCount > 1
+                        ? `${label} (${state.backgroundActivityCount})`
+                        : label;
+                }
+            },
+
             updateLoadingProgress(current, total, message = '') {
-                state.loadingProgress = { current, total };
-                this.elements.loadingCounter.textContent = current;
-                this.elements.loadingMessage.textContent = message || (total ? 
-                    `Processing ${current} of ${total} items...` : 
-                    `Found ${current} items`);
-                if (total > 0) {
-                    const percentage = (current / total) * 100;
+                const normalizedCurrent = Number(current) || 0;
+                const normalizedTotal = Number(total) || 0;
+                const phase = /process|metadata/i.test(message)
+                    ? 'Loading metadata...'
+                    : /compar|ready|almost/i.test(message)
+                        ? 'Almost ready...'
+                        : 'Discovering files...';
+                const previous = state.loadingProgress || { current: 0, total: 0, offset: 0, phase: '', displayCurrent: 0 };
+                let offset = previous.offset || 0;
+                if (previous.phase && phase !== previous.phase && normalizedCurrent < (previous.current || 0)) {
+                    offset = previous.displayCurrent || previous.current || 0;
+                }
+                const displayCurrent = normalizedCurrent + offset;
+                const displayTotal = normalizedTotal > 0 ? Math.max(normalizedTotal + offset, displayCurrent) : 0;
+                state.loadingProgress = { current: normalizedCurrent, total: normalizedTotal, offset, phase, displayCurrent, displayTotal };
+                this.elements.loadingCounter.textContent = displayCurrent;
+                if (this.elements.loadingPhase) {
+                    this.elements.loadingPhase.textContent = phase;
+                }
+                this.elements.loadingMessage.textContent = message || (displayTotal ?
+                    `Processing ${displayCurrent} of ${displayTotal} items...` :
+                    `Found ${displayCurrent} items`);
+                if (displayTotal > 0) {
+                    const percentage = (displayCurrent / displayTotal) * 100;
                     this.elements.loadingProgressBar.style.width = `${percentage}%`;
+                } else {
+                    const pulse = displayCurrent > 0 ? Math.min(88, 12 + ((displayCurrent % 12) * 6)) : 8;
+                    this.elements.loadingProgressBar.style.width = `${pulse}%`;
                 }
             }
         };
@@ -3616,11 +3672,25 @@
             }
             async refreshAccessToken() {
                 if (!this.refreshToken || !this.clientSecret) { throw new Error('No refresh token or client secret available'); }
-                const response = await fetch('https://oauth2.googleapis.com/token', {
-                    method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                    body: new URLSearchParams({ client_id: this.clientId, client_secret: this.clientSecret, refresh_token: this.refreshToken, grant_type: 'refresh_token' })
-                });
-                if (!response.ok) { throw new Error('Failed to refresh access token'); }
+                let response;
+                try {
+                    response = await fetch('https://oauth2.googleapis.com/token', {
+                        method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                        body: new URLSearchParams({ client_id: this.clientId, client_secret: this.clientSecret, refresh_token: this.refreshToken, grant_type: 'refresh_token' })
+                    });
+                } catch (fetchError) {
+                    fetchError.networkError = true;
+                    throw fetchError;
+                }
+                if (!response.ok) {
+                    const error = new Error('Failed to refresh access token');
+                    if (response.status === 400 || response.status === 401) {
+                        error.tokenRevoked = true;
+                    } else if (response.status >= 500) {
+                        error.networkError = true;
+                    }
+                    throw error;
+                }
                 const tokens = await response.json(); this.accessToken = tokens.access_token; this.storeCredentials(); return this.accessToken;
             }
             async makeApiCall(endpoint, options = {}, isJson = true) {
@@ -3641,7 +3711,16 @@
                         await this.refreshAccessToken();
                         headers['Authorization'] = `Bearer ${this.accessToken}`;
                         response = await fetch(url, { ...options, headers });
-                    } catch (refreshError) { this.isAuthenticated = false; this.clearStoredCredentials(); throw new Error('Authentication expired. Please reconnect.'); }
+                    } catch (refreshError) {
+                        if (refreshError?.tokenRevoked) {
+                            this.isAuthenticated = false;
+                            this.clearStoredCredentials();
+                            throw new Error('Authentication expired. Please reconnect.');
+                        }
+                        const error = new Error('Network error during token refresh. Please try again.');
+                        error.networkError = Boolean(refreshError?.networkError);
+                        throw error;
+                    }
                 }
                 if (!response.ok) { const errorText = await response.text(); throw new Error(`API call failed: ${response.status} ${response.statusText} - ${errorText}`); }
                 if (isJson) { return await response.json(); }
@@ -4418,6 +4497,9 @@
             async processAllMetadata(files, isFirstLoad = false, options = {}) {
                  const { navigationToken = null } = options;
                  if (isFirstLoad) Utils.updateLoadingProgress(0, files.length, 'Processing files...');
+                 const showBackgroundIndicator = !isFirstLoad && files.length > 0;
+                 if (showBackgroundIndicator) Utils.beginBackgroundActivity('Loading file records');
+                 try {
 
                  const fileIds = files.map(file => file.id).filter(Boolean);
                  let cachedMetadata = new Map();
@@ -4512,6 +4594,9 @@
                 if (!navigationToken || this.isNavigationActive(navigationToken)) {
                     this.extractMetadataInBackground(files.filter(f => f.mimeType === 'image/png'));
                 }
+                 } finally {
+                    if (showBackgroundIndicator) Utils.endBackgroundActivity('Loading file records');
+                 }
             },
             extractCloudVersionInfo(file) {
                 const appProperties = file?.appProperties || null;
@@ -5236,17 +5321,19 @@
                 }
             },
             async extractMetadataInBackground(pngFiles) {
+                const pendingFiles = pngFiles.filter(file => file.metadataStatus === 'pending' || file.metadataStatus === 'queued');
+                if (pendingFiles.length === 0) return;
                 const BATCH_SIZE = 5;
-                for (let i = 0; i < pngFiles.length; i += BATCH_SIZE) {
-                    if (state.activeRequests.signal.aborted) return;
-                    const batch = pngFiles.slice(i, i + BATCH_SIZE);
-                    const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
-                            return this.processFileMetadata(file);
-                        }
-                        return Promise.resolve();
-                    });
-                    await Promise.allSettled(promises);
+                Utils.beginBackgroundActivity('Extracting metadata');
+                try {
+                    for (let i = 0; i < pendingFiles.length; i += BATCH_SIZE) {
+                        if (state.activeRequests.signal.aborted) return;
+                        const batch = pendingFiles.slice(i, i + BATCH_SIZE);
+                        const promises = batch.map(file => this.processFileMetadata(file));
+                        await Promise.allSettled(promises);
+                    }
+                } finally {
+                    Utils.endBackgroundActivity('Extracting metadata');
                 }
             },
             async processFileMetadata(file) {

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -309,11 +309,16 @@
         @keyframes spin { to { transform: rotate(360deg); } }
         
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
+        .loading-phase { color: var(--accent); font-size: 13px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 8px; }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
         
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
+        .background-activity { position: fixed; top: 14px; left: 50%; transform: translateX(-50%); z-index: 20; display: flex; align-items: center; gap: 8px; padding: 6px 12px; border-radius: 999px; background: rgba(17, 24, 39, 0.82); color: rgba(255, 255, 255, 0.86); font-size: 12px; border: 1px solid rgba(245, 158, 11, 0.35); pointer-events: none; transition: opacity 0.2s ease; }
+        .background-activity.hidden { display: none; }
+        .background-activity-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); animation: backgroundPulse 1.2s ease-in-out infinite; }
+        @keyframes backgroundPulse { 0%, 100% { opacity: 0.35; transform: scale(0.85); } 50% { opacity: 1; transform: scale(1.15); } }
         
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
@@ -926,6 +931,7 @@
         <div class="card">
             <h2 class="title">Loading Images</h2>
             <div class="loading-counter" id="loading-counter">0</div>
+            <div class="loading-phase" id="loading-phase">Discovering files...</div>
             <div class="loading-message" id="loading-message">Processing files...</div>
             <div class="loading-progress">
                 <div class="loading-progress-bar" id="loading-progress-bar"></div>
@@ -939,6 +945,7 @@
     
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
+        <div class="background-activity hidden" id="background-activity"><span class="background-activity-dot"></span><span id="background-activity-label">Background processing</span></div>
         <button class="ui-button" id="back-button">
             <span id="back-button-spinner" class="spinner" style="display: none; width: 14px; height: 14px; margin-right: 6px;"></span>
             Folders
@@ -1227,7 +1234,7 @@
             grid: { stack: null, selected: [], filtered: [], isDirty: false, isDragging: false,
                 dragSession: createDefaultGridDragSession(), skipReorderOnClose: false,
                 lazyLoadState: { allFiles: [], renderedCount: 0, observer: null, batchSize: 20 } },
-            tags: new Set(), loadingProgress: { current: 0, total: 0 },
+            tags: new Set(), loadingProgress: { current: 0, total: 0, offset: 0, phase: '' }, backgroundActivityCount: 0,
             folderMoveMode: { active: false, files: [] },
             isReturningToFolders: false,
             navigationToken: null,
@@ -1478,8 +1485,11 @@
                     focusFavoriteIcon: document.getElementById('focus-favorite-icon'),
 
                     loadingCounter: document.getElementById('loading-counter'),
+                    loadingPhase: document.getElementById('loading-phase'),
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
+                    backgroundActivity: document.getElementById('background-activity'),
+                    backgroundActivityLabel: document.getElementById('background-activity-label'),
                     cancelLoading: document.getElementById('cancel-loading'),
                     
                     edgeTop: document.getElementById('edge-top'),
@@ -1551,6 +1561,10 @@
             },
             
             showScreen(screenId) {
+                if (screenId === 'loading-screen' && state.currentScreen !== 'loading-screen') {
+                    state.loadingProgress = { current: 0, total: 0, offset: 0, phase: '', displayCurrent: 0, displayTotal: 0 };
+                }
+                state.currentScreen = screenId;
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
                     const screen = document.getElementById(id);
@@ -1807,15 +1821,57 @@
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
             
+            beginBackgroundActivity(label = 'Background processing') {
+                state.backgroundActivityCount = (state.backgroundActivityCount || 0) + 1;
+                this.updateBackgroundActivity(label);
+            },
+
+            endBackgroundActivity(label = 'Background processing') {
+                state.backgroundActivityCount = Math.max(0, (state.backgroundActivityCount || 0) - 1);
+                this.updateBackgroundActivity(label);
+            },
+
+            updateBackgroundActivity(label = 'Background processing') {
+                const indicator = this.elements?.backgroundActivity;
+                if (!indicator) return;
+                const active = (state.backgroundActivityCount || 0) > 0;
+                indicator.classList.toggle('hidden', !active);
+                if (this.elements.backgroundActivityLabel) {
+                    this.elements.backgroundActivityLabel.textContent = active && state.backgroundActivityCount > 1
+                        ? `${label} (${state.backgroundActivityCount})`
+                        : label;
+                }
+            },
+
             updateLoadingProgress(current, total, message = '') {
-                state.loadingProgress = { current, total };
-                this.elements.loadingCounter.textContent = current;
-                this.elements.loadingMessage.textContent = message || (total ? 
-                    `Processing ${current} of ${total} items...` : 
-                    `Found ${current} items`);
-                if (total > 0) {
-                    const percentage = (current / total) * 100;
+                const normalizedCurrent = Number(current) || 0;
+                const normalizedTotal = Number(total) || 0;
+                const phase = /process|metadata/i.test(message)
+                    ? 'Loading metadata...'
+                    : /compar|ready|almost/i.test(message)
+                        ? 'Almost ready...'
+                        : 'Discovering files...';
+                const previous = state.loadingProgress || { current: 0, total: 0, offset: 0, phase: '', displayCurrent: 0 };
+                let offset = previous.offset || 0;
+                if (previous.phase && phase !== previous.phase && normalizedCurrent < (previous.current || 0)) {
+                    offset = previous.displayCurrent || previous.current || 0;
+                }
+                const displayCurrent = normalizedCurrent + offset;
+                const displayTotal = normalizedTotal > 0 ? Math.max(normalizedTotal + offset, displayCurrent) : 0;
+                state.loadingProgress = { current: normalizedCurrent, total: normalizedTotal, offset, phase, displayCurrent, displayTotal };
+                this.elements.loadingCounter.textContent = displayCurrent;
+                if (this.elements.loadingPhase) {
+                    this.elements.loadingPhase.textContent = phase;
+                }
+                this.elements.loadingMessage.textContent = message || (displayTotal ?
+                    `Processing ${displayCurrent} of ${displayTotal} items...` :
+                    `Found ${displayCurrent} items`);
+                if (displayTotal > 0) {
+                    const percentage = (displayCurrent / displayTotal) * 100;
                     this.elements.loadingProgressBar.style.width = `${percentage}%`;
+                } else {
+                    const pulse = displayCurrent > 0 ? Math.min(88, 12 + ((displayCurrent % 12) * 6)) : 8;
+                    this.elements.loadingProgressBar.style.width = `${pulse}%`;
                 }
             }
         };
@@ -3869,11 +3925,25 @@
             }
             async refreshAccessToken() {
                 if (!this.refreshToken || !this.clientSecret) { throw new Error('No refresh token or client secret available'); }
-                const response = await fetch('https://oauth2.googleapis.com/token', {
-                    method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                    body: new URLSearchParams({ client_id: this.clientId, client_secret: this.clientSecret, refresh_token: this.refreshToken, grant_type: 'refresh_token' })
-                });
-                if (!response.ok) { throw new Error('Failed to refresh access token'); }
+                let response;
+                try {
+                    response = await fetch('https://oauth2.googleapis.com/token', {
+                        method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                        body: new URLSearchParams({ client_id: this.clientId, client_secret: this.clientSecret, refresh_token: this.refreshToken, grant_type: 'refresh_token' })
+                    });
+                } catch (fetchError) {
+                    fetchError.networkError = true;
+                    throw fetchError;
+                }
+                if (!response.ok) {
+                    const error = new Error('Failed to refresh access token');
+                    if (response.status === 400 || response.status === 401) {
+                        error.tokenRevoked = true;
+                    } else if (response.status >= 500) {
+                        error.networkError = true;
+                    }
+                    throw error;
+                }
                 const tokens = await response.json(); this.accessToken = tokens.access_token; this.storeCredentials(); return this.accessToken;
             }
             async makeApiCall(endpoint, options = {}, isJson = true) {
@@ -3894,7 +3964,16 @@
                         await this.refreshAccessToken();
                         headers['Authorization'] = `Bearer ${this.accessToken}`;
                         response = await fetch(url, { ...options, headers });
-                    } catch (refreshError) { this.isAuthenticated = false; this.clearStoredCredentials(); throw new Error('Authentication expired. Please reconnect.'); }
+                    } catch (refreshError) {
+                        if (refreshError?.tokenRevoked) {
+                            this.isAuthenticated = false;
+                            this.clearStoredCredentials();
+                            throw new Error('Authentication expired. Please reconnect.');
+                        }
+                        const error = new Error('Network error during token refresh. Please try again.');
+                        error.networkError = Boolean(refreshError?.networkError);
+                        throw error;
+                    }
                 }
                 if (!response.ok) { const errorText = await response.text(); throw new Error(`API call failed: ${response.status} ${response.statusText} - ${errorText}`); }
                 if (isJson) { return await response.json(); }
@@ -4760,8 +4839,8 @@
                         options.forceFullResync
                     );
 
-                    const mustRefreshFromCloud = shouldFullSync || isFirstSessionVisit;
-                    const canUseCache = !mustRefreshFromCloud && (preparation?.mode === 'cache' || !coordinator);
+                    const mustRefreshFromCloud = isFirstSessionVisit || Boolean(options.forceFullResync);
+                    const canUseCache = !mustRefreshFromCloud && !shouldFullSync && (preparation?.mode === 'cache' || !coordinator);
 
                     if (!canUseCache) {
                         const synced = await this.syncFolderFromCloud(cachedFiles, sessionKey, { preparation, navigationToken });
@@ -4945,6 +5024,20 @@
                     for (const updatedId of updatedIds) {
                         const updatedFile = mergedFiles.find(file => file.id === updatedId);
                         if (updatedFile) {
+                            const existingMetadata = await state.dbManager.getMetadata(updatedId);
+                            if (existingMetadata) {
+                                const preservedFields = [
+                                    'extractedMetadata', 'metadataStatus', 'prompt', 'negativePrompt',
+                                    'model', 'seed', 'steps', 'cfgScale', 'sampler', 'stack', 'tags',
+                                    'notes', 'qualityRating', 'contentRating', 'favorite', 'stackSequence',
+                                    'lastUpdated', 'localUpdatedAt'
+                                ];
+                                for (const field of preservedFields) {
+                                    if (existingMetadata[field] !== undefined) {
+                                        updatedFile[field] = existingMetadata[field];
+                                    }
+                                }
+                            }
                             await state.dbManager.saveMetadata(updatedId, updatedFile, { folderId, providerType: state.providerType });
                         }
                     }
@@ -5054,6 +5147,7 @@
                 }
             },
             async refreshFolderInBackground() {
+                Utils.beginBackgroundActivity('Refreshing folder');
                 try {
                     const navigationToken = state.navigationToken;
                     const folderId = state.currentFolder.id;
@@ -5069,7 +5163,21 @@
                     for (const updatedId of updatedIds) {
                         const updatedFile = mergedFiles.find(file => file.id === updatedId);
                         if (updatedFile) {
-                        await state.dbManager.saveMetadata(updatedId, updatedFile, { folderId, providerType: state.providerType });
+                            const existingMetadata = await state.dbManager.getMetadata(updatedId);
+                            if (existingMetadata) {
+                                const preservedFields = [
+                                    'extractedMetadata', 'metadataStatus', 'prompt', 'negativePrompt',
+                                    'model', 'seed', 'steps', 'cfgScale', 'sampler', 'stack', 'tags',
+                                    'notes', 'qualityRating', 'contentRating', 'favorite', 'stackSequence',
+                                    'lastUpdated', 'localUpdatedAt'
+                                ];
+                                for (const field of preservedFields) {
+                                    if (existingMetadata[field] !== undefined) {
+                                        updatedFile[field] = existingMetadata[field];
+                                    }
+                                }
+                            }
+                            await state.dbManager.saveMetadata(updatedId, updatedFile, { folderId, providerType: state.providerType });
                         }
                     }
                     if (removedIds.length > 0) {
@@ -5089,11 +5197,16 @@
                     Utils.showToast('Folder updated in background', 'info');
                 } catch (error) {
                     console.warn("Background refresh failed:", error.message);
+                } finally {
+                    Utils.endBackgroundActivity('Refreshing folder');
                 }
             },
             async processAllMetadata(files, isFirstLoad = false, options = {}) {
                  const { navigationToken = null } = options;
                  if (isFirstLoad) Utils.updateLoadingProgress(0, files.length, 'Processing files...');
+                 const showBackgroundIndicator = !isFirstLoad && files.length > 0;
+                 if (showBackgroundIndicator) Utils.beginBackgroundActivity('Loading file records');
+                 try {
                  for (let i = 0; i < files.length; i++) {
                     if (navigationToken && !this.isNavigationActive(navigationToken)) {
                         return;
@@ -5119,6 +5232,9 @@
                 if (!navigationToken || this.isNavigationActive(navigationToken)) {
                     this.extractMetadataInBackground(files.filter(f => f.mimeType === 'image/png'));
                 }
+                 } finally {
+                    if (showBackgroundIndicator) Utils.endBackgroundActivity('Loading file records');
+                 }
             },
             generateDefaultMetadata(file, context = {}) {
                  const baseMetadata = {
@@ -5530,17 +5646,24 @@
                 }
             },
             async extractMetadataInBackground(pngFiles) {
+                const pendingFiles = pngFiles.filter(file => file.metadataStatus === 'pending' || file.metadataStatus === 'queued');
+                if (pendingFiles.length === 0) return;
                 const BATCH_SIZE = 5;
-                for (let i = 0; i < pngFiles.length; i += BATCH_SIZE) {
-                    if (state.activeRequests.signal.aborted) return;
-                    const batch = pngFiles.slice(i, i + BATCH_SIZE);
-                    const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
-                            return this.processFileMetadata(file);
-                        }
-                        return Promise.resolve();
-                    });
-                    await Promise.allSettled(promises);
+                let completed = false;
+                Utils.beginBackgroundActivity('Extracting metadata');
+                try {
+                    for (let i = 0; i < pendingFiles.length; i += BATCH_SIZE) {
+                        if (state.activeRequests.signal.aborted) return;
+                        const batch = pendingFiles.slice(i, i + BATCH_SIZE);
+                        const promises = batch.map(file => this.processFileMetadata(file));
+                        await Promise.allSettled(promises);
+                    }
+                    completed = true;
+                } finally {
+                    if (completed && state.currentFolder?.id && Array.isArray(state.imageFiles)) {
+                        state.dbManager.scheduleFolderCacheSave(state.currentFolder.id, state.imageFiles, { priority: 'normal' });
+                    }
+                    Utils.endBackgroundActivity('Extracting metadata');
                 }
             },
             async processFileMetadata(file) {

--- a/ui.html
+++ b/ui.html
@@ -281,11 +281,16 @@
         @keyframes spin { to { transform: rotate(360deg); } }
         
         .loading-counter { color: var(--accent); font-size: 48px; font-weight: 700; margin: 20px 0; text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8); }
+        .loading-phase { color: var(--accent); font-size: 13px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 8px; }
         .loading-message { color: rgba(255, 255, 255, 0.7); font-size: 16px; margin-bottom: 20px; }
         .loading-progress { width: 100%; height: 6px; background: rgba(255, 255, 255, 0.2); border-radius: 3px; overflow: hidden; margin-bottom: 20px; }
         .loading-progress-bar { height: 100%; background: linear-gradient(45deg, var(--accent), #d97706); border-radius: 3px; transition: width 0.3s ease; width: 0%; }
         
         .app-container { position: relative; width: 100vw; height: 100vh; background: var(--dark); overflow: hidden; }
+        .background-activity { position: fixed; top: 14px; left: 50%; transform: translateX(-50%); z-index: 20; display: flex; align-items: center; gap: 8px; padding: 6px 12px; border-radius: 999px; background: rgba(17, 24, 39, 0.82); color: rgba(255, 255, 255, 0.86); font-size: 12px; border: 1px solid rgba(245, 158, 11, 0.35); pointer-events: none; transition: opacity 0.2s ease; }
+        .background-activity.hidden { display: none; }
+        .background-activity-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); animation: backgroundPulse 1.2s ease-in-out infinite; }
+        @keyframes backgroundPulse { 0%, 100% { opacity: 0.35; transform: scale(0.85); } 50% { opacity: 1; transform: scale(1.15); } }
         
         .image-viewport { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 1; overflow: hidden; }
         .center-image {
@@ -901,6 +906,7 @@
         <div class="card">
             <h2 class="title">Loading Images</h2>
             <div class="loading-counter" id="loading-counter">0</div>
+            <div class="loading-phase" id="loading-phase">Discovering files...</div>
             <div class="loading-message" id="loading-message">Processing files...</div>
             <div class="loading-progress">
                 <div class="loading-progress-bar" id="loading-progress-bar"></div>
@@ -914,6 +920,7 @@
     
     <!-- Main App Container -->
     <div class="app-container hidden" id="app-container">
+        <div class="background-activity hidden" id="background-activity"><span class="background-activity-dot"></span><span id="background-activity-label">Background processing</span></div>
         <button class="ui-button" id="back-button">
             <span id="back-button-spinner" class="spinner" style="display: none; width: 14px; height: 14px; margin-right: 6px;"></span>
             Folders
@@ -1203,7 +1210,7 @@
             grid: { stack: null, selected: [], filtered: [], isDirty: false, isDragging: false,
                 dragSession: createDefaultGridDragSession(), skipReorderOnClose: false,
                 lazyLoadState: { allFiles: [], renderedCount: 0, observer: null, batchSize: 20 } },
-            tags: new Set(), loadingProgress: { current: 0, total: 0 },
+            tags: new Set(), loadingProgress: { current: 0, total: 0, offset: 0, phase: '' }, backgroundActivityCount: 0,
             folderMoveMode: { active: false, files: [] },
             isReturningToFolders: false,
             navigationToken: null,
@@ -1418,8 +1425,11 @@
                     focusFavoriteIcon: document.getElementById('focus-favorite-icon'),
 
                     loadingCounter: document.getElementById('loading-counter'),
+                    loadingPhase: document.getElementById('loading-phase'),
                     loadingMessage: document.getElementById('loading-message'),
                     loadingProgressBar: document.getElementById('loading-progress-bar'),
+                    backgroundActivity: document.getElementById('background-activity'),
+                    backgroundActivityLabel: document.getElementById('background-activity-label'),
                     cancelLoading: document.getElementById('cancel-loading'),
                     
                     edgeTop: document.getElementById('edge-top'),
@@ -1491,6 +1501,10 @@
             },
             
             showScreen(screenId) {
+                if (screenId === 'loading-screen' && state.currentScreen !== 'loading-screen') {
+                    state.loadingProgress = { current: 0, total: 0, offset: 0, phase: '', displayCurrent: 0, displayTotal: 0 };
+                }
+                state.currentScreen = screenId;
                 const screens = ['provider-screen', 'auth-screen', 'folder-screen', 'loading-screen', 'app-container'];
                 screens.forEach(id => {
                     const screen = document.getElementById(id);
@@ -1640,15 +1654,57 @@
                 return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
             },
             
+            beginBackgroundActivity(label = 'Background processing') {
+                state.backgroundActivityCount = (state.backgroundActivityCount || 0) + 1;
+                this.updateBackgroundActivity(label);
+            },
+
+            endBackgroundActivity(label = 'Background processing') {
+                state.backgroundActivityCount = Math.max(0, (state.backgroundActivityCount || 0) - 1);
+                this.updateBackgroundActivity(label);
+            },
+
+            updateBackgroundActivity(label = 'Background processing') {
+                const indicator = this.elements?.backgroundActivity;
+                if (!indicator) return;
+                const active = (state.backgroundActivityCount || 0) > 0;
+                indicator.classList.toggle('hidden', !active);
+                if (this.elements.backgroundActivityLabel) {
+                    this.elements.backgroundActivityLabel.textContent = active && state.backgroundActivityCount > 1
+                        ? `${label} (${state.backgroundActivityCount})`
+                        : label;
+                }
+            },
+
             updateLoadingProgress(current, total, message = '') {
-                state.loadingProgress = { current, total };
-                this.elements.loadingCounter.textContent = current;
-                this.elements.loadingMessage.textContent = message || (total ? 
-                    `Processing ${current} of ${total} items...` : 
-                    `Found ${current} items`);
-                if (total > 0) {
-                    const percentage = (current / total) * 100;
+                const normalizedCurrent = Number(current) || 0;
+                const normalizedTotal = Number(total) || 0;
+                const phase = /process|metadata/i.test(message)
+                    ? 'Loading metadata...'
+                    : /compar|ready|almost/i.test(message)
+                        ? 'Almost ready...'
+                        : 'Discovering files...';
+                const previous = state.loadingProgress || { current: 0, total: 0, offset: 0, phase: '', displayCurrent: 0 };
+                let offset = previous.offset || 0;
+                if (previous.phase && phase !== previous.phase && normalizedCurrent < (previous.current || 0)) {
+                    offset = previous.displayCurrent || previous.current || 0;
+                }
+                const displayCurrent = normalizedCurrent + offset;
+                const displayTotal = normalizedTotal > 0 ? Math.max(normalizedTotal + offset, displayCurrent) : 0;
+                state.loadingProgress = { current: normalizedCurrent, total: normalizedTotal, offset, phase, displayCurrent, displayTotal };
+                this.elements.loadingCounter.textContent = displayCurrent;
+                if (this.elements.loadingPhase) {
+                    this.elements.loadingPhase.textContent = phase;
+                }
+                this.elements.loadingMessage.textContent = message || (displayTotal ?
+                    `Processing ${displayCurrent} of ${displayTotal} items...` :
+                    `Found ${displayCurrent} items`);
+                if (displayTotal > 0) {
+                    const percentage = (displayCurrent / displayTotal) * 100;
                     this.elements.loadingProgressBar.style.width = `${percentage}%`;
+                } else {
+                    const pulse = displayCurrent > 0 ? Math.min(88, 12 + ((displayCurrent % 12) * 6)) : 8;
+                    this.elements.loadingProgressBar.style.width = `${pulse}%`;
                 }
             }
         };
@@ -3754,11 +3810,25 @@
             }
             async refreshAccessToken() {
                 if (!this.refreshToken || !this.clientSecret) { throw new Error('No refresh token or client secret available'); }
-                const response = await fetch('https://oauth2.googleapis.com/token', {
-                    method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                    body: new URLSearchParams({ client_id: this.clientId, client_secret: this.clientSecret, refresh_token: this.refreshToken, grant_type: 'refresh_token' })
-                });
-                if (!response.ok) { throw new Error('Failed to refresh access token'); }
+                let response;
+                try {
+                    response = await fetch('https://oauth2.googleapis.com/token', {
+                        method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                        body: new URLSearchParams({ client_id: this.clientId, client_secret: this.clientSecret, refresh_token: this.refreshToken, grant_type: 'refresh_token' })
+                    });
+                } catch (fetchError) {
+                    fetchError.networkError = true;
+                    throw fetchError;
+                }
+                if (!response.ok) {
+                    const error = new Error('Failed to refresh access token');
+                    if (response.status === 400 || response.status === 401) {
+                        error.tokenRevoked = true;
+                    } else if (response.status >= 500) {
+                        error.networkError = true;
+                    }
+                    throw error;
+                }
                 const tokens = await response.json(); this.accessToken = tokens.access_token; this.storeCredentials(); return this.accessToken;
             }
             async makeApiCall(endpoint, options = {}, isJson = true) {
@@ -3779,7 +3849,16 @@
                         await this.refreshAccessToken();
                         headers['Authorization'] = `Bearer ${this.accessToken}`;
                         response = await fetch(url, { ...options, headers });
-                    } catch (refreshError) { this.isAuthenticated = false; this.clearStoredCredentials(); throw new Error('Authentication expired. Please reconnect.'); }
+                    } catch (refreshError) {
+                        if (refreshError?.tokenRevoked) {
+                            this.isAuthenticated = false;
+                            this.clearStoredCredentials();
+                            throw new Error('Authentication expired. Please reconnect.');
+                        }
+                        const error = new Error('Network error during token refresh. Please try again.');
+                        error.networkError = Boolean(refreshError?.networkError);
+                        throw error;
+                    }
                 }
                 if (!response.ok) { const errorText = await response.text(); throw new Error(`API call failed: ${response.status} ${response.statusText} - ${errorText}`); }
                 if (isJson) { return await response.json(); }
@@ -4621,7 +4700,7 @@
                         options.forceFullResync
                     );
 
-                    const mustRefreshFromCloud = true; // Always refresh to capture latest cloud changes per folder load.
+                    const mustRefreshFromCloud = isFirstSessionVisit || Boolean(options.forceFullResync);
                     const canUseCache = !mustRefreshFromCloud && !shouldFullSync && (preparation?.mode === 'cache' || !coordinator);
 
                     if (!canUseCache) {
@@ -4806,6 +4885,20 @@
                     for (const updatedId of updatedIds) {
                         const updatedFile = mergedFiles.find(file => file.id === updatedId);
                         if (updatedFile) {
+                            const existingMetadata = await state.dbManager.getMetadata(updatedId);
+                            if (existingMetadata) {
+                                const preservedFields = [
+                                    'extractedMetadata', 'metadataStatus', 'prompt', 'negativePrompt',
+                                    'model', 'seed', 'steps', 'cfgScale', 'sampler', 'stack', 'tags',
+                                    'notes', 'qualityRating', 'contentRating', 'favorite', 'stackSequence',
+                                    'lastUpdated', 'localUpdatedAt'
+                                ];
+                                for (const field of preservedFields) {
+                                    if (existingMetadata[field] !== undefined) {
+                                        updatedFile[field] = existingMetadata[field];
+                                    }
+                                }
+                            }
                             await state.dbManager.saveMetadata(updatedId, updatedFile, { folderId, providerType: state.providerType });
                         }
                     }
@@ -4915,6 +5008,7 @@
                 }
             },
             async refreshFolderInBackground() {
+                Utils.beginBackgroundActivity('Refreshing folder');
                 try {
                     const navigationToken = state.navigationToken;
                     const folderId = state.currentFolder.id;
@@ -4930,7 +5024,21 @@
                     for (const updatedId of updatedIds) {
                         const updatedFile = mergedFiles.find(file => file.id === updatedId);
                         if (updatedFile) {
-                        await state.dbManager.saveMetadata(updatedId, updatedFile, { folderId, providerType: state.providerType });
+                            const existingMetadata = await state.dbManager.getMetadata(updatedId);
+                            if (existingMetadata) {
+                                const preservedFields = [
+                                    'extractedMetadata', 'metadataStatus', 'prompt', 'negativePrompt',
+                                    'model', 'seed', 'steps', 'cfgScale', 'sampler', 'stack', 'tags',
+                                    'notes', 'qualityRating', 'contentRating', 'favorite', 'stackSequence',
+                                    'lastUpdated', 'localUpdatedAt'
+                                ];
+                                for (const field of preservedFields) {
+                                    if (existingMetadata[field] !== undefined) {
+                                        updatedFile[field] = existingMetadata[field];
+                                    }
+                                }
+                            }
+                            await state.dbManager.saveMetadata(updatedId, updatedFile, { folderId, providerType: state.providerType });
                         }
                     }
                     if (removedIds.length > 0) {
@@ -4950,11 +5058,16 @@
                     Utils.showToast('Folder updated in background', 'info');
                 } catch (error) {
                     console.warn("Background refresh failed:", error.message);
+                } finally {
+                    Utils.endBackgroundActivity('Refreshing folder');
                 }
             },
             async processAllMetadata(files, isFirstLoad = false, options = {}) {
                  const { navigationToken = null } = options;
                  if (isFirstLoad) Utils.updateLoadingProgress(0, files.length, 'Processing files...');
+                 const showBackgroundIndicator = !isFirstLoad && files.length > 0;
+                 if (showBackgroundIndicator) Utils.beginBackgroundActivity('Loading file records');
+                 try {
                  for (let i = 0; i < files.length; i++) {
                     if (navigationToken && !this.isNavigationActive(navigationToken)) {
                         return;
@@ -4980,6 +5093,9 @@
                 if (!navigationToken || this.isNavigationActive(navigationToken)) {
                     this.extractMetadataInBackground(files.filter(f => f.mimeType === 'image/png'));
                 }
+                 } finally {
+                    if (showBackgroundIndicator) Utils.endBackgroundActivity('Loading file records');
+                 }
             },
             generateDefaultMetadata(file, context = {}) {
                  const baseMetadata = {
@@ -5387,17 +5503,24 @@
                 }
             },
             async extractMetadataInBackground(pngFiles) {
+                const pendingFiles = pngFiles.filter(file => file.metadataStatus === 'pending' || file.metadataStatus === 'queued');
+                if (pendingFiles.length === 0) return;
                 const BATCH_SIZE = 5;
-                for (let i = 0; i < pngFiles.length; i += BATCH_SIZE) {
-                    if (state.activeRequests.signal.aborted) return;
-                    const batch = pngFiles.slice(i, i + BATCH_SIZE);
-                    const promises = batch.map(file => {
-                        if (file.metadataStatus === 'pending' || file.metadataStatus === 'queued') {
-                            return this.processFileMetadata(file);
-                        }
-                        return Promise.resolve();
-                    });
-                    await Promise.allSettled(promises);
+                let completed = false;
+                Utils.beginBackgroundActivity('Extracting metadata');
+                try {
+                    for (let i = 0; i < pendingFiles.length; i += BATCH_SIZE) {
+                        if (state.activeRequests.signal.aborted) return;
+                        const batch = pendingFiles.slice(i, i + BATCH_SIZE);
+                        const promises = batch.map(file => this.processFileMetadata(file));
+                        await Promise.allSettled(promises);
+                    }
+                    completed = true;
+                } finally {
+                    if (completed && state.currentFolder?.id && Array.isArray(state.imageFiles)) {
+                        state.dbManager.scheduleFolderCacheSave(state.currentFolder.id, state.imageFiles, { priority: 'normal' });
+                    }
+                    Utils.endBackgroundActivity('Extracting metadata');
                 }
             },
             async processFileMetadata(file) {


### PR DESCRIPTION
### Motivation
- Prevent accidental credential clearing when token refresh fails due to transient network or 5xx errors. 
- Stop the loading counter bouncing between discovery/metadata phases and give users clear phase context. 
- Surface ongoing background work (metadata extraction / folder refresh) so the UI does not appear idle while heavy work runs. 

### Description
- Improve auth resilience: `refreshAccessToken()` now distinguishes HTTP 400/401 (mark `tokenRevoked = true`) from network/5xx failures (mark `networkError = true`), and the 401 retry path in `makeApiCall()` clears stored credentials only when `tokenRevoked` is true while surfacing a retriable network error otherwise. (Files: `ui-v1.html`, `ui.html`, `ui-v2.html`, `ui-v3.html`, `pic-v1-providers.js`)
- Loading UX: add a phase label element and change `updateLoadingProgress()` to maintain a monotonic/cumulative display (avoid visible backward counter jumps) and update the phase text based on the progress message. (Files: `ui-v1.html`, `ui.html`, `ui-v2.html`, `ui-v3.html`, `pic-v1.html`, `pic-v1-curate-foundation.js`)
- Background activity indicator: add `beginBackgroundActivity` / `endBackgroundActivity` / `updateBackgroundActivity` helpers and a subtle HUD element that appears during deferred metadata reads, extraction, and folder refreshes; wire these into `processAllMetadata()`, `extractMetadataInBackground()` and `refreshFolderInBackground()`. (Files: `ui-v1.html`, `ui.html`, `ui-v2.html`, `ui-v3.html`, `pic-v1.html`, `pic-v1-curate-foundation.js`, `pic-v1-curate-engine.js`)
- Metadata persistence and merge fixes: make `mustRefreshFromCloud` conditional (only on first session visit or forced full resync), preserve existing per-file fields (e.g., `extractedMetadata`, `metadataStatus`, prompts, ratings, stack, local timestamps) when saving cloud-updated file objects, and schedule a folder-cache save after background PNG metadata extraction completes. (Files: `ui-v1.html`, `ui.html`, `ui-v2.html`, `ui-v3.html`, `pic-v1-curate-engine.js`, `pic-v1-curate-sync.js`)
- Minimal UI/DOM additions: added `loading-phase` element and a `background-activity` HUD; no new external deps and `disconnect()` behavior remains unchanged.

### Testing
- Static JS sanity checks: extracted <script> payloads and ran `node --check` across modified HTML script payloads and updated pic-v1 modules (status: passed).
- Build: ran `npm run build` (Vite) to ensure production bundle transforms (status: passed).
- Unit tests: attempted `npm test -- --runInBand` but repository defines no `test` script (status: no-op / expected); no unit failures introduced.
- Smoke/visual check: launched a headless browser, exercised the loading screen state and captured a screenshot of the new phase + background indicator; screenshot was produced successfully (status: passed).

Files changed (summary): `ui-v1.html`, `ui.html`, `ui-v2.html`, `ui-v3.html`, `pic-v1.html`, `pic-v1-providers.js`, `pic-v1-curate-foundation.js`, `pic-v1-curate-engine.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fc34aaf20832daeaa2576e0fb6290)