### PR TITLE
Introduce submode footer and ModeNavigation; refactor Explore/Table UI and gestures

### DIFF
--- a/ui-v2.html
+++ b/ui-v2.html
@@ -698,6 +698,21 @@
         .app-footer .footer-baseline {
             color: rgba(255, 255, 255, 0.6);
         }
+        .submode-footer {
+            position: fixed; z-index: 14000; left: 0; right: 0; bottom: 0;
+            min-height: 44px; padding: 0 max(8px, env(safe-area-inset-right)) env(safe-area-inset-bottom) max(8px, env(safe-area-inset-left));
+            display: flex; align-items: stretch; color: #e5e7eb; background: rgba(15, 23, 42, .9); backdrop-filter: blur(12px);
+        }
+        .submode-footer[hidden] { display: none; }
+        .submode-footer__mode, .submode-footer__exit { min-height: 44px; padding: 0 16px; border: 0; color: inherit; background: transparent; font: 600 13px/1 system-ui, sans-serif; }
+        .submode-footer__mode[aria-current="page"] { background: rgba(255,255,255,.16); box-shadow: inset 0 3px #93c5fd; }
+        .submode-footer__separator { align-self: center; height: 24px; margin-left: auto; border-left: 1px solid rgba(255,255,255,.3); }
+        .submode-footer__exit { min-width: 52px; font-size: 22px; cursor: pointer; }
+        .submode-control { position: absolute; z-index: 1001; min-height: 44px; padding: 9px 13px; border: 1px solid rgba(255,255,255,.25); border-radius: 999px; color: #fff; background: rgba(15,23,42,.76); backdrop-filter: blur(10px); }
+        .submode-control.folder { top: max(12px, env(safe-area-inset-top)); left: max(12px, env(safe-area-inset-left)); }
+        .submode-control.details { top: max(12px, env(safe-area-inset-top)); right: max(12px, env(safe-area-inset-right)); }
+        .submode-control.position { bottom: max(58px, calc(env(safe-area-inset-bottom) + 50px)); left: max(12px, env(safe-area-inset-left)); }
+        .submode-control.delete { bottom: max(58px, calc(env(safe-area-inset-bottom) + 50px)); right: max(12px, env(safe-area-inset-right)); }
         .toast {
             position: fixed;
             bottom: 20px;
@@ -914,11 +929,6 @@
 
 
         /* Explore sphere: an isolated, read-only spatial view of the active stack. */
-        .mode-chooser { position: fixed; z-index: 12500; display: block; padding: 5px; border: 1px solid rgba(255,255,255,.24); border-radius: 999px; background: rgba(15,23,42,.92); box-shadow: 0 18px 48px rgba(0,0,0,.48); backdrop-filter: blur(14px); }
-        .mode-chooser[hidden] { display: none; }
-        .mode-chooser__menu { display: flex; gap: 4px; }
-        .mode-chooser__button { min-height: 44px; padding: 9px 16px; border: 0; border-radius: 999px; color: #e5e7eb; background: transparent; cursor: pointer; font: 600 14px/1 system-ui, sans-serif; }
-        .mode-chooser__button:hover, .mode-chooser__button:focus-visible { color: #fff; background: rgba(37,99,235,.72); outline: 2px solid #93c5fd; outline-offset: 1px; }
         .photo-table { position: fixed; inset: 0; z-index: 12400; overflow: hidden; color: #fff; background: radial-gradient(circle at 48% 38%, #253128 0, #111813 58%, #080b09 100%); touch-action: none; }
         .photo-table[hidden] { display: none; }
         .photo-table::before { content: ''; position: absolute; inset: 0; opacity: .18; pointer-events: none; background-image: repeating-linear-gradient(117deg, transparent 0 7px, rgba(255,255,255,.035) 8px, transparent 9px 15px); }
@@ -931,7 +941,12 @@
         .photo-table__chrome.left { left: max(12px, env(safe-area-inset-left)); }
         .photo-table__chrome.right { right: max(12px, env(safe-area-inset-right)); }
         .photo-table__control { min-height: 44px; padding: 9px 13px; border: 1px solid rgba(255,255,255,.25); border-radius: 999px; color: #fff; background: rgba(15,23,42,.76); backdrop-filter: blur(10px); }
-        .photo-table__a11y { position: absolute; z-index: 1000; left: 50%; bottom: max(12px, env(safe-area-inset-bottom)); display: flex; gap: 5px; transform: translateX(-50%); }
+        .photo-table__destination { position: absolute; z-index: 1000; }
+        .photo-table__destination.top { top: max(72px, calc(env(safe-area-inset-top) + 60px)); left: 50%; transform: translateX(-50%); }
+        .photo-table__destination.bottom { bottom: max(58px, calc(env(safe-area-inset-bottom) + 50px)); left: 50%; transform: translateX(-50%); }
+        .photo-table__destination.left { left: max(12px, env(safe-area-inset-left)); top: 50%; transform: translateY(-50%); }
+        .photo-table__destination.right { right: max(12px, env(safe-area-inset-right)); top: 50%; transform: translateY(-50%); }
+        .photo-table__destination.active, .spatial-gallery__destination.active-stack { border-color: #93c5fd; box-shadow: 0 0 0 2px rgba(147,197,253,.35); }
         @media (prefers-reduced-motion: reduce) { .photo-table__print { transition-duration: 1ms; } }
         .spatial-gallery {
             position: fixed; inset: 0; z-index: 12000; overflow: hidden;
@@ -973,7 +988,7 @@
         .spatial-gallery__destination { position: absolute; z-index: 2; padding: 10px 14px; border: 1px solid rgba(255,255,255,.18); border-radius: 999px; color: #fff; background: rgba(15,23,42,.66); backdrop-filter: blur(10px); font: 700 12px/1 system-ui, sans-serif; letter-spacing: .09em; cursor: pointer; transition: background 120ms ease, transform 120ms ease, border-color 120ms ease; }
         .spatial-gallery__destination.active { background: rgba(59,130,246,.82); border-color: rgba(191,219,254,.9); }
         .spatial-gallery__destination.keep { top: max(72px, calc(env(safe-area-inset-top) + 60px)); left: 50%; transform: translateX(-50%); }
-        .spatial-gallery__destination.trash { bottom: max(24px, env(safe-area-inset-bottom)); left: 50%; transform: translateX(-50%); }
+        .spatial-gallery__destination.trash { bottom: max(58px, calc(env(safe-area-inset-bottom) + 50px)); left: 50%; transform: translateX(-50%); }
         .spatial-gallery__destination.inbox { left: max(18px, env(safe-area-inset-left)); top: 50%; transform: translateY(-50%); }
         .spatial-gallery__destination.maybe { right: max(18px, env(safe-area-inset-right)); top: 50%; transform: translateY(-50%); }
         .spatial-gallery__hint { left: 50%; bottom: max(74px, calc(env(safe-area-inset-bottom) + 62px)); transform: translateX(-50%); color: #cbd5e1; font: 12px/1.3 system-ui, sans-serif; text-align: center; pointer-events: none; }
@@ -1127,7 +1142,7 @@
         <!-- Gesture overlay (triangular sort zones + focus halves) -->
         <div class="gesture-layer" id="gesture-layer">
             <div id="gesture-screen-a" class="stage" role="application" tabindex="0"
-                 aria-label="Sort mode. Double tap for Focus. Press and hold for Explore or Table.">
+                 aria-label="Sort mode. Double tap for Focus.">
                 <div id="gesture-tri-up" class="tri up"></div>
                 <div id="gesture-tri-right" class="tri right"></div>
                 <div id="gesture-tri-down" class="tri down"></div>
@@ -1135,7 +1150,7 @@
                 <div class="hub" id="gesture-hub-a"></div>
             </div>
             <div id="gesture-screen-b" class="stage" role="application"
-                 aria-label="Focus mode. Left/right review halves. Double-tap center hub to return to sort mode." hidden>
+                 aria-label="Focus mode. Left/right review halves. Use the footer to change mode or exit to Sort." hidden>
                 <div id="gesture-half-left" class="half left"></div>
                 <div id="gesture-half-right" class="half right"></div>
                 <div class="hub" id="gesture-hub-b"></div>
@@ -1184,44 +1199,47 @@
         </div>
     </div>
 
-    <div id="mode-chooser" class="mode-chooser" role="dialog" aria-label="Choose image view" hidden>
-        <div class="mode-chooser__menu" role="menu">
-            <button class="mode-chooser__button" type="button" role="menuitem" data-mode="explore">Explore</button>
-            <button class="mode-chooser__button" type="button" role="menuitem" data-mode="table">Table</button>
-        </div>
-    </div>
-
     <section id="photo-table" class="photo-table" role="dialog" aria-modal="true" aria-label="Photo Table" hidden>
         <div id="photo-table-surface" class="photo-table__surface"></div>
-        <div class="photo-table__chrome left"><button id="photo-table-close" class="photo-table__control" type="button">Table</button><span id="photo-table-count" class="photo-table__control" aria-live="polite"></span></div>
-        <div class="photo-table__chrome right"><button id="photo-table-details" class="photo-table__control" type="button">Details</button></div>
-        <div class="photo-table__a11y" aria-label="Move selected photo"><button class="photo-table__control" data-table-stack="in">In</button><button class="photo-table__control" data-table-stack="priority">Priority</button><button class="photo-table__control" data-table-stack="trash">Trash</button><button class="photo-table__control" data-table-stack="out">Out</button></div>
+        <button id="photo-table-folder" class="submode-control folder" type="button"></button>
+        <button id="photo-table-details" class="submode-control details" type="button">Details</button>
+        <span id="photo-table-count" class="submode-control position" aria-live="polite"></span>
+        <button id="photo-table-delete" class="submode-control delete" type="button" aria-label="Move selected image to provider recycle bin">🗑</button>
+        <button class="photo-table__control photo-table__destination top" data-table-stack="priority">KEEP · 0 · ↑</button>
+        <button class="photo-table__control photo-table__destination bottom" data-table-stack="trash">TRASH · 0 · ↓</button>
+        <button class="photo-table__control photo-table__destination left" data-table-stack="in">← · INBOX · 0</button>
+        <button class="photo-table__control photo-table__destination right" data-table-stack="out">MAYBE · 0 · →</button>
     </section>
 
     <!-- Enhanced Grid Modal -->
 
 
-    <section id="spatial-gallery" class="spatial-gallery" role="dialog" aria-modal="true" aria-labelledby="spatial-gallery-title" hidden>
-        <div id="spatial-gallery-scene" class="spatial-gallery__scene" aria-label="Rotatable sphere of images. Double-tap the center background to return to Sort. Dragging does not activate an image."></div>
-        <div class="spatial-gallery__chrome spatial-gallery__header">
-            <div><div id="spatial-gallery-title" class="spatial-gallery__title">Explore</div><div id="spatial-gallery-count" aria-live="polite"></div></div>
-            <div class="spatial-gallery__actions">
-                <button id="spatial-gallery-details" class="spatial-gallery__button" type="button">Details</button>
-                <button id="spatial-gallery-close" class="spatial-gallery__button" type="button" aria-pressed="true">Explore</button>
-            </div>
-        </div>
-        <button type="button" data-stack="priority" class="spatial-gallery__destination keep">KEEP · ↑</button>
-        <button type="button" data-stack="trash" class="spatial-gallery__destination trash">TRASH · ↓</button>
-        <button type="button" data-stack="in" class="spatial-gallery__destination inbox">← · INBOX</button>
-        <button type="button" data-stack="out" class="spatial-gallery__destination maybe">MAYBE · →</button>
+    <section id="spatial-gallery" class="spatial-gallery" role="dialog" aria-modal="true" aria-label="Explore" hidden>
+        <div id="spatial-gallery-scene" class="spatial-gallery__scene" aria-label="Rotatable sphere of images. Dragging does not activate an image."></div>
+        <button id="spatial-gallery-folder" class="submode-control folder" type="button"></button>
+        <button id="spatial-gallery-details" class="submode-control details" type="button">Details</button>
+        <span id="spatial-gallery-count" class="submode-control position" aria-live="polite"></span>
+        <button id="spatial-gallery-delete" class="submode-control delete" type="button" aria-label="Move selected image to provider recycle bin">🗑</button>
+        <button type="button" data-stack="priority" class="spatial-gallery__destination keep">KEEP · 0 · ↑</button>
+        <button type="button" data-stack="trash" class="spatial-gallery__destination trash">TRASH · 0 · ↓</button>
+        <button type="button" data-stack="in" class="spatial-gallery__destination inbox">← · INBOX · 0</button>
+        <button type="button" data-stack="out" class="spatial-gallery__destination maybe">MAYBE · 0 · →</button>
         <div class="spatial-gallery__chrome spatial-gallery__controls" aria-label="Explore sphere controls" title="Drag to reposition">
             <span class="spatial-gallery__control-label">Zoom</span>
             <span class="spatial-gallery__stepper" data-control="scale"><button class="spatial-gallery__adjust" data-delta="10" type="button">+</button><button id="spatial-gallery-density" class="spatial-gallery__value" type="button" aria-live="polite">100%</button><button class="spatial-gallery__adjust" data-delta="-10" type="button">−</button></span>
             <span class="spatial-gallery__control-label">Images</span>
             <span class="spatial-gallery__stepper" data-control="limit"><button class="spatial-gallery__adjust" data-delta="10" type="button">+</button><button id="spatial-gallery-limit" class="spatial-gallery__value" type="button" aria-live="polite">30</button><button class="spatial-gallery__adjust" data-delta="-10" type="button">−</button></span>
         </div>
-        <div class="spatial-gallery__chrome spatial-gallery__hint">Drag to rotate (dragging does not open photos) · Double-tap center background for Sort · Press photo, flick to deal · Pinch to resize</div>
+        <div class="spatial-gallery__chrome spatial-gallery__hint">Drag to rotate (dragging does not open photos) · Press photo, flick to deal · Pinch to resize</div>
     </section>
+
+    <nav id="submode-footer" class="submode-footer" aria-label="Image view" hidden>
+        <button class="submode-footer__mode" type="button" data-submode="focus">Focus</button>
+        <button class="submode-footer__mode" type="button" data-submode="explore">Explore</button>
+        <button class="submode-footer__mode" type="button" data-submode="table">Table</button>
+        <span class="submode-footer__separator" aria-hidden="true"></span>
+        <button class="submode-footer__exit" type="button" aria-label="Exit to Sort" title="Exit to Sort">×</button>
+    </nav>
 
     <div id="grid-modal" class="modal hidden" role="dialog" aria-label="Table view. Double-tap the center background to return to Sort.">
         <div class="modal-content">
@@ -1968,7 +1986,7 @@
 
                     backButton: document.getElementById('back-button'),
                     backButtonSpinner: document.getElementById('back-button-spinner'),
-                    modeChooser: document.getElementById('mode-chooser'),
+                    submodeFooter: document.getElementById('submode-footer'),
                     detailsButton: document.getElementById('details-button'),
                     imageViewport: document.getElementById('image-viewport'),
                     centerImage: document.getElementById('center-image'),
@@ -8453,39 +8471,59 @@ this.updateImageCounters();
             }
         };
 
-        const ModeChooser = {
-            previousFocus: null,
+        const ModeNavigation = {
+            mode: null, entry: null,
             init() {
-                const root = Utils.elements.modeChooser;
-                root.addEventListener('click', event => {
-                    const option = event.target.closest('[data-mode]');
-                    if (option) this.choose(option.dataset.mode);
-                });
-                document.addEventListener('pointerdown', event => {
-                    if (!root.hidden && !root.contains(event.target)) this.close();
+                const root = Utils.elements.submodeFooter;
+                root?.addEventListener('click', event => {
+                    const option = event.target.closest('[data-submode]');
+                    if (option) this.switchTo(option.dataset.submode);
+                    else if (event.target.closest('.submode-footer__exit')) this.exit();
                 });
             },
-            open(point) {
-                if (state.isFocusMode || !Utils.elements.gridModal.classList.contains('hidden') || !SpatialGallery.elements.root?.hidden || !PhotoTable.elements.root?.hidden) return;
-                this.previousFocus = document.activeElement;
-                const root = Utils.elements.modeChooser;
-                root.hidden = false;
-                root.style.left = `${Math.max(8, Math.min(innerWidth - 190, (point?.x ?? innerWidth / 2) - 90))}px`;
-                root.style.top = `${Math.max(8, Math.min(innerHeight - 64, (point?.y ?? innerHeight / 2) - 28))}px`;
-                root.querySelector('[data-mode]')?.focus();
+            selected() {
+                if (this.mode === 'table') return { stackName: PhotoTable.stackName, fileId: PhotoTable.currentFileId };
+                if (this.mode === 'explore') return { stackName: state.currentStack, fileId: SpatialGallery.files[SpatialGallery.selectedIndex]?.id };
+                return { stackName: state.currentStack, fileId: state.stacks[state.currentStack]?.[state.currentStackPosition]?.id };
             },
-            close({ restoreFocus = true } = {}) {
-                const root = Utils.elements.modeChooser;
-                if (root.hidden) return;
-                root.hidden = true;
-                if (restoreFocus) (this.previousFocus || Utils.elements.gestureScreenA)?.focus?.();
+            show(mode) {
+                if (!this.entry) this.entry = this.selected();
+                this.mode = mode;
+                const footer = Utils.elements.submodeFooter;
+                footer.hidden = false;
+                footer.querySelectorAll('[data-submode]').forEach(button => {
+                    const active = button.dataset.submode === mode;
+                    button.toggleAttribute('aria-current', active);
+                    button.disabled = active;
+                });
+                const normalFooter = Utils.elements.appContainer.querySelector('.app-footer');
+                if (normalFooter) normalFooter.inert = true;
             },
-            choose(mode) {
-                this.close({ restoreFocus: false });
-                const file = state.stacks[state.currentStack]?.[state.currentStackPosition];
-                if (!file) return;
-                if (mode === 'table') PhotoTable.open({ stackName: state.currentStack, fileId: file.id });
-                if (mode === 'explore') SpatialGallery.open({ stackName: state.currentStack, fileId: file.id });
+            hide() {
+                Utils.elements.submodeFooter.hidden = true;
+                const normalFooter = Utils.elements.appContainer.querySelector('.app-footer');
+                if (normalFooter) normalFooter.inert = false;
+                this.mode = null; this.entry = null;
+            },
+            switchTo(mode) {
+                if (!mode || mode === this.mode) return;
+                const selection = this.selected();
+                SpatialGallery.close({ restoreFocus: false });
+                PhotoTable.close({ restoreFocus: false });
+                state.currentStack = selection.stackName || this.entry?.stackName || state.currentStack;
+                const stack = state.stacks[state.currentStack] || [];
+                const index = stack.findIndex(file => file.id === (selection.fileId || this.entry?.fileId));
+                if (index >= 0) state.currentStackPosition = index;
+                state.isFocusMode = mode === 'focus';
+                Utils.elements.appContainer.classList.toggle('focus-mode', state.isFocusMode);
+                Gestures.updateGestureOverlayMode();
+                if (mode === 'focus') { this.show('focus'); Core.updateImageCounters(); Core.displayCurrentImage(); }
+                else if (mode === 'table') PhotoTable.open({ stackName: state.currentStack, fileId: stack[state.currentStackPosition]?.id });
+                else SpatialGallery.open({ stackName: state.currentStack, fileId: stack[state.currentStackPosition]?.id });
+            },
+            exit() {
+                const selection = this.selected();
+                returnSpatialModeToSort({ stackName: selection.stackName || this.entry?.stackName, fileId: selection.fileId || this.entry?.fileId });
             }
         };
 
@@ -8513,6 +8551,7 @@ this.updateImageCounters();
                 Gestures.updateGestureOverlayMode();
                 Core.updateImageCounters(); Core.updateActiveProxTab();
                 await Core.displayCurrentImage();
+                ModeNavigation.hide();
                 Utils.elements.gestureScreenA?.focus();
             } finally { spatialReturnInProgress = false; }
         }
@@ -8750,11 +8789,6 @@ this.updateImageCounters();
                 this.gestureStarted = false;
                 state.isDragging = true;
                 this.hubPressActive = false;
-                if (!state.isFocusMode) this.holdTimer = setTimeout(() => {
-                    if (!state.isDragging || this.maxTapDistance > 12 || state.isPinching) return;
-                    this.holdConsumed = true; this.gestureStarted = false; this.lastHubTap = { time: 0, x: 0, y: 0 };
-                    state.haptic?.triggerFeedback('buttonPress'); ModeChooser.open({ x: this.startPos.x, y: this.startPos.y });
-                }, 500);
                 if (!hubInteraction) {
                     Utils.elements.centerImage.classList.add('dragging');
                 }
@@ -8809,7 +8843,7 @@ this.updateImageCounters();
                 const isTap = this.maxTapDistance < this.TAP_DISTANCE_THRESHOLD && duration < this.TAP_DURATION_THRESHOLD;
                 if (this.holdConsumed) { this.holdConsumed = false; this.hideAllEdgeGlows(); return; }
                 if (isTap) {
-                    if (this.lastHubTap.time && now - this.lastHubTap.time <= this.DOUBLE_TAP_MAX_INTERVAL && Math.hypot(this.lastHubTap.x-this.currentPos.x,this.lastHubTap.y-this.currentPos.y)<=this.DOUBLE_TAP_MAX_DISTANCE) {
+                    if (!state.isFocusMode && this.lastHubTap.time && now - this.lastHubTap.time <= this.DOUBLE_TAP_MAX_INTERVAL && Math.hypot(this.lastHubTap.x-this.currentPos.x,this.lastHubTap.y-this.currentPos.y)<=this.DOUBLE_TAP_MAX_DISTANCE) {
                         this.lastHubTap={time:0,x:0,y:0}; this.toggleFocusMode(); state.haptic?.triggerFeedback('buttonPress'); this.hideAllEdgeGlows(); return;
                     }
                     this.lastHubTap={time:now,x:this.currentPos.x,y:this.currentPos.y};
@@ -8821,8 +8855,7 @@ this.updateImageCounters();
                             const tapDistance = Math.hypot(this.lastHubTap.x - this.currentPos.x, this.lastHubTap.y - this.currentPos.y);
                             if (tapDistance <= this.DOUBLE_TAP_MAX_DISTANCE) {
                                 this.spawnRipple(this.currentPos.x, this.currentPos.y);
-                                if (state.isFocusMode) this.toggleFocusMode();
-                                else ModeChooser.open();
+                                if (!state.isFocusMode) this.toggleFocusMode();
                                 if (state.haptic) { state.haptic.triggerFeedback('buttonPress'); }
                                 this.lastHubTap = { time: 0, x: 0, y: 0 };
                             } else {
@@ -8925,6 +8958,8 @@ this.updateImageCounters();
                 }
 
                 Core.updateImageCounters();
+                if (state.isFocusMode) ModeNavigation.show('focus');
+                else ModeNavigation.hide();
                 this.lastHubTap = { time: 0, x: 0, y: 0 };
                 ModeCenterTap.reset();
             },
@@ -9736,17 +9771,17 @@ this.updateImageCounters();
                 this.elements.root = document.getElementById('photo-table');
                 this.elements.surface = document.getElementById('photo-table-surface');
                 this.elements.count = document.getElementById('photo-table-count');
-                this.elements.close = document.getElementById('photo-table-close');
+                this.elements.folder = document.getElementById('photo-table-folder');
                 this.elements.details = document.getElementById('photo-table-details');
+                this.elements.delete = document.getElementById('photo-table-delete');
                 this.reducedMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
-                this.elements.close.addEventListener('click', () => this.exit());
                 this.elements.details.addEventListener('click', () => this.showDetails());
+                this.elements.delete.addEventListener('click', () => this.deleteSelected());
                 this.elements.surface.addEventListener('pointerdown', event => this.down(event));
                 this.elements.surface.addEventListener('pointermove', event => this.move(event));
                 this.elements.surface.addEventListener('pointerup', event => this.up(event));
                 this.elements.surface.addEventListener('pointercancel', event => this.cancelPointer(event));
                 this.elements.surface.addEventListener('click', event => { if (event.target === this.elements.surface && this.examining()) this.restoreExamined(); });
-                this.elements.surface.addEventListener('dblclick', event => { if (!event.target.closest('.photo-table__chrome,.photo-table__a11y,button:not(.photo-table__print),input,a')) { clearTimeout(this.tapTimer); const photo = this.findElement(event); if (photo) this.currentFileId = photo.fileId; this.exit(); } });
                 this.elements.root.querySelectorAll('[data-table-stack]').forEach(button => button.addEventListener('click', () => this.sortSelected(button.dataset.tableStack)));
                 document.addEventListener('visibilitychange', () => { if (document.hidden && this.frameId) { cancelAnimationFrame(this.frameId); this.frameId = null; } });
             },
@@ -9760,6 +9795,7 @@ this.updateImageCounters();
                 this.deck = ordered.slice(limit).map(file => file.id);
                 this.elements.root.hidden = false; document.body.style.overflow = 'hidden';
                 this.build(ordered.slice(0, limit)); this.updateCount();
+                ModeNavigation.show('table');
                 this.photos.find(photo => photo.fileId === fileId)?.element.focus();
             },
             hash(id) { let h = 2166136261; for (const c of String(id)) h = Math.imul(h ^ c.charCodeAt(0), 16777619); return h >>> 0; },
@@ -9786,7 +9822,7 @@ this.updateImageCounters();
             down(event) {
                 if (event.button !== undefined && event.button !== 0) return;
                 const photo = this.findElement(event); if (!photo) return;
-                clearTimeout(this.tapTimer); this.currentFileId = photo.fileId; photo.zIndex = ++this.z; photo.state='held'; photo.scale=1.06; photo.element.classList.add('held');
+                clearTimeout(this.tapTimer); this.currentFileId = photo.fileId; this.updateCount(); photo.zIndex = ++this.z; photo.state='held'; photo.scale=1.06; photo.element.classList.add('held');
                 this.pointer={ id:event.pointerId, photo, x:event.clientX, y:event.clientY, startX:event.clientX, startY:event.clientY, startTime:performance.now(), samples:[{x:event.clientX,y:event.clientY,t:performance.now()}] };
                 photo.element.setPointerCapture?.(event.pointerId); this.paint(photo); state.haptic?.triggerFeedback('buttonPress');
             },
@@ -9806,7 +9842,7 @@ this.updateImageCounters();
                 if(!this.reducedMotion && Math.hypot(vx,vy)>4){photo.state='thrown';photo.velocityX=vx;photo.velocityY=vy;photo.angularVelocity=vx*.035;this.requestFrame();} this.paint(photo);
             },
             cancelPointer(){ if(this.pointer){this.pointer.photo.state='resting';this.pointer.photo.element.classList.remove('held');this.pointer=null;} },
-            handleTap(photo,time) { if(this.lastTap && time-this.lastTap.time<360){clearTimeout(this.tapTimer);this.currentFileId=photo.fileId;this.lastTap=null;this.exit();return;} this.lastTap={time}; this.tapTimer=setTimeout(()=>{this.lastTap=null;this.examine(photo);},370); },
+            handleTap(photo) { this.currentFileId=photo.fileId; this.updateCount(); this.examine(photo); },
             examine(photo){ if(this.examining()&&this.examining()!==photo)this.restoreExamined(); photo.homeX=photo.x;photo.homeY=photo.y;photo.homeRotation=photo.rotation;photo.state='examining';photo.zIndex=++this.z;photo.x=innerWidth/2-photo.element.offsetWidth/2;photo.y=innerHeight/2-photo.element.offsetHeight/2;photo.rotation=0;photo.scale=Math.min(2.1,innerHeight/(photo.element.offsetHeight*1.7));photo.element.classList.add('examining');this.elements.root.classList.add('examining');this.currentFileId=photo.fileId;this.paint(photo); },
             examining(){return this.photos.find(p=>p.state==='examining');},
             restoreExamined(){const p=this.examining();if(!p)return false;p.state='resting';p.x=p.homeX;p.y=p.homeY;p.rotation=p.homeRotation;p.scale=1;p.element.classList.remove('examining');this.elements.root.classList.remove('examining');this.paint(p);return true;},
@@ -9815,7 +9851,8 @@ this.updateImageCounters();
             async commitEdge(photo,vx,vy){photo.state='removed';photo.element.remove();this.photos=this.photos.filter(p=>p!==photo);await sortFileByDirection({fileId:photo.fileId,deltaX:vx,deltaY:vy,source:'table'});this.currentFileId=this.photos.at(-1)?.fileId||null;this.updateCount();},
             async sortSelected(target){const p=this.photos.find(x=>x.fileId===this.currentFileId);if(!p)return;const vector={priority:[0,-1],trash:[0,1],in:[-1,0],out:[1,0]}[target];await this.commitEdge(p,vector[0]*20,vector[1]*20);},
             showDetails(){const stack=state.stacks[this.stackName]||[], i=stack.findIndex(f=>f.id===this.currentFileId);if(i>=0){state.currentStack=this.stackName;state.currentStackPosition=i;Details.show();}},
-            updateCount(){this.elements.count.textContent=`${STACK_NAMES[this.stackName]||this.stackName} · ${this.photos.length}`;},
+            async deleteSelected(){const stack=state.stacks[this.stackName]||[],i=stack.findIndex(f=>f.id===this.currentFileId);if(i<0)return;state.currentStack=this.stackName;state.currentStackPosition=i;await Core.deleteCurrentImage({exitFocusIfEmpty:false,source:'table:delete'});this.photos.find(p=>p.fileId===this.currentFileId)?.element.remove();this.photos=this.photos.filter(p=>p.fileId!==this.currentFileId);this.currentFileId=this.photos.at(-1)?.fileId||null;this.updateCount();},
+            updateCount(){const stack=state.stacks[this.stackName]||[],i=stack.findIndex(f=>f.id===this.currentFileId);this.elements.folder.textContent=STACK_NAMES[this.stackName]||this.stackName;this.elements.count.textContent=stack.length?`${Math.max(1,i+1)}/${stack.length}`:'0/0';const labels={priority:'KEEP',trash:'TRASH',in:'INBOX',out:'MAYBE'};this.elements.root.querySelectorAll('[data-table-stack]').forEach(button=>{const name=button.dataset.tableStack,count=state.stacks[name]?.length||0,arrows={priority:'↑',trash:'↓',in:'←',out:'→'};button.textContent=name==='in'?`${arrows[name]} · ${labels[name]} · ${count}`:`${labels[name]} · ${count} · ${arrows[name]}`;button.classList.toggle('active',name===this.stackName);});},
             exit(){returnSpatialModeToSort({stackName:this.stackName,fileId:this.currentFileId||this.photos.at(-1)?.fileId,source:'table'});},
             close({restoreFocus=true}={}){if(this.elements.root.hidden)return;this.elements.root.hidden=true;clearTimeout(this.tapTimer);if(this.frameId)cancelAnimationFrame(this.frameId);this.frameId=null;this.cancelPointer();this.elements.surface.replaceChildren();this.photos=[];this.lastTap=null;document.body.style.overflow='';if(restoreFocus)this.previousFocus?.focus?.();}
         };
@@ -9833,13 +9870,14 @@ this.updateImageCounters();
                 this.elements.root = document.getElementById('spatial-gallery');
                 this.elements.scene = document.getElementById('spatial-gallery-scene');
                 this.elements.count = document.getElementById('spatial-gallery-count');
-                this.elements.close = document.getElementById('spatial-gallery-close');
+                this.elements.folder = document.getElementById('spatial-gallery-folder');
                 this.elements.details = document.getElementById('spatial-gallery-details');
+                this.elements.delete = document.getElementById('spatial-gallery-delete');
                 this.elements.controls = this.elements.root.querySelector('.spatial-gallery__controls');
                 this.elements.density = document.getElementById('spatial-gallery-density');
                 this.elements.limit = document.getElementById('spatial-gallery-limit');
-                this.elements.close?.addEventListener('click', () => this.close());
                 this.elements.details?.addEventListener('click', () => this.showFocusedDetails());
+                this.elements.delete?.addEventListener('click', () => this.deleteSelected());
                 this.elements.root.querySelectorAll('.spatial-gallery__destination').forEach(button => button.addEventListener('click', () => this.dealFocusedCard(button.dataset.stack)));
                 this.elements.controls?.querySelectorAll('.spatial-gallery__value').forEach(button => button.addEventListener('click', event => {
                     event.stopPropagation(); button.closest('.spatial-gallery__stepper').classList.toggle('expanded');
@@ -9856,12 +9894,11 @@ this.updateImageCounters();
                 scene?.addEventListener('pointermove', event => this.onPointerMove(event));
                 scene?.addEventListener('pointerup', event => this.onPointerUp(event));
                 scene?.addEventListener('pointercancel', event => this.onPointerUp(event));
-                ModeCenterTap.bind(scene, event => !event.target.closest('.spatial-gallery__chrome,.spatial-gallery__destination,button:not(.spatial-gallery__card),input,a'), () => this.openSelected());
                 scene?.addEventListener('wheel', event => this.onWheel(event), { passive: false });
                 this.elements.root?.addEventListener('touchstart', event => this.onTouchStart(event), { passive: false });
                 this.elements.root?.addEventListener('touchmove', event => this.onTouchMove(event), { passive: false });
                 this.elements.root?.addEventListener('keydown', event => {
-                    if (event.key === 'Escape') { event.preventDefault(); this.close(); }
+                    if (event.key === 'Escape') { event.preventDefault(); ModeNavigation.exit(); }
                 });
             },
 
@@ -9883,8 +9920,9 @@ this.updateImageCounters();
                 document.body.style.overflow = 'hidden';
                 this.restoreControlsPosition();
                 this.updateControlLabels();
-                this.elements.count.textContent = `${this.files.length}/${stack.length} image${this.files.length === 1 ? '' : 's'} · ${STACK_NAMES[state.currentStack] || state.currentStack}`;
-                this.elements.close.focus();
+                this.updateChrome();
+                ModeNavigation.show('explore');
+                this.cards[this.selectedIndex]?.element.focus();
                 this.lastFrameTime = performance.now();
                 this.requestFrame();
                 this.scheduleNextPage();
@@ -9970,39 +10008,17 @@ this.updateImageCounters();
                 this.select(index);
             },
 
-            handleCardTap(index, timeStamp) {
+            handleCardTap(index) {
                 clearTimeout(this.tapTimer);
-                if (this.lastTapIndex === index && timeStamp - this.lastTapTime <= 500) {
-                    this.lastTapIndex = -1; this.lastTapTime = 0;
-                    this.select(index);
-                    this.openSelected();
-                    return;
-                }
-                this.lastTapIndex = index; this.lastTapTime = timeStamp;
-                this.tapTimer = setTimeout(() => {
-                    this.lastTapIndex = -1; this.lastTapTime = 0;
-                    this.center(index);
-                }, 500);
+                this.lastTapIndex = -1; this.lastTapTime = 0;
+                this.center(index);
             },
 
             select(index) {
                 this.selectedIndex = index;
                 this.cards.forEach((card, cardIndex) => { card.element.classList.toggle('selected', cardIndex === index); card.element.setAttribute('aria-pressed', cardIndex === index ? 'true' : 'false'); });
+                this.updateChrome();
                 this.requestFrame();
-            },
-
-            openSelected() {
-                const selected = this.files[this.selectedIndex];
-                if (!selected) return;
-                const stack = state.stacks[state.currentStack] || [];
-                const index = stack.findIndex(file => file.id === selected.id);
-                if (index >= 0) state.currentStackPosition = index;
-                returnSpatialModeToSort({ stackName: state.currentStack, fileId: selected.id, source: 'explore' });
-            },
-
-            isCentralPoint(x, y) {
-                const rect = this.elements.scene.getBoundingClientRect();
-                return Math.hypot(x - (rect.left + rect.width / 2), y - (rect.top + rect.height / 2)) <= Math.min(rect.width, rect.height) * .2;
             },
 
             clearCardTap() {
@@ -10101,7 +10117,7 @@ this.updateImageCounters();
                     this.files = stack.slice(0, this.imageLimit);
                     this.selectedIndex = Math.max(0, this.files.findIndex(file => file.id === selected?.id));
                     this.buildCards();
-                    this.elements.count.textContent = `${this.files.length}/${stack.length} image${this.files.length === 1 ? '' : 's'} · ${STACK_NAMES[state.currentStack] || state.currentStack}`;
+                    this.updateChrome();
                 }
                 this.updateControlLabels();
                 this.persistSettings();
@@ -10213,8 +10229,7 @@ this.updateImageCounters();
                 this.selectedIndex = Math.min(index, Math.max(0, this.files.length - 1));
                 if (!this.files.length) { this.close(); return; }
                 this.buildCards(); this.updateControlLabels();
-                const currentStack = state.stacks[state.currentStack] || [];
-                this.elements.count.textContent = `${this.files.length}/${currentStack.length} image${this.files.length === 1 ? '' : 's'} · ${STACK_NAMES[state.currentStack] || state.currentStack}`;
+                this.updateChrome();
             },
 
             async dealFocusedCard(targetStack) {
@@ -10228,6 +10243,32 @@ this.updateImageCounters();
                 if (index < 0) return;
                 state.currentStackPosition = index;
                 Details.show();
+            },
+
+            async deleteSelected() {
+                const selected = this.files[this.selectedIndex], stack = state.stacks[state.currentStack] || [];
+                const index = stack.findIndex(file => file.id === selected?.id);
+                if (index < 0) return;
+                state.currentStackPosition = index;
+                await Core.deleteCurrentImage({ exitFocusIfEmpty: false, source: 'explore:delete' });
+                this.files = (state.stacks[state.currentStack] || []).slice(0, this.imageLimit);
+                this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, this.files.length - 1));
+                if (!this.files.length) { ModeNavigation.exit(); return; }
+                this.buildCards(); this.updateChrome();
+            },
+
+            updateChrome() {
+                if (!this.elements.folder) return;
+                const stack = state.stacks[state.currentStack] || [], selected = this.files[this.selectedIndex];
+                const index = stack.findIndex(file => file.id === selected?.id);
+                this.elements.folder.textContent = STACK_NAMES[state.currentStack] || state.currentStack;
+                this.elements.count.textContent = stack.length ? `${Math.max(1, index + 1)}/${stack.length}` : '0/0';
+                const labels = { priority: 'KEEP', trash: 'TRASH', in: 'INBOX', out: 'MAYBE' }, arrows = { priority: '↑', trash: '↓', in: '←', out: '→' };
+                this.elements.root.querySelectorAll('.spatial-gallery__destination').forEach(button => {
+                    const name = button.dataset.stack, count = state.stacks[name]?.length || 0;
+                    button.textContent = name === 'in' ? `${arrows[name]} · ${labels[name]} · ${count}` : `${labels[name]} · ${count} · ${arrows[name]}`;
+                    button.classList.toggle('active-stack', name === state.currentStack);
+                });
             },
 
             requestFrame() {
@@ -10269,7 +10310,6 @@ this.updateImageCounters();
                 if (nearestIndex !== this.focusedIndex) {
                     this.focusedIndex = nearestIndex;
                     this.cards.forEach((card, index) => card.element.classList.toggle('focused', index === nearestIndex));
-                    if (nearestIndex >= 0) this.select(nearestIndex);
                 }
                 if (this.dragging || Math.abs(this.velocityX) + Math.abs(this.velocityY) > 0.00015) this.requestFrame();
             }
@@ -10564,7 +10604,7 @@ this.updateImageCounters();
                 Utils.elements.detailsClose.addEventListener('click', () => Details.hide());
             },
             setupFocusMode() {
-                ModeChooser.init();
+                ModeNavigation.init();
                 Utils.elements.centerTrashBtn.addEventListener('click', () => Core.deleteCurrentImage({ exitFocusIfEmpty: false, source: 'button:center-trash' }));
                 Utils.elements.focusStackName.addEventListener('click', () => Modal.setupFocusStackSwitch());
                 Utils.elements.focusDeleteBtn.addEventListener('click', () => Core.deleteCurrentImage({ exitFocusIfEmpty: true, source: 'button:focus-trash' }));
@@ -10769,13 +10809,11 @@ this.updateImageCounters();
             setupKeyboardNavigation() {
                 document.addEventListener('keydown', async (e) => {
                     if (Utils.elements.appContainer.classList.contains('hidden')) return;
-                    if (!Utils.elements.modeChooser.hidden) { if (e.key === 'Escape') { e.preventDefault(); ModeChooser.close(); } return; }
                     if (!Utils.elements.detailsModal.classList.contains('hidden')) { if (e.key === 'Escape') Details.hide(); return; }
                     if (!Utils.elements.gridModal.classList.contains('hidden')) { if (e.key === 'Escape') Grid.close(); return; }
                     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
                     if (!PhotoTable.elements.root?.hidden) { if (e.key === 'Escape') { e.preventDefault(); if (!PhotoTable.restoreExamined()) PhotoTable.exit(); } return; }
-                    if (!SpatialGallery.elements.root?.hidden) { if (e.key === 'Escape') { e.preventDefault(); SpatialGallery.openSelected(); } return; }
-                    if ((e.key === 'm' || e.key === 'M') && !state.isFocusMode) { e.preventDefault(); ModeChooser.open(); return; }
+                    if (!SpatialGallery.elements.root?.hidden) { if (e.key === 'Escape') { e.preventDefault(); ModeNavigation.exit(); } return; }
 
                     try {
                         if (state.isFocusMode) {


### PR DESCRIPTION
### Motivation

- Replace the transient mode chooser with a persistent, accessible submode footer and centralized navigation to simplify switching between Focus/Explore/Table and to provide consistent controls in submodes.
- Surface compact controls for the spatial gallery and photo table to improve discoverability and enable inline actions like delete and folder context.
- Reduce accidental activations by removing the long-press/open-on-hold mode chooser behavior and tightening double-tap logic for focus toggling.

### Description

- Adds a new footer and navigation handler: introduces `#submode-footer` with `.submode-footer` styles and a new `ModeNavigation` object that replaces the old `ModeChooser` flow and provides `show`, `hide`, `switchTo`, `selected`, and `exit` semantics.
- Reworks `PhotoTable` and `SpatialGallery` chrome to use compact `submode-control` buttons (`folder`, `details`, `position`, `delete`) and updates destination buttons layout and labels, plus adds deletion helpers `deleteSelected` in both `PhotoTable` and `SpatialGallery` and new `updateChrome`/`updateCount` behaviors to keep UI state in sync.
- Adjusts gesture handling: removes the long-press hook that opened the mode chooser and refines double-tap/hub tap logic so focus toggles only when appropriate; ties mode showing/hiding to `ModeNavigation` in `Gestures.toggleFocusMode` and elsewhere.
- Miscellaneous refactors include removing the old `mode-chooser` element, renaming elements references to `submodeFooter`, updating keyboard handlers to use `ModeNavigation.exit()`, and various CSS tweaks for layout and destination positioning.

### Testing

- Ran lint and static checks via `npm run lint` and they completed successfully with no new warnings related to the changes.
- Performed a local build with `npm run build` and the build succeeded without errors.
- Executed automated unit and integration tests with `npm test` and the existing test suite passed with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75f2555fdc832d84f8433c658f807b)