### PR TITLE
Persist view context across tab focus changes

### DIFF
--- a/ui-v1.html
+++ b/ui-v1.html
@@ -6009,8 +6009,16 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
-                this.persistViewContext();
-                this.restoreViewContext({ force: true });
+                this.restoreViewContext({ force: true })
+                    .then((restored) => {
+                        if (!restored) {
+                            this.persistViewContext();
+                        }
+                    })
+                    .catch((error) => {
+                        console.warn('Failed to restore view context before showing UI:', error);
+                        this.persistViewContext();
+                    });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -6150,7 +6158,10 @@
                 window.addEventListener('focus', restore);
                 window.addEventListener('blur', persist);
                 window.addEventListener('pagehide', persist);
+                window.addEventListener('pageshow', restore);
                 window.addEventListener('beforeunload', persist);
+                document.addEventListener('freeze', persist);
+                document.addEventListener('resume', restore);
                 this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -4834,8 +4834,16 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
-                this.persistViewContext();
-                this.restoreViewContext({ force: true });
+                this.restoreViewContext({ force: true })
+                    .then((restored) => {
+                        if (!restored) {
+                            this.persistViewContext();
+                        }
+                    })
+                    .catch((error) => {
+                        console.warn('Failed to restore view context before showing UI:', error);
+                        this.persistViewContext();
+                    });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -4986,7 +4994,10 @@
                 window.addEventListener('focus', restore);
                 window.addEventListener('blur', persist);
                 window.addEventListener('pagehide', persist);
+                window.addEventListener('pageshow', restore);
                 window.addEventListener('beforeunload', persist);
+                document.addEventListener('freeze', persist);
+                document.addEventListener('resume', restore);
                 this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -5275,8 +5275,16 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
-                this.persistViewContext();
-                this.restoreViewContext({ force: true });
+                this.restoreViewContext({ force: true })
+                    .then((restored) => {
+                        if (!restored) {
+                            this.persistViewContext();
+                        }
+                    })
+                    .catch((error) => {
+                        console.warn('Failed to restore view context before showing UI:', error);
+                        this.persistViewContext();
+                    });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -5399,7 +5407,10 @@
                 window.addEventListener('focus', restore);
                 window.addEventListener('blur', persist);
                 window.addEventListener('pagehide', persist);
+                window.addEventListener('pageshow', restore);
                 window.addEventListener('beforeunload', persist);
+                document.addEventListener('freeze', persist);
+                document.addEventListener('resume', restore);
                 this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {

--- a/ui.html
+++ b/ui.html
@@ -5136,8 +5136,16 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
-                this.persistViewContext();
-                this.restoreViewContext({ force: true });
+                this.restoreViewContext({ force: true })
+                    .then((restored) => {
+                        if (!restored) {
+                            this.persistViewContext();
+                        }
+                    })
+                    .catch((error) => {
+                        console.warn('Failed to restore view context before showing UI:', error);
+                        this.persistViewContext();
+                    });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -5256,7 +5264,10 @@
                 window.addEventListener('focus', restore);
                 window.addEventListener('blur', persist);
                 window.addEventListener('pagehide', persist);
+                window.addEventListener('pageshow', restore);
                 window.addEventListener('beforeunload', persist);
+                document.addEventListener('freeze', persist);
+                document.addEventListener('resume', restore);
                 this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {


### PR DESCRIPTION
### Motivation
- Prevent the app from overwriting a previously saved view (stack/position/focus) when the UI is shown after a tab blur/focus or similar lifecycle event.
- Improve robustness of view persistence across page lifecycle events (pageshow/freeze/resume) beyond visibility/focus/blur so context is reliably saved and restored.

### Description
- Updated `switchToCommonUI()` in `ui.html`, `ui-v1.html`, `ui-v2.html`, and `ui-v3.html` to attempt `restoreViewContext({ force: true })` before writing a fresh persisted view and to fall back to `persistViewContext()` only when restore fails or returns false.
- Wrapped the restore call in a promise chain that logs a warning on failure and ensures `persistViewContext()` runs when no restored context was applied.
- Extended `registerViewPersistenceLifecycle()` in the same four files to add `pageshow` (restore), `freeze` (persist) and `resume` (restore) event handlers alongside the existing `visibilitychange`/`focus`/`blur`/`pagehide`/`beforeunload` hooks.
- The changes are minimal and scoped to the view persistence lifecycle and UI-show flow; no other app logic was modified.

### Testing
- Extracted inline scripts from `ui.html`, `ui-v1.html`, `ui-v2.html`, and `ui-v3.html` and ran a syntax check (`node --check`) against each generated JS bundle; all four files passed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26e3e25f74832d8cbc9749975cfa27)