### PR TITLE
Fix Explore selection state sync

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -9579,8 +9579,6 @@ this.updateImageCounters();
 
             select(index) {
                 this.selectedIndex = index;
-                const stackIndex = (state.stacks[state.currentStack] || []).findIndex(file => file.id === this.files[index]?.id);
-                if (stackIndex >= 0) state.currentStackPosition = stackIndex;
                 this.cards.forEach((card, cardIndex) => card.element.classList.toggle('selected', cardIndex === index));
                 const vector = this.cards[index]?.vector;
                 if (vector) {


### PR DESCRIPTION
### Motivation
- Prevent desynchronization between the modal Explore selection and the global `state.currentStackPosition` so actions after closing the modal always operate on the image visible in the main UI.

### Description
- Stop mutating `state.currentStackPosition` from `SpatialGallery.select(index)` so in-modal selection only updates the gallery UI; the global stack position is still set when the user chooses `Open selected` (via `openSelected()`), which continues to call `Core.displayCurrentImage()`.

### Testing
- Ran a JavaScript syntax check of the embedded script with `node --check` and it succeeded.
- Ran `git diff --check` to ensure no whitespace issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a734ae3a574832da2c14707a8df769c)