### PR TITLE
Explore: mobile-first sphere interactions, density/count controls, pinch zoom, and flick-sort

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -917,9 +917,14 @@
         #explore-button { top: 20px; right: 104px; }
         .spatial-gallery {
             position: fixed; inset: 0; z-index: 12000; overflow: hidden;
-            color: #f8fafc; background: radial-gradient(circle at 50% 45%, #1e293b 0%, #080d18 55%, #020617 100%);
+            color: #f8fafc; background:
+                radial-gradient(circle at 50% 48%, rgba(96,165,250,.18) 0 18%, transparent 46%),
+                radial-gradient(circle at 24% 22%, rgba(255,255,255,.34) 0 1px, transparent 2px),
+                radial-gradient(circle at 76% 68%, rgba(255,255,255,.22) 0 1px, transparent 2px),
+                radial-gradient(circle at 50% 50%, #1e293b 0%, #080d18 56%, #020617 100%);
             touch-action: none; user-select: none; -webkit-user-select: none;
         }
+        .spatial-gallery::after { content: ''; position: absolute; inset: 0; pointer-events: none; background: radial-gradient(circle at 50% 50%, transparent 42%, rgba(2,6,23,.72) 100%); }
         .spatial-gallery[hidden] { display: none; }
         .spatial-gallery__scene { position: absolute; inset: 0; overflow: hidden; cursor: grab; perspective: 900px; }
         .spatial-gallery__scene.dragging { cursor: grabbing; }
@@ -931,23 +936,33 @@
         }
         .spatial-gallery__card img { width: 100%; height: 100%; border-radius: 9px; object-fit: cover; pointer-events: none; }
         .spatial-gallery__card.selected { border-color: #60a5fa; box-shadow: 0 0 0 3px rgba(96,165,250,.35), 0 18px 42px rgba(0,0,0,.5); }
+        .spatial-gallery__card.armed { border-color: #fbbf24; box-shadow: 0 0 0 4px rgba(251,191,36,.28), 0 22px 48px rgba(0,0,0,.56); }
         .spatial-gallery__chrome { position: absolute; z-index: 3; display: flex; align-items: center; gap: 10px; }
         .spatial-gallery__header { top: max(18px, env(safe-area-inset-top)); left: max(18px, env(safe-area-inset-left)); right: max(18px, env(safe-area-inset-right)); justify-content: space-between; pointer-events: none; }
         .spatial-gallery__title { font: 700 16px/1.2 system-ui, sans-serif; letter-spacing: .08em; text-transform: uppercase; text-shadow: 0 2px 8px #000; }
         .spatial-gallery__actions { display: flex; gap: 8px; pointer-events: auto; }
-        .spatial-gallery__button { padding: 9px 13px; border: 1px solid rgba(255,255,255,.25); border-radius: 999px; color: #fff; background: rgba(15,23,42,.72); backdrop-filter: blur(12px); cursor: pointer; }
+        .spatial-gallery__button { min-height: 44px; padding: 10px 14px; border: 1px solid rgba(255,255,255,.25); border-radius: 999px; color: #fff; background: rgba(15,23,42,.72); backdrop-filter: blur(12px); cursor: pointer; }
         .spatial-gallery__button:hover, .spatial-gallery__button:focus-visible { background: rgba(51,65,85,.9); outline: 2px solid #93c5fd; outline-offset: 2px; }
-        .spatial-gallery__destination { position: absolute; z-index: 2; padding: 7px 12px; border: 1px solid rgba(255,255,255,.18); border-radius: 999px; background: rgba(15,23,42,.66); backdrop-filter: blur(10px); font: 700 12px/1 system-ui, sans-serif; letter-spacing: .09em; pointer-events: none; }
+        .spatial-gallery__controls { left: 50%; bottom: max(18px, env(safe-area-inset-bottom)); transform: translateX(-50%); pointer-events: auto; padding: 6px; border: 1px solid rgba(255,255,255,.16); border-radius: 999px; background: rgba(15,23,42,.72); backdrop-filter: blur(12px); }
+        .spatial-gallery__control-label { color: #cbd5e1; font: 700 11px/1 system-ui, sans-serif; letter-spacing: .06em; text-transform: uppercase; }
+        .spatial-gallery__value { min-width: 32px; text-align: center; font: 700 13px/1 system-ui, sans-serif; }
+        .spatial-gallery__destination { position: absolute; z-index: 2; padding: 7px 12px; border: 1px solid rgba(255,255,255,.18); border-radius: 999px; background: rgba(15,23,42,.66); backdrop-filter: blur(10px); font: 700 12px/1 system-ui, sans-serif; letter-spacing: .09em; pointer-events: none; transition: background 120ms ease, transform 120ms ease, border-color 120ms ease; }
+        .spatial-gallery__destination.active { background: rgba(59,130,246,.82); border-color: rgba(191,219,254,.9); }
         .spatial-gallery__destination.keep { top: max(72px, calc(env(safe-area-inset-top) + 60px)); left: 50%; transform: translateX(-50%); }
         .spatial-gallery__destination.trash { bottom: max(24px, env(safe-area-inset-bottom)); left: 50%; transform: translateX(-50%); }
         .spatial-gallery__destination.inbox { left: max(18px, env(safe-area-inset-left)); top: 50%; transform: translateY(-50%); }
         .spatial-gallery__destination.maybe { right: max(18px, env(safe-area-inset-right)); top: 50%; transform: translateY(-50%); }
-        .spatial-gallery__hint { left: 50%; bottom: max(66px, calc(env(safe-area-inset-bottom) + 54px)); transform: translateX(-50%); color: #cbd5e1; font: 12px/1.3 system-ui, sans-serif; text-align: center; pointer-events: none; }
+        .spatial-gallery__hint { left: 50%; bottom: max(74px, calc(env(safe-area-inset-bottom) + 62px)); transform: translateX(-50%); color: #cbd5e1; font: 12px/1.3 system-ui, sans-serif; text-align: center; pointer-events: none; }
         @media (max-width: 640px) {
             #explore-button { top: 64px; right: 20px; }
             .spatial-gallery__card { width: 82px; height: 108px; margin: -54px 0 0 -41px; }
-            .spatial-gallery__destination { padding: 6px 9px; font-size: 10px; }
+            .spatial-gallery__destination { padding: 8px 10px; font-size: 10px; }
+            .spatial-gallery__header { top: max(12px, env(safe-area-inset-top)); left: max(12px, env(safe-area-inset-left)); right: max(12px, env(safe-area-inset-right)); }
+            .spatial-gallery__actions { gap: 6px; }
+            .spatial-gallery__button { padding: 10px 12px; }
             .spatial-gallery__hint { display: none; }
+            .spatial-gallery__controls { gap: 6px; }
+            .spatial-gallery__control-label { display: none; }
         }
         @media (prefers-reduced-motion: reduce) {
             .spatial-gallery__card { transition: none; }
@@ -1162,7 +1177,17 @@
         <div class="spatial-gallery__destination trash">TRASH · ↓</div>
         <div class="spatial-gallery__destination inbox">← · INBOX</div>
         <div class="spatial-gallery__destination maybe">MAYBE · →</div>
-        <div class="spatial-gallery__chrome spatial-gallery__hint">Drag to rotate · Wheel to zoom · Select a photo, then open it</div>
+        <div class="spatial-gallery__chrome spatial-gallery__controls" aria-label="Explore sphere controls">
+            <span class="spatial-gallery__control-label">Density</span>
+            <button id="spatial-gallery-looser" class="spatial-gallery__button" type="button" aria-label="Make sphere looser">−</button>
+            <span id="spatial-gallery-density" class="spatial-gallery__value" aria-live="polite">100%</span>
+            <button id="spatial-gallery-denser" class="spatial-gallery__button" type="button" aria-label="Make sphere denser">+</button>
+            <span class="spatial-gallery__control-label">Images</span>
+            <button id="spatial-gallery-fewer" class="spatial-gallery__button" type="button" aria-label="Show fewer images">−</button>
+            <span id="spatial-gallery-limit" class="spatial-gallery__value" aria-live="polite">90</span>
+            <button id="spatial-gallery-more" class="spatial-gallery__button" type="button" aria-label="Show more images">+</button>
+        </div>
+        <div class="spatial-gallery__chrome spatial-gallery__hint">Drag to rotate · Press photo, flick to Keep/Trash/Inbox/Maybe · Pinch to resize</div>
     </section>
 
     <div id="grid-modal" class="modal hidden">
@@ -9457,9 +9482,10 @@ this.updateImageCounters();
 
 
         const SpatialGallery = {
-            elements: {}, cards: [], files: [], selectedIndex: 0,
-            rotationX: 0, rotationY: 0, velocityX: 0, velocityY: 0, zoom: 1,
-            dragging: false, pointerId: null, lastX: 0, lastY: 0, lastTime: 0,
+            elements: {}, cards: [], files: [], selectedIndex: 0, imageLimit: 90, density: 1, cardScale: 1,
+            rotationX: 0, rotationY: 0, velocityX: 0, velocityY: 0,
+            dragging: false, pointerId: null, lastX: 0, lastY: 0, lastTime: 0, startX: 0, startY: 0,
+            armedCard: null, pressedCard: null, armedIndex: -1, holdTimer: null, activeDestination: null, pinchStartDistance: 0, pinchStartScale: 1,
             frameId: null, lastFrameTime: 0, previousFocus: null,
 
             init() {
@@ -9468,15 +9494,27 @@ this.updateImageCounters();
                 this.elements.count = document.getElementById('spatial-gallery-count');
                 this.elements.close = document.getElementById('spatial-gallery-close');
                 this.elements.open = document.getElementById('spatial-gallery-open');
+                this.elements.density = document.getElementById('spatial-gallery-density');
+                this.elements.limit = document.getElementById('spatial-gallery-limit');
+                this.elements.looser = document.getElementById('spatial-gallery-looser');
+                this.elements.denser = document.getElementById('spatial-gallery-denser');
+                this.elements.fewer = document.getElementById('spatial-gallery-fewer');
+                this.elements.more = document.getElementById('spatial-gallery-more');
                 document.getElementById('explore-button')?.addEventListener('click', () => this.open());
                 this.elements.close?.addEventListener('click', () => this.close());
                 this.elements.open?.addEventListener('click', () => this.openSelected());
+                this.elements.looser?.addEventListener('click', () => this.adjustDensity(0.1));
+                this.elements.denser?.addEventListener('click', () => this.adjustDensity(-0.1));
+                this.elements.fewer?.addEventListener('click', () => this.adjustLimit(-25));
+                this.elements.more?.addEventListener('click', () => this.adjustLimit(25));
                 const scene = this.elements.scene;
                 scene?.addEventListener('pointerdown', event => this.onPointerDown(event));
                 scene?.addEventListener('pointermove', event => this.onPointerMove(event));
                 scene?.addEventListener('pointerup', event => this.onPointerUp(event));
                 scene?.addEventListener('pointercancel', event => this.onPointerUp(event));
                 scene?.addEventListener('wheel', event => this.onWheel(event), { passive: false });
+                this.elements.root?.addEventListener('touchstart', event => this.onTouchStart(event), { passive: false });
+                this.elements.root?.addEventListener('touchmove', event => this.onTouchMove(event), { passive: false });
                 this.elements.root?.addEventListener('keydown', event => {
                     if (event.key === 'Escape') { event.preventDefault(); this.close(); }
                 });
@@ -9484,18 +9522,19 @@ this.updateImageCounters();
 
             open() {
                 const stack = state.stacks[state.currentStack] || [];
-                this.files = stack.slice(0, 100);
+                this.files = stack.slice(0, this.imageLimit);
                 if (!this.files.length) {
                     Utils.showToast('Add images to the current stack before opening Explore.', 'info');
                     return;
                 }
                 this.previousFocus = document.activeElement;
                 this.selectedIndex = Math.max(0, this.files.findIndex(file => file.id === stack[state.currentStackPosition]?.id));
-                this.rotationX = 0; this.rotationY = 0; this.velocityX = 0.0015; this.velocityY = 0; this.zoom = 1;
+                this.rotationX = 0; this.rotationY = 0; this.velocityX = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 0.0015; this.velocityY = 0; this.cardScale = 1;
                 this.buildCards();
                 this.elements.root.hidden = false;
                 document.body.style.overflow = 'hidden';
-                this.elements.count.textContent = `${this.files.length} image${this.files.length === 1 ? '' : 's'} · ${STACK_NAMES[state.currentStack] || state.currentStack}`;
+                this.updateControlLabels();
+                this.elements.count.textContent = `${this.files.length}/${stack.length} image${this.files.length === 1 ? '' : 's'} · ${STACK_NAMES[state.currentStack] || state.currentStack}`;
                 this.elements.close.focus();
                 this.lastFrameTime = performance.now();
                 this.requestFrame();
@@ -9540,6 +9579,8 @@ this.updateImageCounters();
 
             select(index) {
                 this.selectedIndex = index;
+                const stackIndex = (state.stacks[state.currentStack] || []).findIndex(file => file.id === this.files[index]?.id);
+                if (stackIndex >= 0) state.currentStackPosition = stackIndex;
                 this.cards.forEach((card, cardIndex) => card.element.classList.toggle('selected', cardIndex === index));
                 const vector = this.cards[index]?.vector;
                 if (vector) {
@@ -9564,6 +9605,11 @@ this.updateImageCounters();
                 this.dragging = true; this.pointerId = event.pointerId; this.lastX = event.clientX; this.lastY = event.clientY; this.lastTime = performance.now();
                 this.elements.scene.classList.add('dragging');
                 event.target.closest('.spatial-gallery__card')?.setAttribute('data-moved', 'false');
+                this.startX = event.clientX; this.startY = event.clientY;
+                const card = event.target.closest('.spatial-gallery__card');
+                this.armedCard = null; this.pressedCard = card; this.armedIndex = card ? this.cards.findIndex(item => item.element === card) : -1;
+                clearTimeout(this.holdTimer);
+                if (card) this.holdTimer = setTimeout(() => { this.armedCard = card; card.classList.add('armed'); }, 260);
                 this.elements.scene.setPointerCapture?.(event.pointerId);
                 this.requestFrame();
             },
@@ -9572,25 +9618,100 @@ this.updateImageCounters();
                 if (!this.dragging || event.pointerId !== this.pointerId) return;
                 const now = performance.now();
                 const dx = event.clientX - this.lastX, dy = event.clientY - this.lastY;
-                if (Math.abs(dx) + Math.abs(dy) > 3) event.target.closest('.spatial-gallery__card')?.setAttribute('data-moved', 'true');
+                const totalDx = event.clientX - this.startX, totalDy = event.clientY - this.startY;
+                if (Math.abs(dx) + Math.abs(dy) > 3) this.pressedCard?.setAttribute('data-moved', 'true');
+                if (!this.armedCard && Math.hypot(totalDx, totalDy) > 18) clearTimeout(this.holdTimer);
+                if (this.armedCard) this.highlightDestination(totalDx, totalDy);
                 const elapsed = Math.max(8, now - this.lastTime);
-                this.rotationX += dx * 0.006; this.rotationY += dy * 0.006;
-                this.velocityX = dx * 0.006 / elapsed * 16; this.velocityY = dy * 0.006 / elapsed * 16;
+                this.rotationX -= dx * 0.006; this.rotationY -= dy * 0.006;
+                this.velocityX = -dx * 0.006 / elapsed * 16; this.velocityY = -dy * 0.006 / elapsed * 16;
                 this.lastX = event.clientX; this.lastY = event.clientY; this.lastTime = now;
                 this.requestFrame();
             },
 
             onPointerUp(event) {
                 if (event.pointerId !== this.pointerId) return;
-                this.dragging = false; this.pointerId = null;
+                const dx = event.clientX - this.startX, dy = event.clientY - this.startY;
+                const armedIndex = this.armedIndex;
+                const targetStack = this.armedCard ? this.destinationFor(dx, dy) : null;
+                this.dragging = false; this.pointerId = null; clearTimeout(this.holdTimer);
+                this.armedCard?.classList.remove('armed'); this.armedCard = null; this.pressedCard = null; this.armedIndex = -1; this.highlightDestination(0, 0, true);
                 this.elements.scene.classList.remove('dragging');
+                if (targetStack && armedIndex >= 0) this.dealCard(armedIndex, targetStack);
                 this.requestFrame();
             },
 
             onWheel(event) {
                 event.preventDefault();
-                this.zoom = Math.max(0.62, Math.min(1.65, this.zoom * Math.exp(-event.deltaY * 0.001)));
+                this.cardScale = Math.max(0.62, Math.min(1.65, this.cardScale * Math.exp(-event.deltaY * 0.001)));
                 this.requestFrame();
+            },
+
+            onTouchStart(event) {
+                if (this.elements.root.hidden || event.touches.length !== 2) return;
+                event.preventDefault();
+                clearTimeout(this.holdTimer);
+                const [a, b] = event.touches;
+                this.pinchStartDistance = Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
+                this.pinchStartScale = this.cardScale;
+            },
+
+            onTouchMove(event) {
+                if (this.elements.root.hidden || event.touches.length !== 2 || !this.pinchStartDistance) return;
+                event.preventDefault();
+                const [a, b] = event.touches;
+                const distance = Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
+                this.cardScale = Math.max(0.62, Math.min(1.65, this.pinchStartScale * (distance / this.pinchStartDistance)));
+                this.requestFrame();
+            },
+
+            adjustDensity(delta) {
+                this.density = Math.max(0.7, Math.min(1.45, this.density + delta));
+                this.updateControlLabels(); this.requestFrame();
+            },
+
+            adjustLimit(delta) {
+                const stack = state.stacks[state.currentStack] || [];
+                this.imageLimit = Math.max(25, Math.min(150, this.imageLimit + delta));
+                this.files = stack.slice(0, this.imageLimit);
+                this.selectedIndex = Math.max(0, this.files.findIndex(file => file.id === stack[state.currentStackPosition]?.id));
+                this.buildCards(); this.updateControlLabels();
+                this.elements.count.textContent = `${this.files.length}/${stack.length} image${this.files.length === 1 ? '' : 's'} · ${STACK_NAMES[state.currentStack] || state.currentStack}`;
+                this.requestFrame();
+            },
+
+            updateControlLabels() {
+                if (this.elements.density) this.elements.density.textContent = `${Math.round(100 / this.density)}%`;
+                if (this.elements.limit) this.elements.limit.textContent = String(this.imageLimit);
+            },
+
+            destinationFor(dx, dy) {
+                if (Math.hypot(dx, dy) < 92) return null;
+                return Math.abs(dx) > Math.abs(dy) ? (dx > 0 ? 'out' : 'in') : (dy > 0 ? 'trash' : 'priority');
+            },
+
+            highlightDestination(dx, dy, clear = false) {
+                const map = { priority: 'keep', trash: 'trash', in: 'inbox', out: 'maybe' };
+                const next = clear ? null : this.destinationFor(dx, dy);
+                if (next === this.activeDestination) return;
+                this.elements.root.querySelectorAll('.spatial-gallery__destination.active').forEach(el => el.classList.remove('active'));
+                if (next) this.elements.root.querySelector(`.spatial-gallery__destination.${map[next]}`)?.classList.add('active');
+                this.activeDestination = next;
+            },
+
+            async dealCard(index, targetStack) {
+                const file = this.files[index];
+                const stack = state.stacks[state.currentStack] || [];
+                const stackIndex = stack.findIndex(item => item.id === file?.id);
+                if (stackIndex < 0) return;
+                state.currentStackPosition = stackIndex;
+                await Core.moveToStack(targetStack, { source: 'explore:flick' });
+                this.files = (state.stacks[state.currentStack] || []).slice(0, this.imageLimit);
+                this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, this.files.length - 1));
+                if (!this.files.length) { this.close(); return; }
+                this.buildCards(); this.updateControlLabels();
+                const currentStack = state.stacks[state.currentStack] || [];
+                this.elements.count.textContent = `${this.files.length}/${currentStack.length} image${this.files.length === 1 ? '' : 's'} · ${STACK_NAMES[state.currentStack] || state.currentStack}`;
             },
 
             requestFrame() {
@@ -9609,7 +9730,7 @@ this.updateImageCounters();
                 }
                 const sinX = Math.sin(this.rotationX), cosX = Math.cos(this.rotationX);
                 const sinY = Math.sin(this.rotationY), cosY = Math.cos(this.rotationY);
-                const sphereRadius = Math.min(innerWidth, innerHeight) * 0.34 * this.zoom;
+                const sphereRadius = Math.min(innerWidth, innerHeight) * 0.34 * this.density;
                 this.cards.forEach(card => {
                     const v = card.vector;
                     const x1 = v.x * cosX + v.z * sinX;
@@ -9617,12 +9738,14 @@ this.updateImageCounters();
                     const y2 = v.y * cosY - z1 * sinY;
                     const z2 = v.y * sinY + z1 * cosY;
                     const perspective = 1 / (1.8 - z2 * 0.45);
-                    const scale = Math.max(0.38, perspective * 1.25 * this.zoom);
+                    const scale = Math.max(0.34, perspective * 1.18 * this.cardScale);
                     const x = x1 * sphereRadius * perspective;
                     const y = y2 * sphereRadius * perspective;
                     card.element.style.transform = `translate3d(${x.toFixed(1)}px, ${y.toFixed(1)}px, 0) scale(${scale.toFixed(3)})`;
-                    card.element.style.opacity = String(Math.max(0.2, Math.min(1, 0.48 + z2 * 0.45)));
-                    card.element.style.zIndex = String(Math.round((z2 + 1) * 500));
+                    const depth = Math.max(0, Math.min(1, (z2 + 1) / 2));
+                    card.element.style.opacity = String(Math.max(0.16, Math.min(1, 0.22 + depth * 0.78)));
+                    card.element.style.filter = `blur(${((1 - depth) * 1.4).toFixed(2)}px) brightness(${(0.58 + depth * 0.52).toFixed(2)}) contrast(${(0.82 + depth * 0.22).toFixed(2)})`;
+                    card.element.style.zIndex = String(Math.round(depth * 1000));
                 });
                 if (this.dragging || Math.abs(this.velocityX) + Math.abs(this.velocityY) > 0.00015) this.requestFrame();
             }


### PR DESCRIPTION
### Motivation
- Fix the inverted drag/flick rotation so the sphere moves in the same direction as the user's pointer or touch. 
- Make Explore mode touch-first and thumb-friendly while preserving desktop pointer and Escape/close behavior. 
- Improve sphere depth perception and reduce flat overlap so rear images read as deeper in space. 
- Allow quick mobile-friendly density and image-count adjustments and enable tap-hold-and-flick sorting into existing stacks.

### Description
- Styling: added a lightweight CSS scene treatment (radial gradients + vignette), an `armed` card style, and a compact bottom control chrome for density and image-count inside `ui-v2.html` only. 
- Pointer/touch behavior: corrected rotation direction by reversing the sign used when applying pointer deltas to `rotationX`/`rotationY` and adjusted velocity sign so flicks rotate the sphere toward the gesture direction. 
- Mobile-first gestures: implemented tap-hold-to-arm logic with a conservative hold timeout, `pressedCard`/`armedCard` state, destination highlighting, and conservative flick thresholds that map directions to existing stacks and reuse `Core.moveToStack`. 
- Controls & limits: added lightweight density `+ / -` and image-count `+ / -` buttons (image count range 25–150, default ~90), `density` adjusts sphere spacing/radius, `imageLimit` caps the active rendered batch, and `cardScale` (pinch and wheel) controls card size independently of density. 
- Pinch zoom: added two-finger pinch handlers to scale card size and prevent accidental browser zoom while Explore is active; wheel still adjusts `cardScale` on desktop. 
- Rendering: depth-based opacity, blur, brightness, contrast and z-index applied in sphere projection to reduce overlap and improve 3D perception; motion continues to use `requestAnimationFrame` and respects `prefers-reduced-motion` for idle velocity. 
- Selection & sorting: tapping still selects, double-click opens as before, closing preserves selection, and dealing a card updates the active sphere batch without creating new permanent stack arrays.

### Testing
- JavaScript syntax check of the embedded script was run with `node --check` and succeeded. 
- Local smoke tests exercised pointer and touch handlers, pinch scaling, density/count controls, selection, and flick-sorting flows with no exceptions observed. 
- The active rendered batch remains limited to the `imageLimit` setting and image URLs still use existing thumbnail/provider helpers to avoid loading full-resolution assets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72f4380f90832d90c1b8decc9751d0)