### PR TITLE
Revert view persistence lifecycle changes

### DIFF
--- a/ui-v1.html
+++ b/ui-v1.html
@@ -6009,16 +6009,8 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
-                this.restoreViewContext({ force: true })
-                    .then((restored) => {
-                        if (!restored) {
-                            this.persistViewContext();
-                        }
-                    })
-                    .catch((error) => {
-                        console.warn('Failed to restore view context before showing UI:', error);
-                        this.persistViewContext();
-                    });
+                this.persistViewContext();
+                this.restoreViewContext({ force: true });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -6158,10 +6150,7 @@
                 window.addEventListener('focus', restore);
                 window.addEventListener('blur', persist);
                 window.addEventListener('pagehide', persist);
-                window.addEventListener('pageshow', restore);
                 window.addEventListener('beforeunload', persist);
-                document.addEventListener('freeze', persist);
-                document.addEventListener('resume', restore);
                 this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -4834,16 +4834,8 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
-                this.restoreViewContext({ force: true })
-                    .then((restored) => {
-                        if (!restored) {
-                            this.persistViewContext();
-                        }
-                    })
-                    .catch((error) => {
-                        console.warn('Failed to restore view context before showing UI:', error);
-                        this.persistViewContext();
-                    });
+                this.persistViewContext();
+                this.restoreViewContext({ force: true });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -4994,10 +4986,7 @@
                 window.addEventListener('focus', restore);
                 window.addEventListener('blur', persist);
                 window.addEventListener('pagehide', persist);
-                window.addEventListener('pageshow', restore);
                 window.addEventListener('beforeunload', persist);
-                document.addEventListener('freeze', persist);
-                document.addEventListener('resume', restore);
                 this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -5275,16 +5275,8 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
-                this.restoreViewContext({ force: true })
-                    .then((restored) => {
-                        if (!restored) {
-                            this.persistViewContext();
-                        }
-                    })
-                    .catch((error) => {
-                        console.warn('Failed to restore view context before showing UI:', error);
-                        this.persistViewContext();
-                    });
+                this.persistViewContext();
+                this.restoreViewContext({ force: true });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -5407,10 +5399,7 @@
                 window.addEventListener('focus', restore);
                 window.addEventListener('blur', persist);
                 window.addEventListener('pagehide', persist);
-                window.addEventListener('pageshow', restore);
                 window.addEventListener('beforeunload', persist);
-                document.addEventListener('freeze', persist);
-                document.addEventListener('resume', restore);
                 this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {

--- a/ui.html
+++ b/ui.html
@@ -5136,16 +5136,8 @@
             switchToCommonUI() {
                 Utils.showScreen('app-container');
                 this.persistLastPickedFolder();
-                this.restoreViewContext({ force: true })
-                    .then((restored) => {
-                        if (!restored) {
-                            this.persistViewContext();
-                        }
-                    })
-                    .catch((error) => {
-                        console.warn('Failed to restore view context before showing UI:', error);
-                        this.persistViewContext();
-                    });
+                this.persistViewContext();
+                this.restoreViewContext({ force: true });
             },
             persistLastPickedFolder() {
                 if (!state.currentFolder?.id || !state.providerType) {
@@ -5264,10 +5256,7 @@
                 window.addEventListener('focus', restore);
                 window.addEventListener('blur', persist);
                 window.addEventListener('pagehide', persist);
-                window.addEventListener('pageshow', restore);
                 window.addEventListener('beforeunload', persist);
-                document.addEventListener('freeze', persist);
-                document.addEventListener('resume', restore);
                 this._viewPersistenceLifecycleRegistered = true;
             },
             isNavigationActive(token = null) {


### PR DESCRIPTION
### Motivation

- Revert a recent change that introduced a promise chain around `restoreViewContext` and added `pageshow`/`freeze`/`resume` lifecycle handlers which altered the view persistence/show flow.
- Restore the previous, simpler view-persistence ordering and lifecycle handlers to avoid regressions in UI-show and tab focus behavior.

### Description

- Restored `switchToCommonUI()` in `ui.html`, `ui-v1.html`, `ui-v2.html`, and `ui-v3.html` to call `Utils.showScreen('app-container')`, then `this.persistLastPickedFolder()`, then `this.persistViewContext()`, and then `this.restoreViewContext({ force: true });` without the previously added `.then(...)/.catch(...)` promise chain.
- Restored `registerViewPersistenceLifecycle()` in the same four files to keep only handlers for `visibilitychange`, `window.focus`, `window.blur`, `window.pagehide`, and `window.beforeunload`, and removed the added `window.pageshow`, `document.freeze`, and `document.resume` handlers.
- Changes are strictly limited to the listed target files and only modify the view persistence lifecycle and UI-show flow as requested, with no other behavior, styling, markup, metadata, or unrelated logic changed.

### Testing

- Ran `rg -n "pageshow|document\.addEventListener\('freeze'|document\.addEventListener\('resume'|Failed to restore view context before showing UI" ui.html ui-v1.html ui-v2.html ui-v3.html` to verify removed artifacts, and the check returned no matches (success).
- Ran `git diff --check` to ensure there are no diff/whitespace issues, and the check passed (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2938b9acc0832d9c355e9996f2d45d)