### PR TITLE
Prevent focus double-taps from sorting photos

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -8535,8 +8535,19 @@ this.updateImageCounters();
             TRAIL_INTERVAL_MS: 12,
             TRAIL_LIFETIME_MS: 1050,
             trailThrottle: null,
-            ignoreMouseEvents: false, holdTimer: null, holdConsumed: false,
+            ignoreMouseEvents: false, holdTimer: null, holdConsumed: false, pendingSortTapTimer: null,
             cancelHold() { clearTimeout(this.holdTimer); this.holdTimer = null; },
+            cancelPendingSortTap() {
+                clearTimeout(this.pendingSortTapTimer);
+                this.pendingSortTapTimer = null;
+            },
+            scheduleSortTap(clientX, clientY) {
+                this.cancelPendingSortTap();
+                this.pendingSortTapTimer = setTimeout(() => {
+                    this.pendingSortTapTimer = null;
+                    if (!state.isFocusMode) this.handleTap(clientX, clientY);
+                }, this.DOUBLE_TAP_MAX_INTERVAL);
+            },
             init() {
                 this.edgeElements = [Utils.elements.edgeTop, Utils.elements.edgeBottom, Utils.elements.edgeLeft, Utils.elements.edgeRight];
                 this.setupEventListeners();
@@ -8810,7 +8821,7 @@ this.updateImageCounters();
                 if (this.holdConsumed) { this.holdConsumed = false; this.hideAllEdgeGlows(); return; }
                 if (isTap) {
                     if (this.lastHubTap.time && now - this.lastHubTap.time <= this.DOUBLE_TAP_MAX_INTERVAL && Math.hypot(this.lastHubTap.x-this.currentPos.x,this.lastHubTap.y-this.currentPos.y)<=this.DOUBLE_TAP_MAX_DISTANCE) {
-                        this.lastHubTap={time:0,x:0,y:0}; this.toggleFocusMode(); state.haptic?.triggerFeedback('buttonPress'); this.hideAllEdgeGlows(); return;
+                        this.lastHubTap={time:0,x:0,y:0}; this.cancelPendingSortTap(); this.toggleFocusMode(); state.haptic?.triggerFeedback('buttonPress'); this.hideAllEdgeGlows(); return;
                     }
                     this.lastHubTap={time:now,x:this.currentPos.x,y:this.currentPos.y};
                 }
@@ -8859,7 +8870,8 @@ this.updateImageCounters();
                     if (!this.tapHandled) {
                         this.tapHandled = true;
                         this.spawnRipple(this.currentPos.x, this.currentPos.y);
-                        this.handleTap(this.currentPos.x, this.currentPos.y);
+                        if (state.isFocusMode) this.handleTap(this.currentPos.x, this.currentPos.y);
+                        else this.scheduleSortTap(this.currentPos.x, this.currentPos.y);
                     }
                 }
                 this.hideAllEdgeGlows();
@@ -8906,6 +8918,7 @@ this.updateImageCounters();
                 Core.applyTransform();
             },
             toggleFocusMode() {
+                this.cancelPendingSortTap();
                 state.isFocusMode = !state.isFocusMode;
                 Utils.elements.appContainer.classList.toggle('focus-mode', state.isFocusMode);
                 this.updateGestureOverlayMode();


### PR DESCRIPTION
### Motivation
- Prevent the first tap in the focus double-tap sequence from triggering a single-tap sort action that mutates stack metadata before Focus is entered.
- Keep existing double-tap Focus entry behavior while ensuring single-tap sorting still works when it is genuinely a single tap.

### Description
- Added a deferred sort mechanism on the `Gestures` object using a `pendingSortTapTimer` with helper functions `cancelPendingSortTap()` and `scheduleSortTap(clientX, clientY)` to delay invoking `handleTap` until the double-tap interval expires.
- Updated tap handling in `handleEnd` to schedule the single-tap sort via `scheduleSortTap` when not in Focus, and to cancel the pending sort when a qualifying second tap is detected so `toggleFocusMode()` can execute without side effects.
- Ensured `toggleFocusMode()` clears any pending sort by calling `cancelPendingSortTap()` so delayed sorting cannot run across mode transitions.

### Testing
- Ran `node --check /tmp/ui-v2-inline.js` and it completed successfully.
- Ran `npm run build` and the site build completed without errors.
- Ran `git diff --check` and no whitespace issues were reported.
- Verified that double-tap still enters/exits Focus and single-tap sorting still executes when the double-tap window elapses; the deferred-sort behavior cancels correctly when a second tap becomes a Focus toggle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75ce190610832d928269db87107935)