### PR TITLE
Prevent global sorting shortcuts while Explore is open

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -9511,6 +9511,7 @@ this.updateImageCounters();
                 this.elements.root?.addEventListener('touchmove', event => this.onTouchMove(event), { passive: false });
                 this.elements.root?.addEventListener('keydown', event => {
                     if (event.key === 'Escape') { event.preventDefault(); this.close(); }
+                    event.stopPropagation();
                 });
             },
 
@@ -10289,6 +10290,11 @@ this.updateImageCounters();
                     if (Utils.elements.appContainer.classList.contains('hidden')) return;
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
+                    if (!SpatialGallery.elements.root?.hidden) {
+                        e.preventDefault();
+                        if (e.key === 'Escape') SpatialGallery.close();
+                        return;
+                    }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
 
                     try {


### PR DESCRIPTION
### Motivation
- Fix a bug where document-level arrow-key sorting acted on the main viewer's stale `state.currentStackPosition` while the Explore dialog highlighted a different card, causing keyboard sorts to move the wrong photo.

### Description
- In `ui-v2.html` added `event.stopPropagation()` to the `SpatialGallery` root keydown handler and added a document-level guard in `setupKeyboardNavigation` that short-circuits and suppresses global keyboard sorting/navigation while `SpatialGallery.elements.root` is visible, while still preserving `Escape` to close Explore.

### Testing
- Ran `git diff --check`, extracted inline scripts and ran `node --check /tmp/ui-v2-script.js`, and ran `npm run build`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73caf47cfc832d92748a27a4722f28)