### PR TITLE
Replace persistent top view nav with accessible center-triggered mode chooser; fix Explore double-tap, tap/drag detection, and thumbnail caching

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -914,9 +914,11 @@
 
 
         /* Explore sphere: an isolated, read-only spatial view of the active stack. */
-        .view-navigation { position: absolute; z-index: 21; top: 20px; left: 50%; display: flex; padding: 3px; border: 1px solid rgba(255,255,255,.2); border-radius: 999px; background: rgba(0,0,0,.4); backdrop-filter: blur(10px); transform: translateX(-50%); }
-        .view-navigation__button { min-height: 36px; padding: 7px 13px; border: 0; border-radius: 999px; color: #e5e7eb; background: transparent; cursor: pointer; }
-        .view-navigation__button[aria-selected="true"] { background: rgba(37,99,235,.72); color: #fff; }
+        .mode-chooser { position: fixed; inset: 0; z-index: 12500; display: grid; place-items: center; background: rgba(2,6,23,.34); }
+        .mode-chooser[hidden] { display: none; }
+        .mode-chooser__menu { display: flex; gap: 4px; padding: 5px; border: 1px solid rgba(255,255,255,.24); border-radius: 999px; background: rgba(15,23,42,.92); box-shadow: 0 18px 48px rgba(0,0,0,.48); backdrop-filter: blur(14px); }
+        .mode-chooser__button { min-height: 44px; padding: 9px 16px; border: 0; border-radius: 999px; color: #e5e7eb; background: transparent; cursor: pointer; font: 600 14px/1 system-ui, sans-serif; }
+        .mode-chooser__button:hover, .mode-chooser__button:focus-visible { color: #fff; background: rgba(37,99,235,.72); outline: 2px solid #93c5fd; outline-offset: 1px; }
         .spatial-gallery {
             position: fixed; inset: 0; z-index: 12000; overflow: hidden;
             color: #f8fafc; background:
@@ -962,7 +964,6 @@
         .spatial-gallery__destination.maybe { right: max(18px, env(safe-area-inset-right)); top: 50%; transform: translateY(-50%); }
         .spatial-gallery__hint { left: 50%; bottom: max(74px, calc(env(safe-area-inset-bottom) + 62px)); transform: translateX(-50%); color: #cbd5e1; font: 12px/1.3 system-ui, sans-serif; text-align: center; pointer-events: none; }
         @media (max-width: 640px) {
-            .view-navigation { top: 64px; }
             .spatial-gallery__card { width: 82px; height: 108px; margin: -54px 0 0 -41px; }
             .spatial-gallery__destination { padding: 8px 10px; font-size: 10px; }
             .spatial-gallery__header { top: max(12px, env(safe-area-inset-top)); left: max(12px, env(safe-area-inset-left)); right: max(12px, env(safe-area-inset-right)); }
@@ -1104,11 +1105,6 @@
             <span id="back-button-spinner" class="spinner" style="display: none; width: 14px; height: 14px; margin-right: 6px;"></span>
             Folders
         </button>
-        <nav class="view-navigation" aria-label="Image view" role="tablist">
-            <button class="view-navigation__button" id="table-view-button" type="button" role="tab" aria-selected="false">Table</button>
-            <button class="view-navigation__button" id="explore-button" type="button" role="tab" aria-selected="false" aria-haspopup="dialog">Explore</button>
-            <button class="view-navigation__button" id="focus-view-button" type="button" role="tab" aria-selected="false">Focus</button>
-        </nav>
         <button class="ui-button" id="details-button">Details</button>
 
         <div class="image-viewport" id="image-viewport">
@@ -1117,7 +1113,7 @@
         <!-- Gesture overlay (triangular sort zones + focus halves) -->
         <div class="gesture-layer" id="gesture-layer">
             <div id="gesture-screen-a" class="stage" role="application"
-                 aria-label="Sort mode. Triangular flick zones. Double-tap center hub to enter focus mode.">
+                 aria-label="Sort mode. Triangular flick zones. Double-tap the center to choose Table, Explore, or Focus.">
                 <div id="gesture-tri-up" class="tri up"></div>
                 <div id="gesture-tri-right" class="tri right"></div>
                 <div id="gesture-tri-down" class="tri down"></div>
@@ -1174,11 +1170,19 @@
         </div>
     </div>
 
+    <div id="mode-chooser" class="mode-chooser" role="dialog" aria-modal="true" aria-label="Choose image view" hidden>
+        <div class="mode-chooser__menu" role="menu">
+            <button class="mode-chooser__button" type="button" role="menuitem" data-mode="table">Table</button>
+            <button class="mode-chooser__button" type="button" role="menuitem" data-mode="explore">Explore</button>
+            <button class="mode-chooser__button" type="button" role="menuitem" data-mode="focus">Focus</button>
+        </div>
+    </div>
+
     <!-- Enhanced Grid Modal -->
 
 
     <section id="spatial-gallery" class="spatial-gallery" role="dialog" aria-modal="true" aria-labelledby="spatial-gallery-title" hidden>
-        <div id="spatial-gallery-scene" class="spatial-gallery__scene" aria-label="Rotatable sphere of images"></div>
+        <div id="spatial-gallery-scene" class="spatial-gallery__scene" aria-label="Rotatable sphere of images. Double-tap the center background to return to Sort. Dragging does not activate an image."></div>
         <div class="spatial-gallery__chrome spatial-gallery__header">
             <div><div id="spatial-gallery-title" class="spatial-gallery__title">Explore</div><div id="spatial-gallery-count" aria-live="polite"></div></div>
             <div class="spatial-gallery__actions">
@@ -1196,10 +1200,10 @@
             <span class="spatial-gallery__control-label">Images</span>
             <span class="spatial-gallery__stepper" data-control="limit"><button class="spatial-gallery__adjust" data-delta="10" type="button">+</button><button id="spatial-gallery-limit" class="spatial-gallery__value" type="button" aria-live="polite">30</button><button class="spatial-gallery__adjust" data-delta="-10" type="button">−</button></span>
         </div>
-        <div class="spatial-gallery__chrome spatial-gallery__hint">Drag to rotate · Press photo, flick to Keep/Trash/Inbox/Maybe · Pinch to resize</div>
+        <div class="spatial-gallery__chrome spatial-gallery__hint">Drag to rotate (dragging does not open photos) · Double-tap center background for Sort · Press photo, flick to deal · Pinch to resize</div>
     </section>
 
-    <div id="grid-modal" class="modal hidden">
+    <div id="grid-modal" class="modal hidden" role="dialog" aria-label="Table view. Double-tap the center background to return to Sort.">
         <div class="modal-content">
             <div class="modal-header">
                 <div id="grid-modal-header-main" class="modal-header-main">
@@ -1944,8 +1948,7 @@
 
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
-                    tableViewButton: document.getElementById('table-view-button'),
-                    focusViewButton: document.getElementById('focus-view-button'),
+                    modeChooser: document.getElementById('mode-chooser'),
                     detailsButton: document.getElementById('details-button'),
                     imageViewport: document.getElementById('image-viewport'),
                     centerImage: document.getElementById('center-image'),
@@ -7228,7 +7231,6 @@ this.updateImageCounters();
             open(stack) {
                 this.clearDragState();
                 Utils.showModal('grid-modal');
-                Utils.elements.tableViewButton?.setAttribute('aria-selected', 'true');
                 Utils.elements.gridTitle.textContent = STACK_NAMES[stack] || stack;
                 state.grid.stack = stack;
                 state.grid.isDirty = false;
@@ -7251,7 +7253,7 @@ this.updateImageCounters();
                         await this.reorderStackOnClose();
                     }
                     Utils.hideModal('grid-modal');
-                    Utils.elements.tableViewButton?.setAttribute('aria-selected', 'false');
+                    ModeCenterTap.reset();
                     this.resetSearch(); this.destroyLazyLoad();
                     const selectedImages = state.grid.selected;
                     if (selectedImages.length === 1) {
@@ -8400,10 +8402,84 @@ this.updateImageCounters();
                 Utils.showToast(`Select destination folder for ${state.folderMoveMode.files.length} images`, 'info', true);
             }
         };
+        const ModeCenterTap = {
+            interval: 360, distance: 28, movement: 8, pending: null, pointer: null,
+            reset() { this.pending = null; this.pointer = null; },
+            bind(element, isEligible, action) {
+                element?.addEventListener('pointerdown', event => {
+                    if ((event.button !== undefined && event.button !== 0) || !isEligible(event)) { this.pointer = null; return; }
+                    this.pointer = { id: event.pointerId, x: event.clientX, y: event.clientY, max: 0 };
+                });
+                element?.addEventListener('pointermove', event => {
+                    if (!this.pointer || event.pointerId !== this.pointer.id) return;
+                    this.pointer.max = Math.max(this.pointer.max, Math.hypot(event.clientX - this.pointer.x, event.clientY - this.pointer.y));
+                    if (this.pointer.max > this.movement) this.pending = null;
+                });
+                const finish = event => {
+                    if (!this.pointer || event.pointerId !== this.pointer.id) return;
+                    const tap = this.pointer;
+                    this.pointer = null;
+                    tap.max = Math.max(tap.max, Math.hypot(event.clientX - tap.x, event.clientY - tap.y));
+                    if (tap.max > this.movement || !isEligible(event)) { this.pending = null; return; }
+                    const now = performance.now();
+                    if (this.pending && now - this.pending.time <= this.interval && Math.hypot(event.clientX - this.pending.x, event.clientY - this.pending.y) <= this.distance) {
+                        this.pending = null;
+                        event.preventDefault();
+                        action();
+                    } else this.pending = { time: now, x: event.clientX, y: event.clientY };
+                };
+                element?.addEventListener('pointerup', finish);
+                element?.addEventListener('pointercancel', () => this.reset());
+            }
+        };
+
+        const ModeChooser = {
+            previousFocus: null,
+            init() {
+                const root = Utils.elements.modeChooser;
+                root?.addEventListener('click', event => {
+                    const option = event.target.closest('[data-mode]');
+                    if (option) this.choose(option.dataset.mode);
+                    else if (event.target === root) this.close();
+                });
+                root?.addEventListener('keydown', event => {
+                    if (event.key === 'Escape') { event.preventDefault(); this.close(); }
+                    if (!['ArrowLeft', 'ArrowRight'].includes(event.key)) return;
+                    event.preventDefault();
+                    const options = [...root.querySelectorAll('[data-mode]')];
+                    const offset = event.key === 'ArrowRight' ? 1 : -1;
+                    options[(options.indexOf(document.activeElement) + offset + options.length) % options.length].focus();
+                });
+            },
+            open() {
+                if (state.isFocusMode || !Utils.elements.gridModal.classList.contains('hidden') || !SpatialGallery.elements.root?.hidden) return;
+                this.previousFocus = document.activeElement;
+                ModeCenterTap.reset();
+                Gestures.lastHubTap = { time: 0, x: 0, y: 0 };
+                Utils.elements.modeChooser.hidden = false;
+                Utils.elements.modeChooser.querySelector('[data-mode]')?.focus();
+            },
+            close({ restoreFocus = true } = {}) {
+                if (Utils.elements.modeChooser.hidden) return;
+                Utils.elements.modeChooser.hidden = true;
+                ModeCenterTap.reset();
+                Gestures.lastHubTap = { time: 0, x: 0, y: 0 };
+                if (restoreFocus) this.previousFocus?.focus?.();
+            },
+            choose(mode) {
+                const returnFocus = this.previousFocus;
+                this.close({ restoreFocus: false });
+                returnFocus?.focus?.();
+                if (mode === 'table') Grid.open(state.currentStack);
+                else if (mode === 'explore') SpatialGallery.open();
+                else if (mode === 'focus' && !state.isFocusMode) Gestures.toggleFocusMode();
+            }
+        };
         const Gestures = {
             startPos: { x: 0, y: 0 },
             currentPos: { x: 0, y: 0 },
             startTimestamp: 0,
+            maxTapDistance: 0,
             gestureStarted: false,
             edgeElements: [],
             hubPressActive: false,
@@ -8626,6 +8702,7 @@ this.updateImageCounters();
                 this.startPos = { x: point.clientX, y: point.clientY };
                 this.currentPos = { x: point.clientX, y: point.clientY };
                 this.startTimestamp = performance.now();
+                this.maxTapDistance = 0;
                 this.gestureStarted = false;
                 state.isDragging = true;
                 this.hubPressActive = hubInteraction;
@@ -8644,6 +8721,7 @@ this.updateImageCounters();
                 e.preventDefault();
                 const point = e.touches ? e.touches[0] : e;
                 this.currentPos = { x: point.clientX, y: point.clientY };
+                this.maxTapDistance = Math.max(this.maxTapDistance, Math.hypot(this.currentPos.x - this.startPos.x, this.currentPos.y - this.startPos.y));
                 this.queueTrail(point.clientX, point.clientY);
                 if (this.hubPressActive) { return; }
                 if (state.imageFiles.length === 0) return;
@@ -8674,9 +8752,10 @@ this.updateImageCounters();
                 const deltaX = this.currentPos.x - this.startPos.x;
                 const deltaY = this.currentPos.y - this.startPos.y;
                 const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+                this.maxTapDistance = Math.max(this.maxTapDistance, distance);
                 const now = performance.now();
                 const duration = now - this.startTimestamp;
-                const isTap = distance < this.TAP_DISTANCE_THRESHOLD && duration < this.TAP_DURATION_THRESHOLD;
+                const isTap = this.maxTapDistance < this.TAP_DISTANCE_THRESHOLD && duration < this.TAP_DURATION_THRESHOLD;
 
                 if (this.hubPressActive) {
                     if (isTap) {
@@ -8684,7 +8763,8 @@ this.updateImageCounters();
                             const tapDistance = Math.hypot(this.lastHubTap.x - this.currentPos.x, this.lastHubTap.y - this.currentPos.y);
                             if (tapDistance <= this.DOUBLE_TAP_MAX_DISTANCE) {
                                 this.spawnRipple(this.currentPos.x, this.currentPos.y);
-                                this.toggleFocusMode();
+                                if (state.isFocusMode) this.toggleFocusMode();
+                                else ModeChooser.open();
                                 if (state.haptic) { state.haptic.triggerFeedback('buttonPress'); }
                                 this.lastHubTap = { time: 0, x: 0, y: 0 };
                             } else {
@@ -8770,7 +8850,6 @@ this.updateImageCounters();
             toggleFocusMode() {
                 state.isFocusMode = !state.isFocusMode;
                 Utils.elements.appContainer.classList.toggle('focus-mode', state.isFocusMode);
-                Utils.elements.focusViewButton?.setAttribute('aria-selected', String(state.isFocusMode));
                 this.updateGestureOverlayMode();
 
                 if (!state.isFocusMode) {
@@ -8789,6 +8868,7 @@ this.updateImageCounters();
 
                 Core.updateImageCounters();
                 this.lastHubTap = { time: 0, x: 0, y: 0 };
+                ModeCenterTap.reset();
             },
             async nextImage() {
                 const stack = state.stacks[state.currentStack];
@@ -9496,7 +9576,7 @@ this.updateImageCounters();
 
         const ExploreThumbnailCache = {
             dbName: `${APP_IDENTITY.storagePrefix}:explore-thumbnails:v1`, storeName: 'thumbnails', maxEntries: 320,
-            objectUrls: new Map(), dbPromise: null,
+            objectUrls: new Map(), inFlight: new Map(), dbPromise: null,
             open() {
                 if (!('indexedDB' in window)) return Promise.resolve(null);
                 if (!this.dbPromise) this.dbPromise = new Promise(resolve => {
@@ -9518,33 +9598,45 @@ this.updateImageCounters();
                     request.onerror = () => resolve(null);
                 });
             },
-            async load(img, url) {
-                if (!url) return;
+            async load(img, url, isValid = () => true) {
+                if (!url || !isValid()) return;
                 const existing = this.objectUrls.get(url);
                 if (existing) {
-                    existing.used = Date.now(); img.src = existing.src;
-                    this.open().then(db => db && this.request(db, 'readonly', store => store.get(url)).then(record => {
-                        if (record) { record.used = Date.now(); this.request(db, 'readwrite', store => store.put(record)); }
-                    }));
+                    existing.used = Date.now();
+                    if (isValid() && img.isConnected) img.src = existing.src;
                     return;
                 }
-                img.src = url;
+                if (isValid()) img.src = url;
                 try {
-                    const db = await this.open();
-                    let record = db && await this.request(db, 'readonly', store => store.get(url));
-                    if (!record) {
-                        const response = await fetch(url, { credentials: 'same-origin' });
-                        if (!response.ok) return;
-                        record = { url, blob: await response.blob(), used: Date.now() };
-                        if (db) this.request(db, 'readwrite', store => store.put(record)).then(() => this.evict(db));
-                    } else {
-                        record.used = Date.now();
-                        this.request(db, 'readwrite', store => store.put(record));
+                    let pending = this.inFlight.get(url);
+                    if (!pending) {
+                        pending = (async () => {
+                            const db = await this.open();
+                            let record = db && await this.request(db, 'readonly', store => store.get(url));
+                            if (!record) {
+                                const response = await fetch(url, { credentials: 'same-origin' });
+                                if (!response.ok) return null;
+                                record = { url, blob: await response.blob(), used: Date.now() };
+                                if (db) this.request(db, 'readwrite', store => store.put(record)).then(() => this.evict(db));
+                            } else {
+                                record.used = Date.now();
+                                this.request(db, 'readwrite', store => store.put(record));
+                            }
+                            return record.blob;
+                        })();
+                        this.inFlight.set(url, pending);
+                        pending.finally(() => { if (this.inFlight.get(url) === pending) this.inFlight.delete(url); });
                     }
-                    if (!img.isConnected) return;
-                    const src = URL.createObjectURL(record.blob);
-                    this.objectUrls.set(url, { src, used: Date.now() });
-                    img.src = src;
+                    const blob = await pending;
+                    if (!blob || !isValid() || !img.isConnected) return;
+                    let value = this.objectUrls.get(url);
+                    if (!value) {
+                        if (!isValid() || !img.isConnected) return;
+                        value = { src: URL.createObjectURL(blob), used: Date.now() };
+                        if (!isValid() || !img.isConnected) { URL.revokeObjectURL(value.src); return; }
+                        this.objectUrls.set(url, value);
+                    }
+                    if (isValid() && img.isConnected) img.src = value.src;
                 } catch (_) { /* The normal browser image cache remains the safe fallback. */ }
             },
             async evict(db) {
@@ -9554,8 +9646,10 @@ this.updateImageCounters();
                 expired.forEach(record => {
                     this.request(db, 'readwrite', store => store.delete(record.url));
                     const value = this.objectUrls.get(record.url);
-                    if (value) URL.revokeObjectURL(value.src);
-                    this.objectUrls.delete(record.url);
+                    const inUse = value && [...document.querySelectorAll('.spatial-gallery__card img')].some(img => img.isConnected && img.src === value.src);
+                    if (value && !inUse) {
+                        URL.revokeObjectURL(value.src); this.objectUrls.delete(record.url);
+                    }
                 });
             },
             releaseUnused(activeUrls) {
@@ -9572,7 +9666,7 @@ this.updateImageCounters();
             armedCard: null, pressedCard: null, armedIndex: -1, holdTimer: null, activeDestination: null, pinchStartDistance: 0, pinchStartScale: 1,
             controlsDragging: false, controlsPointerId: null, controlsOffsetX: 0, controlsOffsetY: 0,
             frameId: null, lastFrameTime: 0, previousFocus: null, focusedIndex: -1, pageSize: 30,
-            pageTimer: null, persistTimer: null, logTimer: null, tapTimer: null, lastTapIndex: -1, lastTapTime: 0,
+            pageTimer: null, persistTimer: null, logTimer: null, tapTimer: null, lastTapIndex: -1, lastTapTime: 0, loadGeneration: 0, maxPointerDistance: 0,
 
             init() {
                 this.elements.root = document.getElementById('spatial-gallery');
@@ -9581,10 +9675,8 @@ this.updateImageCounters();
                 this.elements.close = document.getElementById('spatial-gallery-close');
                 this.elements.details = document.getElementById('spatial-gallery-details');
                 this.elements.controls = this.elements.root.querySelector('.spatial-gallery__controls');
-                this.elements.exploreButton = document.getElementById('explore-button');
                 this.elements.density = document.getElementById('spatial-gallery-density');
                 this.elements.limit = document.getElementById('spatial-gallery-limit');
-                this.elements.exploreButton?.addEventListener('click', () => this.elements.root.hidden ? this.open() : this.close());
                 this.elements.close?.addEventListener('click', () => this.close());
                 this.elements.details?.addEventListener('click', () => this.showFocusedDetails());
                 this.elements.root.querySelectorAll('.spatial-gallery__destination').forEach(button => button.addEventListener('click', () => this.dealFocusedCard(button.dataset.stack)));
@@ -9603,6 +9695,7 @@ this.updateImageCounters();
                 scene?.addEventListener('pointermove', event => this.onPointerMove(event));
                 scene?.addEventListener('pointerup', event => this.onPointerUp(event));
                 scene?.addEventListener('pointercancel', event => this.onPointerUp(event));
+                ModeCenterTap.bind(scene, event => event.target === scene && this.isCentralPoint(event.clientX, event.clientY), () => this.close());
                 scene?.addEventListener('wheel', event => this.onWheel(event), { passive: false });
                 this.elements.root?.addEventListener('touchstart', event => this.onTouchStart(event), { passive: false });
                 this.elements.root?.addEventListener('touchmove', event => this.onTouchMove(event), { passive: false });
@@ -9620,12 +9713,11 @@ this.updateImageCounters();
                     return;
                 }
                 this.previousFocus = document.activeElement;
+                this.loadGeneration++;
                 this.selectedIndex = Math.max(0, this.files.findIndex(file => file.id === stack[state.currentStackPosition]?.id));
                 this.rotationX = 0; this.rotationY = 0; this.velocityX = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 0.0015; this.velocityY = 0;
-                this.buildCards();
                 this.elements.root.hidden = false;
-                this.elements.exploreButton?.classList.add('active');
-                this.elements.exploreButton?.setAttribute('aria-selected', 'true');
+                this.buildCards();
                 document.body.style.overflow = 'hidden';
                 this.restoreControlsPosition();
                 this.updateControlLabels();
@@ -9639,22 +9731,23 @@ this.updateImageCounters();
             close() {
                 if (this.elements.root.hidden) return;
                 this.elements.root.hidden = true;
-                this.elements.exploreButton?.classList.remove('active');
-                this.elements.exploreButton?.setAttribute('aria-selected', 'false');
+                this.loadGeneration++;
                 document.body.style.overflow = '';
                 if (this.frameId) cancelAnimationFrame(this.frameId);
                 this.frameId = null;
-                clearTimeout(this.pageTimer); clearTimeout(this.tapTimer);
+                clearTimeout(this.pageTimer); clearTimeout(this.tapTimer); clearTimeout(this.holdTimer);
                 this.lastTapIndex = -1; this.lastTapTime = 0;
                 this.elements.scene.replaceChildren();
                 this.cards = [];
+                this.files = []; this.dragging = false; this.pointerId = null; this.pressedCard = null; this.armedCard = null; this.armedIndex = -1; this.pinchStartDistance = 0;
+                ModeCenterTap.reset();
                 ExploreThumbnailCache.releaseUnused(new Set());
                 this.previousFocus?.focus?.();
             },
 
             buildCards() {
                 this.elements.scene.replaceChildren();
-                ExploreThumbnailCache.releaseUnused(new Set(this.files.slice(0, this.pageSize).map(file => Utils.getPreferredImageUrl(file) || file.thumbnailLink || file.downloadUrl || '')));
+                ExploreThumbnailCache.releaseUnused(new Set(this.files.map(file => Utils.getPreferredImageUrl(file) || file.thumbnailLink || file.downloadUrl || '')));
                 this.cards = [];
                 this.appendPage();
             },
@@ -9672,7 +9765,6 @@ this.updateImageCounters();
                     img.loading = index < 18 ? 'eager' : 'lazy';
                     img.decoding = 'async';
                     img.draggable = false;
-                    ExploreThumbnailCache.load(img, Utils.getPreferredImageUrl(file) || file.thumbnailLink || file.downloadUrl || '');
                     card.appendChild(img);
                     card.addEventListener('click', event => {
                         if (card.dataset.moved === 'true') return;
@@ -9682,6 +9774,8 @@ this.updateImageCounters();
                     });
                     this.elements.scene.appendChild(card);
                     this.cards.push({ element: card, vector: null });
+                    const generation = this.loadGeneration;
+                    ExploreThumbnailCache.load(img, Utils.getPreferredImageUrl(file) || file.thumbnailLink || file.downloadUrl || '', () => generation === this.loadGeneration && !this.elements.root.hidden && img.isConnected);
                 }
                 this.updateVectors();
                 this.requestFrame();
@@ -9746,12 +9840,22 @@ this.updateImageCounters();
                 Core.displayCurrentImage();
             },
 
+            isCentralPoint(x, y) {
+                const rect = this.elements.scene.getBoundingClientRect();
+                return Math.hypot(x - (rect.left + rect.width / 2), y - (rect.top + rect.height / 2)) <= Math.min(rect.width, rect.height) * .2;
+            },
+
+            clearCardTap() {
+                clearTimeout(this.tapTimer); this.lastTapIndex = -1; this.lastTapTime = 0;
+            },
+
             onPointerDown(event) {
                 if (event.button !== undefined && event.button !== 0) return;
                 this.dragging = true; this.pointerId = event.pointerId; this.lastX = event.clientX; this.lastY = event.clientY; this.lastTime = performance.now();
                 this.elements.scene.classList.add('dragging');
                 event.target.closest('.spatial-gallery__card')?.setAttribute('data-moved', 'false');
                 this.startX = event.clientX; this.startY = event.clientY;
+                this.maxPointerDistance = 0;
                 const card = event.target.closest('.spatial-gallery__card');
                 this.armedCard = null; this.pressedCard = card; this.armedIndex = card ? this.cards.findIndex(item => item.element === card) : -1;
                 clearTimeout(this.holdTimer);
@@ -9765,7 +9869,10 @@ this.updateImageCounters();
                 const now = performance.now();
                 const dx = event.clientX - this.lastX, dy = event.clientY - this.lastY;
                 const totalDx = event.clientX - this.startX, totalDy = event.clientY - this.startY;
-                if (Math.abs(dx) + Math.abs(dy) > 3) this.pressedCard?.setAttribute('data-moved', 'true');
+                this.maxPointerDistance = Math.max(this.maxPointerDistance, Math.hypot(totalDx, totalDy));
+                if (this.maxPointerDistance > 3 && this.pressedCard?.dataset.moved !== 'true') {
+                    this.pressedCard?.setAttribute('data-moved', 'true'); this.clearCardTap();
+                }
                 if (!this.armedCard && Math.hypot(totalDx, totalDy) > 18) clearTimeout(this.holdTimer);
                 if (this.armedCard) {
                     this.highlightDestination(totalDx, totalDy);
@@ -9783,12 +9890,13 @@ this.updateImageCounters();
                 if (event.pointerId !== this.pointerId) return;
                 const dx = event.clientX - this.startX, dy = event.clientY - this.startY;
                 const armedIndex = this.armedIndex;
+                const moved = this.maxPointerDistance > 3 || this.pressedCard?.dataset.moved === 'true';
                 const targetStack = this.armedCard ? this.destinationFor(dx, dy) : null;
                 this.dragging = false; this.pointerId = null; clearTimeout(this.holdTimer);
                 this.armedCard?.classList.remove('armed'); this.armedCard = null; this.pressedCard = null; this.armedIndex = -1; this.highlightDestination(0, 0, true);
                 this.elements.scene.classList.remove('dragging');
                 if (targetStack && armedIndex >= 0) this.dealCard(armedIndex, targetStack);
-                else if (armedIndex >= 0 && Math.hypot(dx, dy) <= 8) this.handleCardTap(armedIndex, event.timeStamp);
+                else if (armedIndex >= 0 && !moved && Math.hypot(dx, dy) <= 8) this.handleCardTap(armedIndex, event.timeStamp);
                 this.requestFrame();
             },
 
@@ -9803,7 +9911,8 @@ this.updateImageCounters();
                 if (this.elements.root.hidden || event.touches.length !== 2) return;
                 event.preventDefault();
                 this.dragging = false; this.pointerId = null; this.elements.scene.classList.remove('dragging');
-                clearTimeout(this.holdTimer);
+                clearTimeout(this.holdTimer); this.clearCardTap();
+                this.pressedCard = null; this.armedCard?.classList.remove('armed'); this.armedCard = null; this.armedIndex = -1;
                 const [a, b] = event.touches;
                 this.pinchStartDistance = Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
                 this.pinchStartScale = this.cardScale;
@@ -10295,10 +10404,13 @@ this.updateImageCounters();
                 Utils.elements.detailsClose.addEventListener('click', () => Details.hide());
             },
             setupFocusMode() {
-                Utils.elements.tableViewButton?.addEventListener('click', () => Grid.open(state.currentStack));
-                Utils.elements.focusViewButton?.addEventListener('click', () => {
-                    if (!state.isFocusMode) Gestures.toggleFocusMode();
-                });
+                ModeChooser.init();
+                ModeCenterTap.bind(Utils.elements.gridModal, event => {
+                    if (Utils.elements.gridModal.classList.contains('hidden')) return false;
+                    if (event.target.closest('button, input, select, textarea, a, [role="button"], .grid-item')) return false;
+                    const rect = Utils.elements.gridModal.getBoundingClientRect();
+                    return Math.hypot(event.clientX - (rect.left + rect.width / 2), event.clientY - (rect.top + rect.height / 2)) <= Math.min(rect.width, rect.height) * .22;
+                }, () => Grid.close());
                 Utils.elements.centerTrashBtn.addEventListener('click', () => Core.deleteCurrentImage({ exitFocusIfEmpty: false, source: 'button:center-trash' }));
                 Utils.elements.focusStackName.addEventListener('click', () => Modal.setupFocusStackSwitch());
                 Utils.elements.focusDeleteBtn.addEventListener('click', () => Core.deleteCurrentImage({ exitFocusIfEmpty: true, source: 'button:focus-trash' }));


### PR DESCRIPTION
### Motivation
- Remove the persistent Table/Explore/Focus nav to simplify the Sort UI and provide a compact, accessible way to choose modes from the Sort center hub. 
- Make center double-tap behavior consistent and reliable across Sort, Focus, Explore, and Table while avoiding accidental triggers from drags or interactive element taps. 
- Repair Explore thumbnail caching and lifecycle so scaling/pinching/wheel changes do not recreate or reassign thumbnails and so stale loads cannot leak object URLs after Explore closes.

### Description
- Removed the persistent top `view-navigation` controls and related ARIA/state wiring and replaced them with a hidden, center-triggered `mode-chooser` dialog opened on center double-tap in Sort; the chooser exposes `Table`, `Explore`, and `Focus` and reuses the existing implementations rather than duplicating them. 
- Added `ModeCenterTap` pointer-based double-tap detector and `ModeChooser` dialog helpers to handle double-tap detection, focus management, keyboard activation (arrow keys/Escape), focus restoration, and accessible semantics (`role=dialog/menu`, `aria-label`). 
- Changed center-hub double-tap gesture handling in `Gestures` to open the chooser in Sort instead of directly entering Focus, and to close Focus/Explore/Table back to Sort when double-tapping their central non-interactive background areas using the new pointer double-tap handler. 
- Hardened Explore touch/pointer handling by tracking maximum displacement for the entire gesture, clearing pending tap timers when movement begins, and ensuring moved gestures never call `handleCardTap` or count toward double-tap sequences; preserved card double-tap/opening and long-press behaviors. 
- Overhauled `ExploreThumbnailCache` to deduplicate in-flight loads (`inFlight` map), reuse existing object URLs, guard image assignment with a gallery `loadGeneration` validity callback to prevent assigning URLs after Explore closed, avoid creating multiple object URLs for the same thumbnail, and avoid revoking object URLs still used by connected cards. 
- Strengthened Explore close/cleanup to increment `loadGeneration`, detach cards before releasing thumbnails, cancel timers (page/tap/hold), clear pointer/pinch/armed state, and avoid stale callbacks populating `objectUrls` after close. 
- Kept Sort as the default workspace and preserved existing Grid/Table/Focus/Explore implementations, paging, rotation, scale controls, and other interactions without duplicating modes.

### Testing
- Extracted inline scripts and ran `node --check` against the concatenated inline JS and the check completed successfully. (pass)
- Ran `npm run build` (Vite) to verify the page builds; the build completed successfully. (pass)
- Ran `git diff --check` and basic repository checks; there were no trailing whitespace/patch issues. (pass)
- Attempted automated Playwright browser verification of the center double-tap flows and Explore thumbnail lifecycle, but headless browser execution could not be fully completed in this environment due to missing host browser dependencies (Playwright/browser install attempted; binaries downloaded but host libs missing), so interactive browser-based checks were not completed here. (skipped / environment limitation)

Files changed: only `/workspace/perf/ui-v2.html` (no other files modified).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75987b6800832d8a273ef7b690c097)