### PR TITLE
Auto-resume stored folder on startup for curation apps

### DIFF
--- a/pic-v1-curate-engine.js
+++ b/pic-v1-curate-engine.js
@@ -2,6 +2,27 @@
 // App, Core, Grid — extracted verbatim from ui-v1.html
 
 const App = {
+    async attemptAutoResume() {
+        const lastFolder = state.lastPickedFolder;
+        if (!lastFolder?.providerType || !lastFolder?.folderId) return false;
+        const providerType = lastFolder.providerType;
+        if (providerType !== 'googledrive' && providerType !== 'onedrive') return false;
+        const provider = providerType === 'googledrive' ? new GoogleDriveProvider() : new OneDriveProvider();
+        if (!provider.isAuthenticated) return false;
+        const probeEndpoint = providerType === 'googledrive' ? '/files?pageSize=1&fields=files(id)&supportsAllDrives=true&includeItemsFromAllDrives=true' : '/me/drive';
+        try { await provider.makeApiCall(probeEndpoint); }
+        catch (probeError) {
+            if (providerType !== 'googledrive' || typeof provider.refreshAccessToken !== 'function' || probeError?.networkError || probeError?.tokenRevoked) {
+                state.syncLog?.log({ event: 'startup:auto_resume:probe_failed', level: 'warn', details: probeError?.message || 'Provider probe failed.' });
+                return false;
+            }
+            try { await provider.refreshAccessToken(); await provider.makeApiCall(probeEndpoint); }
+            catch (refreshError) { state.syncLog?.log({ event: 'startup:auto_resume:refresh_failed', level: refreshError?.tokenRevoked ? 'warn' : 'info', details: refreshError?.message || 'Silent refresh failed.' }); return false; }
+        }
+        state.syncLog?.log({ event: 'startup:auto_resume:success', level: 'info', details: `Auto-resuming ${lastFolder.folderName || 'last folder'} from ${providerType}.` });
+        await this.initializeWithProvider(providerType, lastFolder.folderId, lastFolder.folderName || '', provider);
+        return true;
+    },
     selectProvider(type) {
         state.providerType = type;
         const isGoogle = type === 'googledrive';

--- a/pic-v1-curate-events.js
+++ b/pic-v1-curate-events.js
@@ -352,7 +352,10 @@ async function initApp() {
         });
         state.syncManager.start();
         state.metadataExtractor = new MetadataExtractor();
-        Utils.showScreen('provider-screen');
+        const didAutoResume = await App.attemptAutoResume();
+        if (!didAutoResume) {
+            Utils.showScreen('provider-screen');
+        }
         Events.init();
         Gestures.init();
         Core.updateActiveProxTab();

--- a/ui-v1.html
+++ b/ui-v1.html
@@ -5392,6 +5392,41 @@
         }
 
         const App = {
+            async attemptAutoResume() {
+                const lastFolder = state.lastPickedFolder;
+                if (!lastFolder?.providerType || !lastFolder?.folderId) {
+                    return false;
+                }
+                const providerType = lastFolder.providerType;
+                if (providerType !== 'googledrive' && providerType !== 'onedrive') {
+                    return false;
+                }
+                const provider = providerType === 'googledrive' ? new GoogleDriveProvider() : new OneDriveProvider();
+                if (!provider.isAuthenticated) {
+                    return false;
+                }
+                const probeEndpoint = providerType === 'googledrive'
+                    ? '/files?pageSize=1&fields=files(id)&supportsAllDrives=true&includeItemsFromAllDrives=true'
+                    : '/me/drive';
+                try {
+                    await provider.makeApiCall(probeEndpoint);
+                } catch (probeError) {
+                    if (providerType !== 'googledrive' || typeof provider.refreshAccessToken !== 'function' || probeError?.networkError || probeError?.tokenRevoked) {
+                        state.syncLog?.log({ event: 'startup:auto_resume:probe_failed', level: 'warn', details: probeError?.message || 'Provider probe failed.' });
+                        return false;
+                    }
+                    try {
+                        await provider.refreshAccessToken();
+                        await provider.makeApiCall(probeEndpoint);
+                    } catch (refreshError) {
+                        state.syncLog?.log({ event: 'startup:auto_resume:refresh_failed', level: refreshError?.tokenRevoked ? 'warn' : 'info', details: refreshError?.message || 'Silent refresh failed.' });
+                        return false;
+                    }
+                }
+                state.syncLog?.log({ event: 'startup:auto_resume:success', level: 'info', details: `Auto-resuming ${lastFolder.folderName || 'last folder'} from ${providerType}.` });
+                await this.initializeWithProvider(providerType, lastFolder.folderId, lastFolder.folderName || '', provider);
+                return true;
+            },
             selectProvider(type) {
                 state.providerType = type;
                 const isGoogle = type === 'googledrive';
@@ -9585,7 +9620,10 @@ this.updateImageCounters();
                 });
                 state.syncManager.start();
                 state.metadataExtractor = new MetadataExtractor();
-                Utils.showScreen('provider-screen');
+                const didAutoResume = await App.attemptAutoResume();
+                if (!didAutoResume) {
+                    Utils.showScreen('provider-screen');
+                }
                 Events.init();
                 Gestures.init();
                 Core.updateActiveProxTab();

--- a/ui-v2.html
+++ b/ui-v2.html
@@ -4346,6 +4346,41 @@
         }
 
         const App = {
+            async attemptAutoResume() {
+                const lastFolder = state.lastPickedFolder;
+                if (!lastFolder?.providerType || !lastFolder?.folderId) {
+                    return false;
+                }
+                const providerType = lastFolder.providerType;
+                if (providerType !== 'googledrive' && providerType !== 'onedrive') {
+                    return false;
+                }
+                const provider = providerType === 'googledrive' ? new GoogleDriveProvider() : new OneDriveProvider();
+                if (!provider.isAuthenticated) {
+                    return false;
+                }
+                const probeEndpoint = providerType === 'googledrive'
+                    ? '/files?pageSize=1&fields=files(id)&supportsAllDrives=true&includeItemsFromAllDrives=true'
+                    : '/me/drive';
+                try {
+                    await provider.makeApiCall(probeEndpoint);
+                } catch (probeError) {
+                    if (providerType !== 'googledrive' || typeof provider.refreshAccessToken !== 'function' || probeError?.networkError || probeError?.tokenRevoked) {
+                        state.syncLog?.log({ event: 'startup:auto_resume:probe_failed', level: 'warn', details: probeError?.message || 'Provider probe failed.' });
+                        return false;
+                    }
+                    try {
+                        await provider.refreshAccessToken();
+                        await provider.makeApiCall(probeEndpoint);
+                    } catch (refreshError) {
+                        state.syncLog?.log({ event: 'startup:auto_resume:refresh_failed', level: refreshError?.tokenRevoked ? 'warn' : 'info', details: refreshError?.message || 'Silent refresh failed.' });
+                        return false;
+                    }
+                }
+                state.syncLog?.log({ event: 'startup:auto_resume:success', level: 'info', details: `Auto-resuming ${lastFolder.folderName || 'last folder'} from ${providerType}.` });
+                await this.initializeWithProvider(providerType, lastFolder.folderId, lastFolder.folderName || '', provider);
+                return true;
+            },
             selectProvider(type) {
                 state.providerType = type;
                 const isGoogle = type === 'googledrive';
@@ -8419,7 +8454,10 @@ this.updateImageCounters();
                 window.__orbitalDbManager = state.dbManager;
                 state.syncManager = null;
                 state.metadataExtractor = new MetadataExtractor();
-                Utils.showScreen('provider-screen');
+                const didAutoResume = await App.attemptAutoResume();
+                if (!didAutoResume) {
+                    Utils.showScreen('provider-screen');
+                }
                 Events.init();
                 Gestures.init();
                 Core.updateActiveProxTab();

--- a/ui-v3.html
+++ b/ui-v3.html
@@ -4709,6 +4709,41 @@
         }
 
         const App = {
+            async attemptAutoResume() {
+                const lastFolder = state.lastPickedFolder;
+                if (!lastFolder?.providerType || !lastFolder?.folderId) {
+                    return false;
+                }
+                const providerType = lastFolder.providerType;
+                if (providerType !== 'googledrive' && providerType !== 'onedrive') {
+                    return false;
+                }
+                const provider = providerType === 'googledrive' ? new GoogleDriveProvider() : new OneDriveProvider();
+                if (!provider.isAuthenticated) {
+                    return false;
+                }
+                const probeEndpoint = providerType === 'googledrive'
+                    ? '/files?pageSize=1&fields=files(id)&supportsAllDrives=true&includeItemsFromAllDrives=true'
+                    : '/me/drive';
+                try {
+                    await provider.makeApiCall(probeEndpoint);
+                } catch (probeError) {
+                    if (providerType !== 'googledrive' || typeof provider.refreshAccessToken !== 'function' || probeError?.networkError || probeError?.tokenRevoked) {
+                        state.syncLog?.log({ event: 'startup:auto_resume:probe_failed', level: 'warn', details: probeError?.message || 'Provider probe failed.' });
+                        return false;
+                    }
+                    try {
+                        await provider.refreshAccessToken();
+                        await provider.makeApiCall(probeEndpoint);
+                    } catch (refreshError) {
+                        state.syncLog?.log({ event: 'startup:auto_resume:refresh_failed', level: refreshError?.tokenRevoked ? 'warn' : 'info', details: refreshError?.message || 'Silent refresh failed.' });
+                        return false;
+                    }
+                }
+                state.syncLog?.log({ event: 'startup:auto_resume:success', level: 'info', details: `Auto-resuming ${lastFolder.folderName || 'last folder'} from ${providerType}.` });
+                await this.initializeWithProvider(providerType, lastFolder.folderId, lastFolder.folderName || '', provider);
+                return true;
+            },
             selectProvider(type) {
                 state.providerType = type;
                 const isGoogle = type === 'googledrive';
@@ -8479,7 +8514,10 @@ this.updateImageCounters();
                 window.__orbitalSyncManager = state.syncManager;
                 state.syncManager.start();
                 state.metadataExtractor = new MetadataExtractor();
-                Utils.showScreen('provider-screen');
+                const didAutoResume = await App.attemptAutoResume();
+                if (!didAutoResume) {
+                    Utils.showScreen('provider-screen');
+                }
                 Events.init();
                 Gestures.init();
                 Core.updateActiveProxTab();

--- a/ui.html
+++ b/ui.html
@@ -4570,6 +4570,41 @@
         }
 
         const App = {
+            async attemptAutoResume() {
+                const lastFolder = state.lastPickedFolder;
+                if (!lastFolder?.providerType || !lastFolder?.folderId) {
+                    return false;
+                }
+                const providerType = lastFolder.providerType;
+                if (providerType !== 'googledrive' && providerType !== 'onedrive') {
+                    return false;
+                }
+                const provider = providerType === 'googledrive' ? new GoogleDriveProvider() : new OneDriveProvider();
+                if (!provider.isAuthenticated) {
+                    return false;
+                }
+                const probeEndpoint = providerType === 'googledrive'
+                    ? '/files?pageSize=1&fields=files(id)&supportsAllDrives=true&includeItemsFromAllDrives=true'
+                    : '/me/drive';
+                try {
+                    await provider.makeApiCall(probeEndpoint);
+                } catch (probeError) {
+                    if (providerType !== 'googledrive' || typeof provider.refreshAccessToken !== 'function' || probeError?.networkError || probeError?.tokenRevoked) {
+                        state.syncLog?.log({ event: 'startup:auto_resume:probe_failed', level: 'warn', details: probeError?.message || 'Provider probe failed.' });
+                        return false;
+                    }
+                    try {
+                        await provider.refreshAccessToken();
+                        await provider.makeApiCall(probeEndpoint);
+                    } catch (refreshError) {
+                        state.syncLog?.log({ event: 'startup:auto_resume:refresh_failed', level: refreshError?.tokenRevoked ? 'warn' : 'info', details: refreshError?.message || 'Silent refresh failed.' });
+                        return false;
+                    }
+                }
+                state.syncLog?.log({ event: 'startup:auto_resume:success', level: 'info', details: `Auto-resuming ${lastFolder.folderName || 'last folder'} from ${providerType}.` });
+                await this.initializeWithProvider(providerType, lastFolder.folderId, lastFolder.folderName || '', provider);
+                return true;
+            },
             selectProvider(type) {
                 state.providerType = type;
                 const isGoogle = type === 'googledrive';
@@ -8272,7 +8307,10 @@ this.updateImageCounters();
                 window.__orbitalSyncManager = state.syncManager;
                 state.syncManager.start();
                 state.metadataExtractor = new MetadataExtractor();
-                Utils.showScreen('provider-screen');
+                const didAutoResume = await App.attemptAutoResume();
+                if (!didAutoResume) {
+                    Utils.showScreen('provider-screen');
+                }
                 Events.init();
                 Gestures.init();
                 Core.updateActiveProxTab();


### PR DESCRIPTION
### Motivation
- Reduce friction on mobile by resuming curation automatically when `lastPickedFolder` and stored credentials exist so users return directly to their last folder without extra taps.
- Perform a lightweight provider probe on startup and, for Google Drive, attempt a single silent token refresh when appropriate to avoid unnecessary full OAuth flows.
- Keep the existing manual provider selection and authentication flow as the fallback path when auto-resume is not possible.

### Description
- Add `App.attemptAutoResume()` which reads `state.lastPickedFolder`, instantiates the proper provider (`GoogleDriveProvider` or `OneDriveProvider`), checks `provider.isAuthenticated`, issues a lightweight probe (`/files?pageSize=1` for Google, `/me/drive` for OneDrive), and on success calls `App.initializeWithProvider(...)` to skip selection screens.
- If the probe fails for Google with a token issue, `attemptAutoResume()` will call `refreshAccessToken()` once and retry the probe; it logs probe/refresh outcomes and only falls back to the provider screen on irrecoverable errors or network failures.
- Invoke `App.attemptAutoResume()` during `initApp()` before showing `provider-screen`; only call `Utils.showScreen('provider-screen')` when auto-resume returns false, leaving the manual flow unchanged.
- Files modified: `ui-v1.html`, `ui.html`, `ui-v2.html`, `ui-v3.html`, `pic-v1-curate-engine.js`, and `pic-v1-curate-events.js`.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it passed.
- Performed `node --check` on the modular `pic-v1` JS files and on extracted inline `<script>` blocks from the HTML variants using a small Python helper, and syntax checks passed.
- Verified presence of the new `App.attemptAutoResume()` and that `initApp()` calls it before `Utils.showScreen('provider-screen')` across all targeted files via repository grep; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aa55e0efc832d9d0cedd07d79b52d)